### PR TITLE
Add temporary notice banner to app layouts for scheduled downtime

### DIFF
--- a/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
+++ b/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
@@ -8,14 +8,11 @@ import styled from 'styled-components'
 import { useTranslation } from 'next-i18next'
 
 import { useAdminMode } from '@hooks'
-import {
-  AdminContainer,
-  Announcements,
-  ProjectHeader
-} from '@components'
+import { AdminContainer, Announcements, ProjectHeader } from '@components'
 import PageHeader from '../../../components/PageHeader/PageHeader.js'
 
-export const adminBorderImage = 'repeating-linear-gradient(45deg,#000,#000 25px,#ff0 25px,#ff0 50px) 5'
+export const adminBorderImage =
+  'repeating-linear-gradient(45deg,#000,#000 25px,#ff0 25px,#ff0 50px) 5'
 const PageBox = styled(Box)`
   &.admin {
     border-image: ${adminBorderImage};
@@ -56,6 +53,44 @@ function StandardLayout({ children, page = '' }) {
 
   return (
     <PageBox className={className} data-testid='project-page' border={border}>
+      <details
+        style={{
+          padding: '5px clamp(20px, 3vw, 30px)',
+          fontSize: '1rem',
+          lineHeight: 1.2,
+          color: '#000',
+          background: '#f0b200'
+        }}
+      >
+        <summary style={{ fontWeight: 'bold', cursor: 'pointer' }}>
+          Platform downtime scheduled on Wednesday November 20.
+        </summary>
+        <p style={{ paddingInline: '15px' }}>
+          The Zooniverse platform will be offline for scheduled maintenance on
+          Wednesday, November 20 from 4pm-10pm US Central Standard Time
+          (2024-11-20 22:00 UTC to 2024-11-21 4:00 UTC). During this period, all
+          projects and platform services will be inaccessible. We apologize for
+          the inconvenience; this maintenance is necessary to make updates to
+          platform infrastructure and improve long-term reliability and uptime.
+          Please visit{' '}
+          <a
+            href='https://status.zooniverse.org/incident/1019747'
+            target='_blank'
+            style={{ color: '#000' }}
+          >
+            status.zooniverse.org
+          </a>{' '}
+          for updates before and during the downtime period. For any additional
+          questions, please email{' '}
+          <a
+            style={{ color: '#000' }}
+            href='mailto:contact@zooniverse.org'
+          >
+            contact@zooniverse.org
+          </a>
+          .
+        </p>
+      </details>
       {page !== 'home' && <HeaderComponents adminMode={adminMode} />}
       {children}
       <ZooFooter

--- a/packages/app-root/src/components/RootLayout.js
+++ b/packages/app-root/src/components/RootLayout.js
@@ -6,6 +6,44 @@ export default function RootLayout({ children }) {
   return (
     <body>
       <PageContextProviders>
+        <details
+          style={{
+            padding: '5px clamp(20px, 3vw, 30px)',
+            fontSize: '1rem',
+            lineHeight: 1.2,
+            color: '#000',
+            background: '#f0b200'
+          }}
+        >
+          <summary style={{ fontWeight: 'bold', cursor: 'pointer' }}>
+            Platform downtime scheduled on Wednesday November 20.
+          </summary>
+          <p style={{ paddingInline: '15px' }}>
+            The Zooniverse platform will be offline for scheduled maintenance on
+            Wednesday, November 20 from 4pm-10pm US Central Standard Time
+            (2024-11-20 22:00 UTC to 2024-11-21 4:00 UTC). During this period, all
+            projects and platform services will be inaccessible. We apologize for
+            the inconvenience; this maintenance is necessary to make updates to
+            platform infrastructure and improve long-term reliability and uptime.
+            Please visit{' '}
+            <a
+              href='https://status.zooniverse.org/incident/1019747'
+              target='_blank'
+              style={{ color: '#000' }}
+            >
+              status.zooniverse.org
+            </a>{' '}
+            for updates before and during the downtime period. For any additional
+            questions, please email{' '}
+            <a
+              style={{ color: '#000' }}
+              href='mailto:contact@zooniverse.org'
+            >
+              contact@zooniverse.org
+            </a>
+            .
+          </p>
+        </details>
         <PageHeader />
         {children}
         <PageFooter />


### PR DESCRIPTION
## Package
app-project
app-root

## Linked Issue and/or Talk Post
Slack: https://zooniverse.slack.com/archives/C4RJRAGKA/p1731079514305719
Corresponds to: https://github.com/zooniverse/Panoptes-Front-End/pull/7217

## Describe your changes
- Add html and css for a simple `<details>` and `<summary>` at the top of each layout.

## How to Review
- I will likely end up just self-reviewing and merging this due to its simplicity and non-permanence.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
 
