### PR TITLE
build: docker instructions and fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as builder
+FROM node:20-alpine AS builder
 
 ARG COMMIT_ID
 ENV COMMIT_ID=$COMMIT_ID
@@ -55,7 +55,7 @@ RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.
 RUN echo $COMMIT_ID > /usr/src/packages/app-root/public/commit_id.txt
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/fe-root build
 
-FROM node:20-alpine as runner
+FROM node:20-alpine AS runner
 
 ARG NODE_ENV=production
 ENV NODE_ENV=$NODE_ENV

--- a/README.md
+++ b/README.md
@@ -70,17 +70,24 @@ You can run the code locally in Docker, which avoids needing to install Node or 
 ```sh
 git clone git@github.com:zooniverse/front-end-monorepo.git
 cd front-end-monorepo
-docker-compose build
+docker compose build
+# run all services in the background
+# app-project at http://localhost:3002/projects/[owner]/[project-name]
+# app-root at http://localhost:3003
+docker compose up -d
+# shut down the running containers when you're finished
+docker compose down
+# run this if you need a shell inside the running container
+docker compose run --rm shell
 ```
 
-`docker-compose up` runs local production builds as follows:
-
-- project app at http://localhost:3002
-- root app at http://localhost:3003
-
-`docker-compose down` stops the running container.
-
-`docker-compose run --rm shell` runs an interactive shell on the Docker image.
+You can supply a service name (from `docker-compose.yml`) to `docker compose` if you only want to run a single service eg.
+```sh
+# only build the project app
+docker compose build fe-project
+# only run the project app
+docker compose up -d fe-project
+```
 
 Development environments for individual packages can be run from the package directories. For example:
 
@@ -89,7 +96,7 @@ cd packages/app-project
 docker-compose up
 ```
 
-to run a development server for the project app.
+to run a development server for the project app. See the READMEs for individual packages for detailed instructions.
 
 ### With Node and yarn
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ You can run the code locally in Docker, which avoids needing to install Node or 
 ```sh
 git clone git@github.com:zooniverse/front-end-monorepo.git
 cd front-end-monorepo
+# build first
 docker compose build
-# run all services in the background
+# run all services in the background (no authentication available)
 # app-project at http://localhost:3002/projects/[owner]/[project-name]
 # app-root at http://localhost:3003
 docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   shell:
     image: front-end-monorepo_dev:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     build:
       context: ./
       target: builder
+      args:
+        - APP_ENV=development
     command:
       - "/bin/sh"
   fe-project:

--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -19,9 +19,9 @@ Once you have the hosts file configured, you'll be able to use one of those subd
 
 ### Docker
 
-- `docker-compose up -d` to run a dev server, in the background, on http://localhost:3000 and the storybook on http://localhost:9001 using `yarn dev` and `yarn storybook` respectively. The `--build` flag can be used to build the container. This builds and runs a local image which matches the Jenkins build except for running behind a proxy. Note: `devcert` is not yet setup for our docker build for local development.
-- `docker-compose down` to stop the dev containers.
-- `docker-compose run --rm project test` to run the tests.
+- `docker compose up -d` to run a dev server, in the background, on https://localhost:3000 and the storybook on http://localhost:9001 using `yarn dev` and `yarn storybook` respectively. The `--build` flag can be used to build the container. This builds and runs a local image which matches the Jenkins build except for running behind a proxy. Note: `devcert` is not yet setup for our docker build for local development.
+- `docker compose down` to stop the dev containers.
+- `docker compose run --rm project test` to run the tests.
 
 ### Node
 ```sh

--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -22,7 +22,7 @@ Once you have the hosts file configured, you'll be able to use one of those subd
 ```sh
 # run a development build using the top-level Dockerfile
 docker compose build
-# run a dev server on port 3000 (with HTTPS) and a storybook on port 9001.
+# run a dev server on port 3000 (with HTTPS, but no authentication) and a storybook on port 9001.
 # eg. https://localhost:3000/projects/nora-dot-eisner/planet-hunters-tess
 # http://localhost:9001
 docker compose up -d

