### PR TITLE
lib-classifier: Refactor survey task Choice and Questions styling

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.js
@@ -28,6 +28,13 @@ export function SurveyTask ({
     setAnswers(answers)
   }
 
+  function handleCancel (selectedChoice) {
+    setAnswers({})
+    setPreviousChoice(selectedChoice)
+    setSelectedChoice('')
+    annotation.setChoiceInProgress(false)
+  }
+
   function handleChoice (selectedChoice) {
     if (selectedChoice === '') {
       annotation.setChoiceInProgress(false)
@@ -94,8 +101,8 @@ export function SurveyTask ({
             answers={answers}
             choiceId={selectedChoice}
             handleAnswers={handleAnswers}
+            handleCancel={handleCancel}
             handleChoice={handleChoice}
-            handleDelete={handleDelete}
             onIdentify={handleIdentify}
             task={task}
           />

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userClicks.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userClicks.spec.js
@@ -173,9 +173,9 @@ describe('SurveyTask with user clicks', function () {
       await user.click(choiceButton)
     })
 
-    it('should show the choice description', async function () {
-      const choiceDescription = screen.getByText('It\'s a fire. Pretty sure you know what this looks like.')
-      expect(choiceDescription).to.be.ok()
+    it('should show the "More info" button', async function () {
+      const choiceMoreInfoButton = screen.getByRole('button', { name: 'SurveyTask.Choice.moreInfo' })
+      expect(choiceMoreInfoButton).to.be.ok()
     })
 
     it('should show choice images', async function () {
@@ -184,12 +184,12 @@ describe('SurveyTask with user clicks', function () {
     })
 
     it('should show choices with closed choice focused when Not This button is clicked', async function () {
-      const notThisButton = screen.getByText('SurveyTask.Choice.notThis')
+      const cancelButton = screen.getByText('SurveyTask.Choice.cancel')
       // close choice (Fire) component
-      await user.click(notThisButton)
-      // confirm choice (Fire) description, and therefore choice, is not shown
-      const choiceDescription = screen.queryByText('It\'s a fire. Pretty sure you know what this looks like.')
-      expect(choiceDescription).to.be.null()
+      await user.click(cancelButton)
+      // confirm choice "More info" button is not shown, therefore choice is closed
+      const choiceMoreInfoButton = screen.queryByRole('button', { name: 'SurveyTask.Choice.moreInfo' })
+      expect(choiceMoreInfoButton).to.be.null()
       // confirm choices are shown
       const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
       expect(choiceButtons.length).to.equal(6)
@@ -202,9 +202,9 @@ describe('SurveyTask with user clicks', function () {
       const identifyButton = screen.getByTestId('choice-identify-button')
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
-      // confirm choice (Fire) description, and therefore choice, is not shown
-      const choiceDescription = screen.queryByText('It\'s a fire. Pretty sure you know what this looks like.')
-      expect(choiceDescription).to.be.null()
+      // confirm choice "More info" button is not shown, therefore choice is closed
+      const choiceMoreInfoButton = screen.queryByRole('button', { name: 'SurveyTask.Choice.moreInfo' })
+      expect(choiceMoreInfoButton).to.be.null()
       // confirm choices are shown
       const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
       expect(choiceButtons.length).to.equal(6)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userKeystrokes.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userKeystrokes.spec.js
@@ -167,9 +167,9 @@ describe('SurveyTask with user keystrokes', function () {
       await user.keyboard('[Enter]')
     })
     
-    it('should show the choice description', async function () {
-      const choiceDescription = screen.getByText('Not as awesome as a pangolin, but surprisingly big.')
-      expect(choiceDescription).to.be.ok()
+    it('should show the "more info" button', async function () {
+      const choiceMoreInfoButton = screen.getByRole('button', { name: 'SurveyTask.Choice.moreInfo' })
+      expect(choiceMoreInfoButton).to.be.ok()
     })
 
     it('should show choice images', async function () {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -28,14 +28,15 @@ const StyledPrimaryButton = styled(PrimaryButton)`
   border-radius: 4px;
 `
 
+const DEFAULT_HANDLER = () => true
 
 function Choice({
   answers = {},
   choiceId = '',
-  handleAnswers = () => {},
-  handleChoice = () => {},
-  handleDelete = () => {},
-  onIdentify = () => {},
+  handleAnswers = DEFAULT_HANDLER,
+  handleCancel = DEFAULT_HANDLER,
+  handleChoice = DEFAULT_HANDLER,
+  onIdentify = DEFAULT_HANDLER,
   task
 }) {
   const [showInfo, setShowInfo] = useState(false)
@@ -191,7 +192,7 @@ function Choice({
           <StyledButton
             fill='horizontal'
             label={t('SurveyTask.Choice.cancel')}
-            onClick={() => handleDelete(choiceId)}
+            onClick={() => handleCancel(choiceId)}
           />
           <StyledPrimaryButton
             data-testid='choice-identify-button'
@@ -215,8 +216,8 @@ Choice.propTypes = {
   ),
   choiceId: PropTypes.string,
   handleAnswers: PropTypes.func,
+  handleCancel: PropTypes.func,
   handleChoice: PropTypes.func,
-  handleDelete: PropTypes.func,
   onIdentify: PropTypes.func,
   task: PropTypes.shape({
     help: PropTypes.string,

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -117,12 +117,14 @@ function Choice({
       )}
       <Box
         pad={{
-          vertical: '20px'
+          bottom: '10px',
+          top: '20px'
         }}
       >
         <Box
           direction='row'
           fill='horizontal'
+          height='20px'
           justify='between'
           margin={{ bottom: '30px' }}
         >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -38,7 +38,7 @@ function Choice({
   onIdentify = () => {},
   task
 }) {
-  const [showDescription, setShowDescription] = useState(false)
+  const [showInfo, setShowInfo] = useState(false)
   const {
     choices,
     images,
@@ -58,12 +58,12 @@ function Choice({
   const choice = choices?.get(choiceId) || {}
   const questionIds = getQuestionIds(choiceId, task)
   const allowIdentify = allowIdentification(answers, choiceId, task)
-  const DescriptionLabel = (
+  const InfoLabel = (
     <Box
       direction='row'
       gap='xsmall'
     >
-      {showDescription ? (
+      {showInfo ? (
         <>
           <Text>{t('SurveyTask.Choice.lessInfo')}</Text>
           <FormUp />
@@ -139,13 +139,14 @@ function Choice({
             {strings.get(`choices.${choiceId}.label`)}
           </Heading>
           <Button
-            label={DescriptionLabel}
-            onClick={() => setShowDescription(!showDescription)}          
+            a11yTitle={showInfo ? t('SurveyTask.Choice.lessInfo') : t('SurveyTask.Choice.moreInfo')}
+            label={InfoLabel}
+            onClick={() => setShowInfo(!showInfo)}          
             plain
           />
         </Box>
         <Collapsible
-          open={showDescription}
+          open={showInfo}
         >
           <Box margin={{ bottom: '30px' }}>
             <Paragraph margin='none'>

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -72,12 +72,12 @@ function Choice({
       {showInfo ? (
         <>
           <Text>{t('SurveyTask.Choice.lessInfo')}</Text>
-          <FormUp />
+          <FormUp aria-hidden="true" />
         </>
       ) : (
         <>
           <Text>{t('SurveyTask.Choice.moreInfo')}</Text>
-          <FormDown />
+          <FormDown aria-hidden="true" />
         </>
       )}
     </Box>

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -1,6 +1,7 @@
-import { Box, Button, Carousel, Heading, Paragraph } from 'grommet'
+import { Box, Button, Carousel, Collapsible, Heading, Paragraph, Text } from 'grommet'
+import { FormDown, FormUp } from 'grommet-icons'
 import PropTypes from 'prop-types'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { useTranslation } from '@translations/i18n'
 import { PrimaryButton, Media } from '@zooniverse/react-components'
@@ -27,6 +28,7 @@ function Choice({
   onIdentify = () => {},
   task
 }) {
+  const [showDescription, setShowDescription] = useState(false)
   const {
     choices,
     images,
@@ -46,6 +48,24 @@ function Choice({
   const choice = choices?.get(choiceId) || {}
   const questionIds = getQuestionIds(choiceId, task)
   const allowIdentify = allowIdentification(answers, choiceId, task)
+  const DescriptionLabel = (
+    <Box
+      direction='row'
+      gap='xsmall'
+    >
+      {showDescription ? (
+        <>
+          <Text>{t('SurveyTask.Choice.lessInfo')}</Text>
+          <FormUp />
+        </>
+      ) : (
+        <>
+          <Text>{t('SurveyTask.Choice.moreInfo')}</Text>
+          <FormDown />
+        </>
+      )}
+    </Box>
+  )
 
   function handleKeyDown (event) {
     if (event.key === 'Escape') {
@@ -90,31 +110,47 @@ function Choice({
           vertical: '30px'
         }}
       >
-        <Heading
-          id='choice-label'
-          color={{
-            dark: 'accent-1',
-            light: 'neutral-7'
-          }}
-          size='1.5rem'
-          weight='bold'
+        <Box
+          direction='row'
+          fill='horizontal'
+          justify='between'
         >
-          {strings.get(`choices.${choiceId}.label`)}
-        </Heading>
-        <Paragraph>
-          {strings.get(`choices.${choiceId}.description`)}
-        </Paragraph>
-        {choice.confusionsOrder?.length > 0 && (
-          <ConfusedWith
-            choices={choices}
-            choiceId={choiceId}
-            confusions={choice.confusions}
-            confusionsOrder={choice.confusionsOrder}
-            handleChoice={handleChoice}
-            images={images}
-            strings={strings}
+          <Heading
+            id='choice-label'
+            color={{
+              dark: 'accent-1',
+              light: 'neutral-7'
+            }}
+            margin='none'
+            size='1.5rem'
+            weight='bold'
+          >
+            {strings.get(`choices.${choiceId}.label`)}
+          </Heading>
+          <Button
+            label={DescriptionLabel}
+            onClick={() => setShowDescription(!showDescription)}          
+            plain
           />
-        )}
+        </Box>
+        <Collapsible
+          open={showDescription}
+        >
+          <Paragraph>
+            {strings.get(`choices.${choiceId}.description`)}
+          </Paragraph>
+          {choice.confusionsOrder?.length > 0 && (
+            <ConfusedWith
+              choices={choices}
+              choiceId={choiceId}
+              confusions={choice.confusions}
+              confusionsOrder={choice.confusionsOrder}
+              handleChoice={handleChoice}
+              images={images}
+              strings={strings}
+            />
+          )}
+        </Collapsible>
         {questionIds.length > 0 && (
           <Questions
             answers={answers}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -22,10 +22,14 @@ const StyledBox = styled(Box)`
 const StyledButton = styled(Button)`
   border: 1px solid ${props => props.theme.global.colors.brand};
   border-radius: 4px;
+  flex: 1 0;
+  margin-right: 1ch;
+  max-width: 350px;
 `
 
 const StyledPrimaryButton = styled(PrimaryButton)`
   border-radius: 4px;
+  flex: 1 0;
 `
 
 const DEFAULT_HANDLER = () => true
@@ -184,7 +188,6 @@ function Choice({
           }}
           direction='row'
           fill='horizontal'
-          gap='xsmall'
           justify='center'
           pad={{ vertical: '30px' }}
         >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -128,7 +128,7 @@ function Choice({
         <Box
           direction='row'
           fill='horizontal'
-          height='20px'
+          height='auto'
           justify='between'
           margin={{ bottom: '20px' }}
         >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -130,7 +130,7 @@ function Choice({
           fill='horizontal'
           height='20px'
           justify='between'
-          margin={{ bottom: '30px' }}
+          margin={{ bottom: '20px' }}
         >
           <Heading
             id='choice-label'
@@ -154,7 +154,7 @@ function Choice({
         <Collapsible
           open={showInfo}
         >
-          <Box margin={{ bottom: '30px' }}>
+          <Box margin={{ bottom: '20px' }}>
             <Paragraph margin='none'>
               {strings.get(`choices.${choiceId}.description`)}
             </Paragraph>
@@ -189,7 +189,7 @@ function Choice({
           direction='row'
           fill='horizontal'
           justify='center'
-          pad={{ vertical: '30px' }}
+          pad={{ vertical: '20px' }}
         >
           <StyledButton
             fill='horizontal'

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -93,7 +93,6 @@ function Choice({
         dark: 'dark-3',
         light: 'neutral-6'
       }}
-      elevation='large'
       flex='grow'
       forwardedAs='section'
       onKeyDown={handleKeyDown}
@@ -118,8 +117,7 @@ function Choice({
       )}
       <Box
         pad={{
-          horizontal: '20px',
-          vertical: '30px'
+          vertical: '20px'
         }}
       >
         <Box
@@ -178,16 +176,15 @@ function Choice({
         )}
         <Box
           border={{
-            color: 'light-3',
-            side: 'top',
+            color: 'light-5',
+            side: 'bottom',
             size: 'small'
           }}
           direction='row'
           fill='horizontal'
           gap='xsmall'
           justify='center'
-          margin={{ top: '30px' }}
-          pad={{ top: 'small' }}
+          pad={{ vertical: '30px' }}
         >
           <StyledButton
             fill='horizontal'

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -19,6 +19,16 @@ const StyledBox = styled(Box)`
   }
 `
 
+const StyledButton = styled(Button)`
+  border: 1px solid ${props => props.theme.global.colors.brand};
+  border-radius: 4px;
+`
+
+const StyledPrimaryButton = styled(PrimaryButton)`
+  border-radius: 4px;
+`
+
+
 function Choice({
   answers = {},
   choiceId = '',
@@ -176,12 +186,12 @@ function Choice({
           margin={{ top: '30px' }}
           pad={{ top: 'small' }}
         >
-          <Button
+          <StyledButton
             fill='horizontal'
             label={t('SurveyTask.Choice.cancel')}
             onClick={() => handleDelete(choiceId)}
           />
-          <PrimaryButton
+          <StyledPrimaryButton
             data-testid='choice-identify-button'
             disabled={!allowIdentify}
             fill='horizontal'

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -58,14 +58,13 @@ function Choice({
       ref={choiceRef}
       aria-labelledby='choice-label'
       background={{
-        dark: 'dark-1',
-        light: 'light-1'
+        dark: 'dark-3',
+        light: 'neutral-6'
       }}
       elevation='large'
       flex='grow'
       forwardedAs='section'
       onKeyDown={handleKeyDown}
-      pad='small'
       tabIndex={0}
     >
       {choice.images?.length > 0 && (
@@ -74,7 +73,7 @@ function Choice({
           controls='arrows'
           data-testid='choice-images'
           height={{ max: 'medium' }}
-          width={{ max: 'medium' }}
+          width='100%'
         >
           {choice.images.map((filename, index) => (
             <Media
@@ -85,57 +84,71 @@ function Choice({
           ))}
         </Carousel>
       )}
-      <Heading
-        id='choice-label'
-      >
-        {strings.get(`choices.${choiceId}.label`)}
-      </Heading>
-      <Paragraph>{strings.get(`choices.${choiceId}.description`)}</Paragraph>
-      {choice.confusionsOrder?.length > 0 && (
-        <ConfusedWith
-          choices={choices}
-          choiceId={choiceId}
-          confusions={choice.confusions}
-          confusionsOrder={choice.confusionsOrder}
-          handleChoice={handleChoice}
-          images={images}
-          strings={strings}
-        />
-      )}
-      {questionIds.length > 0 && (
-        <Questions
-          answers={answers}
-          questionIds={questionIds}
-          questions={questions}
-          setAnswers={handleAnswers}
-          strings={strings}
-        />
-      )}
       <Box
-        border={{
-          color: 'light-5',
-          side: 'top',
-          size: 'small'
+        pad={{
+          horizontal: '20px',
+          vertical: '30px'
         }}
-        direction='row'
-        fill='horizontal'
-        gap='xsmall'
-        justify='center'
-        margin={{ top: 'small' }}
-        pad={{ top: 'small' }}
       >
-        <Button
+        <Heading
+          id='choice-label'
+          color={{
+            dark: 'accent-1',
+            light: 'neutral-7'
+          }}
+          size='1.5rem'
+          weight='bold'
+        >
+          {strings.get(`choices.${choiceId}.label`)}
+        </Heading>
+        <Paragraph>
+          {strings.get(`choices.${choiceId}.description`)}
+        </Paragraph>
+        {choice.confusionsOrder?.length > 0 && (
+          <ConfusedWith
+            choices={choices}
+            choiceId={choiceId}
+            confusions={choice.confusions}
+            confusionsOrder={choice.confusionsOrder}
+            handleChoice={handleChoice}
+            images={images}
+            strings={strings}
+          />
+        )}
+        {questionIds.length > 0 && (
+          <Questions
+            answers={answers}
+            questionIds={questionIds}
+            questions={questions}
+            setAnswers={handleAnswers}
+            strings={strings}
+          />
+        )}
+        <Box
+          border={{
+            color: 'light-3',
+            side: 'top',
+            size: 'small'
+          }}
+          direction='row'
           fill='horizontal'
-          label={t('SurveyTask.Choice.notThis')}
-          onClick={() => handleDelete(choiceId)}
-        />
-        <PrimaryButton
-          data-testid='choice-identify-button'
-          disabled={!allowIdentify}
-          fill='horizontal'
-          label={t('SurveyTask.Choice.identify')}
-          onClick={() => onIdentify()}
-        />
+          gap='xsmall'
+          justify='center'
+          pad={{ top: 'small' }}
+        >
+          <Button
+            fill='horizontal'
+            label={t('SurveyTask.Choice.notThis')}
+            onClick={() => handleDelete(choiceId)}
+          />
+          <PrimaryButton
+            data-testid='choice-identify-button'
+            disabled={!allowIdentify}
+            fill='horizontal'
+            label={t('SurveyTask.Choice.identify')}
+            onClick={() => onIdentify()}
+          />
+        </Box>
       </Box>
     </StyledBox>
   )

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -107,7 +107,10 @@ function Choice({
           alignSelf='center'
           controls='arrows'
           data-testid='choice-images'
-          height={{ max: 'medium' }}
+          height={{
+            max: 'medium',
+            min: '160px'
+          }}
           width='100%'
         >
           {choice.images.map((filename, index) => (

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -60,6 +60,7 @@ function Choice({
   const allowIdentify = allowIdentification(answers, choiceId, task)
   const InfoLabel = (
     <Box
+      align='center'
       direction='row'
       gap='xsmall'
     >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -145,7 +145,6 @@ function Choice({
             {strings.get(`choices.${choiceId}.label`)}
           </Heading>
           <Button
-            a11yTitle={showInfo ? t('SurveyTask.Choice.lessInfo') : t('SurveyTask.Choice.moreInfo')}
             label={InfoLabel}
             onClick={() => setShowInfo(!showInfo)}          
             plain

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -114,6 +114,7 @@ function Choice({
           direction='row'
           fill='horizontal'
           justify='between'
+          margin={{ bottom: '30px' }}
         >
           <Heading
             id='choice-label'
@@ -136,20 +137,22 @@ function Choice({
         <Collapsible
           open={showDescription}
         >
-          <Paragraph>
-            {strings.get(`choices.${choiceId}.description`)}
-          </Paragraph>
-          {choice.confusionsOrder?.length > 0 && (
-            <ConfusedWith
-              choices={choices}
-              choiceId={choiceId}
-              confusions={choice.confusions}
-              confusionsOrder={choice.confusionsOrder}
-              handleChoice={handleChoice}
-              images={images}
-              strings={strings}
-            />
-          )}
+          <Box margin={{ bottom: '30px' }}>
+            <Paragraph margin='none'>
+              {strings.get(`choices.${choiceId}.description`)}
+            </Paragraph>
+            {choice.confusionsOrder?.length > 0 && (
+              <ConfusedWith
+                choices={choices}
+                choiceId={choiceId}
+                confusions={choice.confusions}
+                confusionsOrder={choice.confusionsOrder}
+                handleChoice={handleChoice}
+                images={images}
+                strings={strings}
+              />
+            )}
+          </Box>
         </Collapsible>
         {questionIds.length > 0 && (
           <Questions
@@ -170,11 +173,12 @@ function Choice({
           fill='horizontal'
           gap='xsmall'
           justify='center'
+          margin={{ top: '30px' }}
           pad={{ top: 'small' }}
         >
           <Button
             fill='horizontal'
-            label={t('SurveyTask.Choice.notThis')}
+            label={t('SurveyTask.Choice.cancel')}
             onClick={() => handleDelete(choiceId)}
           />
           <PrimaryButton

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
@@ -12,10 +12,10 @@ const mockTask = SurveyTask.TaskModel.create(task)
 describe('Component > Choice', function () {
   this.timeout(0)
 
-  describe('with choice with images, confusions, and questions', function () {
-    let carousel, confusedWith, question
+  describe('with choice with images and questions', function () {
+    let carousel, showMoreInfo, question
 
-    // choice 'KD' (Kudu) includes images, confusions, and questions
+    // choice 'KD' (Kudu) includes images and questions
     before(function () {
       render(
         <Grommet
@@ -30,7 +30,7 @@ describe('Component > Choice', function () {
       )
 
       carousel = screen.getByTestId('choice-images')
-      confusedWith = screen.getByText('SurveyTask.ConfusedWith.confused')
+      showMoreInfo = screen.getByRole('button', { name: 'SurveyTask.Choice.moreInfo' })
       question = screen.getByText('Are there any young present?')
     })
     
@@ -38,8 +38,8 @@ describe('Component > Choice', function () {
       expect(carousel).to.be.ok()
     })
   
-    it('should show ConfusedWith', function () {
-      expect(confusedWith).to.be.ok()
+    it('should show "More info" button', function () {
+      expect(showMoreInfo).to.be.ok()
     })
   
     it('should show Questions', function () {
@@ -47,8 +47,8 @@ describe('Component > Choice', function () {
     })
   })
 
-  describe('with choice without images, with confusions', function () {
-    // choice 'NTHNGHR' (Nothing here) excludes images, includes confusions
+  describe('with choice without images', function () {
+    // choice 'NTHNGHR' (Nothing here) excludes images
 
     it('should not render Carousel', function () {
       render(
@@ -66,27 +66,8 @@ describe('Component > Choice', function () {
     })
   })
 
-  describe('with choice without images or confusions, with questions', function () {
-    // choice 'HMN' (Human) excludes images and confusions, includes questions
-
-    it('should not render ConfusedWith', function () {
-      render(
-        <Grommet
-          theme={zooTheme}
-          themeMode='light'
-        >
-          <Choice
-            choiceId='HMN'
-            task={mockTask}
-          />
-        </Grommet>
-      )
-      expect(screen.queryByText('Sometimes confused with')).to.be.null()
-    })
-  })
-
-  describe('with choice without more than 1 image, confusions, or questions', function () {
-    // choice 'FR' (Fire) has 1 image, excludes confusions and questions
+  describe('with choice without more than 1 image or questions', function () {
+    // choice 'FR' (Fire) has 1 image excludes questions
 
     it('should not render Questions', function () {
       render(

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.stories.js
@@ -29,8 +29,8 @@ export const Default = ({ choiceId }) => {
           dark: 'dark-3',
           light: 'neutral-6'
         }}
-        pad='1em'
-        width='540px'
+        margin='20px'
+        width='498px'
       >
         <Choice choiceId={choiceId} task={mockTask} />
       </Box>

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.stories.js
@@ -30,7 +30,7 @@ export const Default = ({ choiceId }) => {
           light: 'neutral-6'
         }}
         pad='1em'
-        width='380px'
+        width='540px'
       >
         <Choice choiceId={choiceId} task={mockTask} />
       </Box>

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -48,6 +48,7 @@ function ConfusedWith({
   return (
     <Box margin={{ top: '30px' }}>
       <SpacedHeading
+        color={{ dark: 'neutral-6', light: 'dark-5' }}
         margin={{ bottom: '20px', top: 'none' }}
         size='1rem'
       >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -93,6 +93,10 @@ function ConfusedWith({
                 responsive: false
               }}
               label={strings.get(`choices.${confusionId}.label`)}
+              margin={{
+                bottom: '10px',
+                right: '10px'
+              }}
               open={open === confusionId}
               onClose={() => onClose()}
               onOpen={() => onOpen(confusionId)}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -11,12 +11,17 @@ import Confusion from './components/Confusion'
 export const StyledDropButton = styled(DropButton)`
   background-color: ${props => props.theme.global.colors[props.backgroundColor]};
   border: none;
+  border-radius: 4px;
   color: ${props => props.theme.dark ? props.theme.global.colors['neutral-6'] : props.theme.global.colors['neutral-7']};
   font-size: 1rem;
   height: 40px;
   min-width: 110px;
   margin-right: 5px;
   padding: 5px;
+
+  &:hover:not(:focus-within) {
+    box-shadow: 0 0 2px 2px ${props => props.theme.global.colors.brand};
+  }
 `
 
 function ConfusedWith({

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -11,6 +11,10 @@ import Confusion from './components/Confusion'
 export const StyledDropButton = styled(DropButton)`
   background-color: ${props => props.theme.global.colors[props.backgroundColor]};
   border: none;
+  color: ${props => props.theme.dark ? props.theme.global.colors['neutral-6'] : props.theme.global.colors['neutral-7']};
+  font-size: 1rem;
+  height: 40px;
+  min-width: 110px;
   margin-right: 5px;
   padding: 5px;
 `
@@ -44,9 +48,9 @@ function ConfusedWith({
         wrap
       >
         {confusionsOrder.map((confusionId, index) => {
-          let backgroundColor = 'neutral-6'
+          let backgroundColor = 'light-1'
           if (theme.dark) {
-            backgroundColor = 'dark-3'
+            backgroundColor = 'dark-4'
           }
           if (open === confusionId) {
             backgroundColor = 'accent-1'

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -46,7 +46,7 @@ function ConfusedWith({
   }
 
   return (
-    <Box margin={{ top: '30px' }}>
+    <Box margin={{ top: '20px' }}>
       <SpacedHeading
         color={{ dark: 'neutral-6', light: 'dark-5' }}
         margin={{ bottom: '20px', top: 'none' }}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -41,8 +41,13 @@ function ConfusedWith({
   }
 
   return (
-    <Box>
-      <SpacedHeading>{t('SurveyTask.ConfusedWith.confused')}</SpacedHeading>
+    <Box margin={{ top: '30px' }}>
+      <SpacedHeading
+        margin={{ bottom: '20px', top: 'none' }}
+        size='1rem'
+      >
+        {t('SurveyTask.ConfusedWith.confused')}
+      </SpacedHeading>
       <Box
         direction='row'
         wrap

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
@@ -42,6 +42,7 @@ export default function Questions({
           >
             <SpacedHeading
               id={`${questionId}-label`}
+              color={{ dark: 'neutral-6', light: 'dark-5' }}
               margin={{
                 top: 'none',
                 bottom: '20px'

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
@@ -26,7 +26,7 @@ export default function Questions({
   return (
     <Box
       flex='grow'
-      gap='30px'
+      gap='20px'
     >
       {questionIds.map((questionId, index) => {
         const question = questions.get(questionId) || { answers: {}, answersOrder: [] }

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
@@ -41,6 +41,7 @@ export default function Questions({
           >
             <SpacedHeading
               id={`${questionId}-label`}
+              size='1rem'
             >
               {strings.get(`questions.${questionId}.label`)}
             </SpacedHeading>

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
@@ -26,6 +26,7 @@ export default function Questions({
   return (
     <Box
       flex='grow'
+      gap='30px'
     >
       {questionIds.map((questionId, index) => {
         const question = questions.get(questionId) || { answers: {}, answersOrder: [] }
@@ -41,6 +42,10 @@ export default function Questions({
           >
             <SpacedHeading
               id={`${questionId}-label`}
+              margin={{
+                top: 'none',
+                bottom: '20px'
+              }}
               size='1rem'
             >
               {strings.get(`questions.${questionId}.label`)}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
@@ -58,7 +58,7 @@ function QuestionInput (props) {
           bottom: '10px',
           right: '10px'
         }}
-        pad={{ horizontal: 'xsmall' }}
+        pad={{ horizontal: '10px' }}
         round={type === 'radio' ? '20px / 50%' : '4px'}
         width={type === 'radio' ? { min: '40px' } : { min: '110px' }}
       >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
@@ -37,9 +37,9 @@ function QuestionInput (props) {
     type
   } = props
 
-  let backgroundColor = 'neutral-6'
+  let backgroundColor = 'light-1'
   if (theme.dark) {
-    backgroundColor = 'dark-3'
+    backgroundColor = 'dark-4'
   }
   if (isChecked) {
     backgroundColor = 'accent-1'
@@ -60,7 +60,7 @@ function QuestionInput (props) {
         }}
         pad={{ horizontal: 'xsmall' }}
         round={type === 'radio' ? 'full' : false}
-        width={{ min: '40px' }}
+        width={type === 'radio' ? { min: '40px' } : { min: '110px' }}
       >
         <input
           autoFocus={hasFocus}
@@ -73,6 +73,8 @@ function QuestionInput (props) {
           onKeyDown={type === 'radio' ? (event) => (handleRadioKeyDown(event)) : null}
         />
         <Text
+          color={theme.dark ? 'neutral-6' : 'neutral-7'}
+          size='1rem'
           weight={isChecked ? 'bold' : 'normal'}
         >
           {option.label}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
@@ -73,7 +73,7 @@ function QuestionInput (props) {
           onKeyDown={type === 'radio' ? (event) => (handleRadioKeyDown(event)) : null}
         />
         <Text
-          color={theme.dark ? 'neutral-6' : 'neutral-7'}
+          color={(theme.dark && !isChecked) ? 'neutral-6' : 'neutral-7'}
           size='1rem'
           weight={isChecked ? 'bold' : 'normal'}
         >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
@@ -59,7 +59,7 @@ function QuestionInput (props) {
           right: 'xsmall'
         }}
         pad={{ horizontal: 'xsmall' }}
-        round={type === 'radio' ? 'full' : false}
+        round={type === 'radio' ? 'full' : '4px'}
         width={type === 'radio' ? { min: '40px' } : { min: '110px' }}
       >
         <input

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.js
@@ -55,11 +55,11 @@ function QuestionInput (props) {
         height='40px'
         justify='center'
         margin={{
-          bottom: 'xsmall',
-          right: 'xsmall'
+          bottom: '10px',
+          right: '10px'
         }}
         pad={{ horizontal: 'xsmall' }}
-        round={type === 'radio' ? 'full' : '4px'}
+        round={type === 'radio' ? '20px / 50%' : '4px'}
         width={type === 'radio' ? { min: '40px' } : { min: '110px' }}
       >
         <input

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -24,6 +24,8 @@
     },
     "Choice": {
       "identify": "Identify",
+      "lessInfo": "Less info",
+      "moreInfo": "More info",
       "notThis": "Not this"
     },
     "ConfusedWith": {

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -30,7 +30,7 @@
     },
     "ConfusedWith": {
       "cancel": "Cancel",
-      "confused": "Sometimes confused with",
+      "confused": "Often confused with",
       "itsThis": "I think it's this"
     }
   },

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -26,7 +26,7 @@
       "identify": "Identify",
       "lessInfo": "Less info",
       "moreInfo": "More info",
-      "notThis": "Not this"
+      "cancel": "Cancel"
     },
     "ConfusedWith": {
       "cancel": "Cancel",


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #6239 
- related to #6238 and #6076 - whose related PR #6494 should be merged to production together with this PR

## Describe your changes
- refactors Choice and related components per related Figma: https://www.figma.com/design/ASqNlLhicNRzEDhYDA2t8j/Survey?node-id=55-7053&t=BvyK5fjoLo5qzkDS-4

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - lib-classifier, staging: https://local.zooniverse.org:8080/?project=1634&workflow=2434
- What user actions should my reviewer step through to review this PR?
  - compare Figma designs to local survey task
  - note new collapsable info (choice description and confused withs)
- Which storybook stories should be reviewed?
  - http://localhost:6006/?path=/story/tasks-survey-choice--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? yes, see related survey task feedback follow-up issues

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).