### PR TITLE
Dependabot: Create groups for sentry, storybook, and visx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,19 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 15
+    groups:
+      sentry:
+        patterns:
+          - "@sentry*"
+      storybook:
+        patterns:
+          - "@storybook*"
+          - "storybook"
+        exclude-patterns:
+          - "storybook-react-i18next"
+      visx:
+        patterns:
+          - "@visx*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Describe your changes
- Add a `groups` config for `@sentry`, Storybook, and VisX. This will group their version update PRs into one PR per group, making it easier to maintain consistent versions across the monorepo.
- Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

## How to Review
- This will only apply to dependabot once merged.