### PR TITLE
fix(lib-classifier): record classification times between the first and last annotation

### DIFF
--- a/packages/lib-classifier/src/store/Classification/Classification.js
+++ b/packages/lib-classifier/src/store/Classification/Classification.js
@@ -26,7 +26,7 @@ const Classification = types
     get inProgress() {
       let inProgress = false
       self.annotations.forEach(annotation => {
-        inProgress ||= annotation._inProgress
+        inProgress ||= annotation._inProgress || annotation._choiceInProgress
       })
       return inProgress
     },

--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
@@ -36,9 +36,10 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
   .actions(self => ({
     afterAttach() {
       function _onLocaleChange() {
-        self.update({
-          userLanguage: getRoot(self)?.locale
-        })
+        const userLanguage = getRoot(self)?.locale
+        if (userLanguage) {
+          self.update({ userLanguage })
+        }
       }
       addDisposer(self, autorun(_onLocaleChange))
     },

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -88,10 +88,6 @@ const ClassificationStore = types
 
       if (validClassificationReference) {
         const classification = self.active
-        if (classification?.annotations.size === 0) {
-          // update startedAt if we're starting a new classification
-          classification.metadata.startedAt = (new Date()).toISOString()
-        }
         if (classification) {
           return classification.addAnnotation(task, annotationValue)
         }

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -88,6 +88,10 @@ const ClassificationStore = types
 
       if (validClassificationReference) {
         const classification = self.active
+        if (classification?.annotations.size === 0) {
+          // update startedAt if we're starting a new classification
+          classification.metadata.startedAt = (new Date()).toISOString()
+        }
         if (classification) {
           return classification.addAnnotation(task, annotationValue)
         }

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -128,7 +128,6 @@ describe('Model > ClassificationStore', function () {
 
         classifications = rootStore.classifications
         classifications.setOnComplete(snapshot => {
-          console.log(snapshot)
           submittedClassification = snapshot
         })
         const taskSnapshot = Object.assign({}, singleChoiceTaskSnapshot, { taskKey: singleChoiceAnnotationSnapshot.task })

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -135,6 +135,7 @@ describe('Model > ClassificationStore', function () {
         clock.tick(1 * 60 * 60 * 1000) // wait for one hour before starting the classification.
         classifications.addAnnotation(taskSnapshot, singleChoiceAnnotationSnapshot.value)
         clock.tick(30 * 1000) // wait for 30 seconds before finishing the classification.
+        classifications.addAnnotation(taskSnapshot, 1)
         classifications.completeClassification()
       })
 
@@ -150,6 +151,13 @@ describe('Model > ClassificationStore', function () {
       it('should record the finished at time', function () {
         const finishedAt = submittedClassification.metadata.finished_at
         expect(finishedAt).to.equal('2024-11-06T14:00:30.000Z')
+      })
+
+      it('should only record time spent classifying', function () {
+        const startedAt = submittedClassification.metadata.started_at
+        const finishedAt = submittedClassification.metadata.finished_at
+        const timeSpent = (new Date(finishedAt) - new Date(startedAt)) / 1000
+        expect(timeSpent).to.equal(30)
       })
     })
 

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -132,10 +132,12 @@ describe('Model > ClassificationStore', function () {
         })
         const taskSnapshot = Object.assign({}, singleChoiceTaskSnapshot, { taskKey: singleChoiceAnnotationSnapshot.task })
         taskSnapshot.createAnnotation = () => SingleChoiceAnnotation.create(singleChoiceAnnotationSnapshot)
+        const classification = classifications.active
+        const annotation = classification.createAnnotation(taskSnapshot)
         clock.tick(1 * 60 * 60 * 1000) // wait for one hour before starting the classification.
-        classifications.addAnnotation(taskSnapshot, singleChoiceAnnotationSnapshot.value)
+        annotation.update(0)
         clock.tick(30 * 1000) // wait for 30 seconds before finishing the classification.
-        classifications.addAnnotation(taskSnapshot, 1)
+        annotation.update(1)
         classifications.completeClassification()
       })
 


### PR DESCRIPTION
- [x] Add tests for classification `started_at` and `finished_at` timestamps, to catch #6447.
- [x] fix the failing test for classification start times by recording `started_at` when a volunteer first interacts with a task eg. making a choice selection for a survey, choosing an answer to a question, drawing a mark etc. If they go straight to Done, without updating an annotation, `started_at` will fall back to the old value.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- fixes #6448.
- adds tests that reproduce #6447.
- fixes #6447.
- #6441 has a chart from my personal stats page, where 10 minutes worth of classification effort was recorded as 5 hours, because of this bug.
- Talk comment from Peter Mason about unreliable classification durations in project data that he works with: https://www.zooniverse.org/talk/17/3490049?comment=5741903&page=1

## How to Review
`classification.metadata.started_at` should now record the time that you started a classification, proxied as the time that you first annotate a subject. You should be able to test by waiting between downloading a subject and starting a classification.

It should fix cases, [mentioned by Peter Mason on Talk](https://www.zooniverse.org/talk/17/3490049?comment=5741903&page=1), where project teams are finding classifications that seem to have taken hours or days, but really only took minutes.
> I have seen differences in the start time (started classifying by the volunteer) and finished times (completed classification received by zooniverse) of many hours, even days.

The new tests for classification start time and duration should fail when run with the old code for `classification.metadata.started_at`.
https://github.com/zooniverse/front-end-monorepo/actions/runs/11720164440/job/32644906423#step:9:5027

<img width=800 alt="Logs from a failing test for classification start time, where the expected time is one hour different from the recorded time." src="https://github.com/user-attachments/assets/8a9fe1ed-d5f2-4061-9912-9a7d696e179b">

I've got a staging project with a variety of workflows and tasks, including drawing tasks, which now record `started_at` when you first draw on the subject:
https://localhost:8080/?project=eatyourgreens/-project-testing-ground&workflow=3370


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
