### PR TITLE
fix(lib-classifier): canvas context for SVG drawing tools

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -4,6 +4,7 @@ import { useContext, useRef, useState } from 'react';
 import styled, { css } from 'styled-components'
 
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
+import { convertEvent } from '@plugins/drawingTools/components/draggable/draggable'
 import DrawingToolMarks from './components/DrawingToolMarks'
 import TranscribedLines from './components/TranscribedLines'
 import SubTaskPopup from './components/SubTaskPopup'
@@ -24,38 +25,6 @@ const DrawingCanvas = styled('rect')`
 function cancelEvent(event) {
   event.preventDefault()
   event.stopPropagation()
-}
-
-function createPoint(event) {
-  const { clientX, clientY } = event
-  // SVG 2 uses DOMPoint
-  if (window.DOMPointReadOnly) {
-    return new DOMPointReadOnly(clientX, clientY)
-  }
-  // jsdom doesn't support SVG
-  return {
-    x: clientX,
-    y: clientY
-  }
-}
-
-function getEventOffset(event, canvas) {
-  const svgPoint = createPoint(event)
-  const svgEventOffset = svgPoint.matrixTransform
-    ? svgPoint.matrixTransform(canvas.getScreenCTM().inverse())
-    : svgPoint
-  return svgEventOffset
-}
-
-function convertEvent(event, canvas) {
-  const svgEventOffset = getEventOffset(event, canvas)
-  const svgCoordinateEvent = {
-    type: event.type,
-    x: svgEventOffset.x,
-    y: svgEventOffset.y
-  }
-
-  return svgCoordinateEvent
 }
 
 function InteractionLayer({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -1,7 +1,9 @@
 import cuid from 'cuid'
 import PropTypes from 'prop-types'
-import { useRef, useState } from 'react';
+import { useContext, useRef, useState } from 'react';
 import styled, { css } from 'styled-components'
+
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import DrawingToolMarks from './components/DrawingToolMarks'
 import TranscribedLines from './components/TranscribedLines'
 import SubTaskPopup from './components/SubTaskPopup'
@@ -24,6 +26,38 @@ function cancelEvent(event) {
   event.stopPropagation()
 }
 
+function createPoint(event) {
+  const { clientX, clientY } = event
+  // SVG 2 uses DOMPoint
+  if (window.DOMPointReadOnly) {
+    return new DOMPointReadOnly(clientX, clientY)
+  }
+  // jsdom doesn't support SVG
+  return {
+    x: clientX,
+    y: clientY
+  }
+}
+
+function getEventOffset(event, canvas) {
+  const svgPoint = createPoint(event)
+  const svgEventOffset = svgPoint.matrixTransform
+    ? svgPoint.matrixTransform(canvas.getScreenCTM().inverse())
+    : svgPoint
+  return svgEventOffset
+}
+
+function convertEvent(event, canvas) {
+  const svgEventOffset = getEventOffset(event, canvas)
+  const svgCoordinateEvent = {
+    type: event.type,
+    x: svgEventOffset.x,
+    y: svgEventOffset.y
+  }
+
+  return svgCoordinateEvent
+}
+
 function InteractionLayer({
   activeMark,
   activeTool,
@@ -43,7 +77,9 @@ function InteractionLayer({
   duration
 }) {
   const [creating, setCreating] = useState(false)
-  const canvas = useRef()
+  const svgContext = useContext(SVGContext)
+  const canvasRef = useRef()
+  svgContext.canvas = canvasRef.current
 
   if (creating && !activeMark) {
     setCreating(false)
@@ -52,42 +88,6 @@ function InteractionLayer({
   if (activeMark?.finished && !activeMark.isValid) {
     activeTool.deleteMark(activeMark)
     setActiveMark(undefined)
-  }
-
-  function convertEvent(event) {
-    const type = event.type
-
-    const svgEventOffset = getEventOffset(event)
-
-    const svgCoordinateEvent = {
-      pointerId: event.pointerId,
-      type,
-      x: svgEventOffset.x,
-      y: svgEventOffset.y
-    }
-
-    return svgCoordinateEvent
-  }
-
-  function createPoint(event) {
-    const { clientX, clientY } = event
-    // SVG 2 uses DOMPoint
-    if (window.DOMPointReadOnly) {
-      return new DOMPointReadOnly(clientX, clientY)
-    }
-    // jsdom doesn't support SVG
-    return {
-      x: clientX,
-      y: clientY
-    }
-  }
-
-  function getEventOffset(event) {
-    const svgPoint = createPoint(event)
-    const svgEventOffset = svgPoint.matrixTransform
-      ? svgPoint.matrixTransform(canvas.current?.getScreenCTM().inverse())
-      : svgPoint
-    return svgEventOffset
   }
 
   function createMark(event) {
@@ -99,7 +99,7 @@ function InteractionLayer({
       toolIndex: activeToolIndex
     })
 
-    mark.initialPosition(convertEvent(event))
+    mark.initialPosition(convertEvent(event, canvasRef.current))
     setActiveMark(mark)
     setCreating(true)
     mark.setSubTaskVisibility(false)
@@ -124,7 +124,7 @@ function InteractionLayer({
     }
 
     if (creating) {
-      activeTool?.handlePointerDown?.(convertEvent(event), activeMark)
+      activeTool?.handlePointerDown?.(convertEvent(event, canvasRef.current), activeMark)
       if (activeMark.finished) onFinish(event)
       return true
     }
@@ -136,7 +136,7 @@ function InteractionLayer({
   function onPointerMove(event) {
     cancelEvent(event)
     if (creating) {
-      activeTool?.handlePointerMove?.(convertEvent(event), activeMark)
+      activeTool?.handlePointerMove?.(convertEvent(event, canvasRef.current), activeMark)
     }
   }
 
@@ -149,7 +149,7 @@ function InteractionLayer({
   function onPointerUp(event) {
     cancelEvent(event)
     if (creating) {
-      activeTool?.handlePointerUp?.(convertEvent(event), activeMark)
+      activeTool?.handlePointerUp?.(convertEvent(event, canvasRef.current), activeMark)
       if (activeMark.finished) onFinish(event)
     }
   }
@@ -165,7 +165,7 @@ function InteractionLayer({
   return (
     <>
       <DrawingCanvas
-        ref={canvas}
+        ref={canvasRef}
         disabled={disabled || move}
         pointerEvents={move ? 'none' : 'all'}
         width={width}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -34,12 +34,10 @@ function SingleImageViewer({
   zoomControlFn = null,
   zooming = false
 }) {
-  const canvasLayer = useRef()
-  const canvas = canvasLayer.current
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
 
   return (
-    <SVGContext.Provider value={{ canvas, viewBox, rotate, width, height }}>
+    <SVGContext.Provider value={{ viewBox, rotate, width, height }}>
       {zoomControlFn && (
         <ZoomControlButton
           onClick={zoomControlFn}
@@ -68,7 +66,6 @@ function SingleImageViewer({
             transform={transform}
           >
             <SVGImageCanvas
-              ref={canvasLayer}
               viewBox={viewBox}
             >
               {children}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -34,10 +34,12 @@ function SingleImageViewer({
   zoomControlFn = null,
   zooming = false
 }) {
+  const canvasLayer = useRef()
+  const canvas = canvasLayer.current
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
 
   return (
-    <SVGContext.Provider value={{ viewBox, rotate, width, height }}>
+    <SVGContext.Provider value={{ canvas, viewBox, rotate, width, height }}>
       {zoomControlFn && (
         <ZoomControlButton
           onClick={zoomControlFn}
@@ -66,6 +68,7 @@ function SingleImageViewer({
             transform={transform}
           >
             <SVGImageCanvas
+              ref={canvasLayer}
               viewBox={viewBox}
             >
               {children}

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -16,8 +16,9 @@ function createPoint(event) {
 
 function getEventOffset(event, canvas) {
   const svgPoint = createPoint(event)
-  const svgEventOffset = svgPoint.matrixTransform
-    ? svgPoint.matrixTransform(canvas.getScreenCTM().inverse())
+  const ctm = canvas?.getScreenCTM()
+  const svgEventOffset = ctm && svgPoint.matrixTransform
+    ? svgPoint.matrixTransform(ctm.inverse())
     : svgPoint
   return svgEventOffset
 }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -22,7 +22,7 @@ function getEventOffset(event, canvas) {
   return svgEventOffset
 }
 
-function convertEvent(event, canvas) {
+export function convertEvent(event, canvas) {
   const svgEventOffset = getEventOffset(event, canvas)
   const svgCoordinateEvent = {
     type: event.type,


### PR DESCRIPTION
Make sure that `SVGContext.canvas` is a reference to the SVG `rect` element that's used as a drawing canvas, so that creating new drawing marks and editing existing marks both use the same screen CTM when calculating the pointer position in SVG space.

This fixes a bug in Firefox where the `draggable` decorator doesn't correctly track the active pointer, in the context of a zoomed SVG image.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #6490.

## How to Review
On I Fancy Cats, you should be able to draw while zoomed in, without seeing any of the mismatched positioning described in #6490. You can try it out by drawing an ellipse while zoomed in, or by placing a point then dragging the point to a new position.

Try it out in Firefox and Chrome, while zoomed in and also after rotating the image. Pointer interactions should be correctly mapped to the SVG image now, regardless of any external transformation.

While drawing, in any browser, you should be able to pan and zoom with the keyboard too.

The stroke width of drawn marks should also stay the same as you zoom in. Lines shouldn’t be thicker at increased magnification. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
