### PR TITLE
Remove temporary banners from app layouts

### DIFF
--- a/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
+++ b/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
@@ -53,44 +53,6 @@ function StandardLayout({ children, page = '' }) {
 
   return (
     <PageBox className={className} data-testid='project-page' border={border}>
-      <details
-        style={{
-          padding: '5px clamp(20px, 3vw, 30px)',
-          fontSize: '1rem',
-          lineHeight: 1.2,
-          color: '#000',
-          background: '#f0b200'
-        }}
-      >
-        <summary style={{ fontWeight: 'bold', cursor: 'pointer' }}>
-          Platform downtime scheduled on Wednesday November 20.
-        </summary>
-        <p style={{ paddingInline: '15px' }}>
-          The Zooniverse platform will be offline for scheduled maintenance on
-          Wednesday, November 20 from 4pm-10pm US Central Standard Time
-          (2024-11-20 22:00 UTC to 2024-11-21 4:00 UTC). During this period, all
-          projects and platform services will be inaccessible. We apologize for
-          the inconvenience; this maintenance is necessary to make updates to
-          platform infrastructure and improve long-term reliability and uptime.
-          Please visit{' '}
-          <a
-            href='https://status.zooniverse.org/incident/1019747'
-            target='_blank'
-            style={{ color: '#000' }}
-          >
-            status.zooniverse.org
-          </a>{' '}
-          for updates before and during the downtime period. For any additional
-          questions, please email{' '}
-          <a
-            style={{ color: '#000' }}
-            href='mailto:contact@zooniverse.org'
-          >
-            contact@zooniverse.org
-          </a>
-          .
-        </p>
-      </details>
       {page !== 'home' && <HeaderComponents adminMode={adminMode} />}
       {children}
       <ZooFooter

--- a/packages/app-root/src/components/RootLayout.js
+++ b/packages/app-root/src/components/RootLayout.js
@@ -6,44 +6,6 @@ export default function RootLayout({ children }) {
   return (
     <body>
       <PageContextProviders>
-        <details
-          style={{
-            padding: '5px clamp(20px, 3vw, 30px)',
-            fontSize: '1rem',
-            lineHeight: 1.2,
-            color: '#000',
-            background: '#f0b200'
-          }}
-        >
-          <summary style={{ fontWeight: 'bold', cursor: 'pointer' }}>
-            Platform downtime scheduled on Wednesday November 20.
-          </summary>
-          <p style={{ paddingInline: '15px' }}>
-            The Zooniverse platform will be offline for scheduled maintenance on
-            Wednesday, November 20 from 4pm-10pm US Central Standard Time
-            (2024-11-20 22:00 UTC to 2024-11-21 4:00 UTC). During this period, all
-            projects and platform services will be inaccessible. We apologize for
-            the inconvenience; this maintenance is necessary to make updates to
-            platform infrastructure and improve long-term reliability and uptime.
-            Please visit{' '}
-            <a
-              href='https://status.zooniverse.org/incident/1019747'
-              target='_blank'
-              style={{ color: '#000' }}
-            >
-              status.zooniverse.org
-            </a>{' '}
-            for updates before and during the downtime period. For any additional
-            questions, please email{' '}
-            <a
-              style={{ color: '#000' }}
-              href='mailto:contact@zooniverse.org'
-            >
-              contact@zooniverse.org
-            </a>
-            .
-          </p>
-        </details>
         <PageHeader />
         {children}
         <PageFooter />


### PR DESCRIPTION
## Package
app-root
app-project

## Linked Issue and/or Talk Post
Reversion of https://github.com/zooniverse/front-end-monorepo/pull/6456
Corresponding PFE PR: https://github.com/zooniverse/Panoptes-Front-End/pull/7221

## Describe your changes
- Remove `<details>` component from layouts.

## How to Review
- app-root should run locally without the banner
- app-project should run locally without the banner

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected