### PR TITLE
DRAFT: WIP for VV ModelTool

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.js
@@ -34,6 +34,8 @@ function Task ({
   task,
   ...props
 }) {
+	// Delilah: This is where the TaskComponent+TaskModel+AnnotationModel gets imported
+	// If I piggyback on the barrel export this is where it shows up
   const TaskPlugin = task.type === 'dropdown-simple'? tasks.dropdownSimple : tasks[task.type]
   const TaskComponent = TaskPlugin?.TaskComponent
   let annotation

--- a/packages/lib-classifier/src/plugins/tasks/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/index.js
@@ -10,3 +10,5 @@ export { default as text } from './text'
 export { default as highlighter } from './experimental/highlighter'
 export { default as textFromSubject } from './experimental/textFromSubject'
 export { default as transcription } from './experimental/transcription'
+
+// Delilah: Import VV Tool Component here as barrel import from lib-subject-viewers?

--- a/packages/lib-classifier/src/plugins/tasks/single/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/index.js
@@ -2,6 +2,7 @@ import { default as TaskComponent } from './components/SingleChoiceTask'
 import { default as TaskModel } from './models/SingleChoiceTask'
 import { default as AnnotationModel } from './models/SingleChoiceAnnotation'
 
+// Delilah: This is the interface that should be implemented in lib-subject-viewers, right?
 export default {
   TaskComponent,
   TaskModel,

--- a/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceAnnotation.js
@@ -1,6 +1,10 @@
 import { types } from 'mobx-state-tree'
 import Annotation from '../../models/Annotation'
 
+// Delilah: Where should this live for VV?
+// Depends on MobX so if it should live in lib-subject-viewers we'll need to add MobX as a dependency there
+// I can use this as the model that gets imported
+
 const SingleChoice = types.model('SingleChoice', {
   taskType: types.literal('single'),
   value: types.maybeNull(types.number)

--- a/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceTask.js
@@ -3,6 +3,7 @@ import { types } from 'mobx-state-tree'
 import Task from '../../models/Task'
 import SingleChoiceAnnotation from './SingleChoiceAnnotation'
 
+// Delilah: Where should this live for VV?
 // TODO: should we make question/instruction consistent between task types?
 // What should be it called? I think we should use 'instruction'
 


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package

## Linked Issue and/or Talk Post

## Describe your changes

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).