--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -19,9 +19,18 @@ Once you have the hosts file configured, you'll be able to use one of those subd
 
 ### Docker
 
-- `docker compose up -d` to run a dev server, in the background, on https://localhost:3000 and the storybook on http://localhost:9001 using `yarn dev` and `yarn storybook` respectively. The `--build` flag can be used to build the container. This builds and runs a local image which matches the Jenkins build except for running behind a proxy. Note: `devcert` is not yet setup for our docker build for local development.
-- `docker compose down` to stop the dev containers.
-- `docker compose run --rm project test` to run the tests.
+```sh
+# run a development build using the top-level Dockerfile
+docker compose build
+# run a dev server on port 3000 (with HTTPS) and a storybook on port 9001.
+# eg. https://localhost:3000/projects/nora-dot-eisner/planet-hunters-tess
+# http://localhost:9001
+docker compose up -d
+# stop the local services when you're finished
+docker compose down
+# run the tests
+docker compose run --rm project test
+```
 
 ### Node
 ```sh

--- a/packages/app-project/docker-compose.yml
+++ b/packages/app-project/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   project:
     image: front-end-monorepo_dev:latest

--- a/packages/app-project/docker-compose.yml
+++ b/packages/app-project/docker-compose.yml
@@ -3,8 +3,15 @@ version: '3.7'
 services:
   project:
     image: front-end-monorepo_dev:latest
+    environment:
+      PANOPTES_ENV: staging
+      APP_ENV: development
     build:
       context: ../../
+      target: builder
+      args:
+        - NEXT_TELEMETRY_DISABLED=1
+        - APP_ENV=development
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/app-root/README.md
+++ b/packages/app-root/README.md
@@ -18,9 +18,17 @@ To view data from Contentful, you'll need to create a `.env` file containing the
 
 ### Docker
 
-- `docker-compose up -d` to run a dev server, in the background, on http://localhost:3000 using `yarn dev`. The `--build` flag can be used to build the container. This builds and runs a local image which matches the GitHub Action build except for running behind a proxy. Note: `devcert` is not yet setup for our docker build for local development.
-- `docker-compose down` to stop the dev containers.
-<!-- - `docker-compose run --rm root test` to run the tests. -->
+```sh
+# run a development build using the top-level Dockerfile
+docker compose build
+# run a dev server on port 3000 (with HTTPS, but no authentication).
+# eg. https://localhost:3000/about
+docker compose up -d
+# stop the local services when you're finished
+docker compose down
+# run the tests
+docker compose run --rm project test
+```
 
 ### Node
 

--- a/packages/app-root/docker-compose.yml
+++ b/packages/app-root/docker-compose.yml
@@ -1,10 +1,15 @@
-version: '3.7'
-
 services:
   root:
     image: front-end-monorepo_dev:latest
+    environment:
+      PANOPTES_ENV: staging
+      APP_ENV: development
     build:
       context: ../../
+      target: builder
+      args:
+        - NEXT_TELEMETRY_DISABLED=1
+        - APP_ENV=development
     entrypoint:
       - "yarn"
       - "workspace"


### PR DESCRIPTION
- replace the outdated `docker-compose` command with `docker compose` in the READMEs.
- fix `AS` in Dockerfile.
- update the Docker instructions in the READMEs.
- make sure that environment variables are set for local development in the `docker-compose.yml` files.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Linked Issue and/or Talk Post
- https://github.com/zooniverse/front-end-monorepo/pull/6446#issuecomment-2475316117

## How to Review
To build and run the monorepo packages from the root directory:
```sh
docker compose build
docker compose up -d
```
That runs production builds of the project app and root app in a container:
- http://localhost:3002/projects/nora-dot-eisner/planet-hunters-tess
- http://localhost:3003

Shut down the running services and test the project docker compose config:
```sh
docker compose down
cd packages/app-project
docker compose up -d
```
That runs `yarn dev` for the project app and starts a development storybook. In theory, local changes to the project app should trigger hot module reloading in the running container:
- https://localhost:3000/projects/nora-dot-eisner/planet-hunters-tess
- http://localhost:9001

Shut down the project services:
```sh
docker compose down
```

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
