### PR TITLE
fix(lib-classifier): expire classification session IDs

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
@@ -1,7 +1,7 @@
 import cuid from 'cuid'
-import { getRoot, getSnapshot, types } from 'mobx-state-tree'
+import { getSnapshot, types } from 'mobx-state-tree'
 
-import { sessionUtils } from '@store/utils'
+import { getSessionID } from '@store/utils/session'
 
 const Annotation = types.model('Annotation', {
   id: types.identifier,
@@ -37,7 +37,7 @@ const Annotation = types.model('Annotation', {
       self.value = value
       self._inProgress = true
       // refresh the classification session ID
-      sessionUtils.getSessionID()
+      getSessionID()
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
@@ -1,6 +1,8 @@
 import cuid from 'cuid'
 import { getRoot, getSnapshot, types } from 'mobx-state-tree'
 
+import { sessionUtils } from '@store/utils'
+
 const Annotation = types.model('Annotation', {
   id: types.identifier,
   task: types.string,
@@ -34,8 +36,8 @@ const Annotation = types.model('Annotation', {
     update (value) {
       self.value = value
       self._inProgress = true
-      const { authClient } = getRoot(self)
-      authClient?.checkBearerToken()
+      // refresh the classification session ID
+      sessionUtils.getSessionID()
     }
   }))
 

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -7,8 +7,8 @@ import Classification, { ClassificationMetadata } from './Classification'
 import ResourceStore from './ResourceStore'
 import {
   ClassificationQueue,
-  sessionUtils
 } from './utils'
+import { getSessionID } from './utils/session'
 import { subjectsSeenThisSession } from '@helpers'
 
 const ClassificationStore = types
@@ -109,7 +109,7 @@ const ClassificationStore = types
 
         const metadata = {
           finishedAt: (new Date()).toISOString(),
-          session: sessionUtils.getSessionID(),
+          session: getSessionID(),
           subjectDimensions,
           viewport: {
             width: window.innerWidth,

--- a/packages/lib-classifier/src/store/utils/index.js
+++ b/packages/lib-classifier/src/store/utils/index.js
@@ -1,4 +1,5 @@
+import * as sessionUtils from './session'
+export { sessionUtils }
 export { default as ClassificationQueue } from './ClassificationQueue'
 export { default as convertMapToArray } from './convertMapToArray'
-export { default as sessionUtils } from './session'
 export { default as getBearerToken } from './getBearerToken'

--- a/packages/lib-classifier/src/store/utils/session.js
+++ b/packages/lib-classifier/src/store/utils/session.js
@@ -15,6 +15,16 @@ const sessionUtils = {
     return id
   },
 
+  storedSession() {
+    const storedSession = storage.getItem('session_id')
+    if (storedSession) {
+      const session = JSON.parse(storedSession)
+      session.ttl = new Date(session.ttl)
+      return session
+    }
+    return null
+  },
+
   newSession() {
     return {
       id: this.generateSessionID(),
@@ -23,11 +33,7 @@ const sessionUtils = {
   },
 
   getSessionID() {
-    const storedSession = storage.getItem('session_id')
-    const stored = storedSession
-      ? JSON.parse(storedSession)
-      : this.newSession()
-    stored.ttl = new Date(stored.ttl)
+    const stored = this.storedSession() || this.newSession()
 
     if (stored.ttl < Date.now()) {
       stored.id = this.generateSessionID()

--- a/packages/lib-classifier/src/store/utils/session.js
+++ b/packages/lib-classifier/src/store/utils/session.js
@@ -25,6 +25,7 @@ const sessionUtils = {
   getSessionID () {
     const stored = (storage.getItem('session_id')) ? JSON.parse(storage.getItem('session_id')) : this.generateSessionID()
     let { id, ttl } = stored
+    console.log(stored)
 
     if (ttl < Date.now()) {
       id = this.generateSessionID()

--- a/packages/lib-classifier/src/store/utils/session.js
+++ b/packages/lib-classifier/src/store/utils/session.js
@@ -3,23 +3,30 @@ import hash from 'hash.js'
 const storage = window.sessionStorage
 
 const sessionUtils = {
-  fiveMinutesFromNow () {
+  fiveMinutesFromNow() {
     const d = new Date()
     d.setMinutes(d.getMinutes() + 5)
     return d
   },
 
-  generateSessionID () {
+  generateSessionID() {
     const sha2 = hash.sha256()
     const id = sha2.update(`${Math.random() * 10000}${Date.now()}${Math.random() * 1000}`).digest('hex')
     return id
   },
 
-  getSessionID () {
+  newSession() {
+    return {
+      id: this.generateSessionID(),
+      ttl: this.fiveMinutesFromNow()
+    }
+  },
+
+  getSessionID() {
     const storedSession = storage.getItem('session_id')
     const stored = storedSession
       ? JSON.parse(storedSession)
-      : { id: this.generateSessionID(), ttl: new Date() }
+      : this.newSession()
     stored.ttl = new Date(stored.ttl)
 
     if (stored.ttl < Date.now()) {

--- a/packages/lib-classifier/src/store/utils/session.js
+++ b/packages/lib-classifier/src/store/utils/session.js
@@ -14,38 +14,34 @@ function storedSession() {
 
 function newSession() {
   return {
-    id: sessionUtils.generateSessionID(),
-    ttl: sessionUtils.fiveMinutesFromNow()
+    id: generateSessionID(),
+    ttl: fiveMinutesFromNow()
   }
 }
 
-const sessionUtils = {
-  fiveMinutesFromNow() {
-    const d = new Date()
-    d.setMinutes(d.getMinutes() + 5)
-    return d
-  },
-
-  generateSessionID() {
-    const sha2 = hash.sha256()
-    const id = sha2.update(`${Math.random() * 10000}${Date.now()}${Math.random() * 1000}`).digest('hex')
-    return id
-  },
-
-  getSessionID() {
-    const stored = storedSession() || newSession()
-
-    if (stored.ttl < Date.now()) {
-      stored.id = this.generateSessionID()
-    }
-    stored.ttl = this.fiveMinutesFromNow()
-    try {
-      storage.setItem('session_id', JSON.stringify(stored))
-    } catch (e) {
-      console.error(e)
-    }
-    return stored.id
-  }
+export function fiveMinutesFromNow() {
+  const d = new Date()
+  d.setMinutes(d.getMinutes() + 5)
+  return d
 }
 
-export default sessionUtils
+export function generateSessionID() {
+  const sha2 = hash.sha256()
+  const id = sha2.update(`${Math.random() * 10000}${Date.now()}${Math.random() * 1000}`).digest('hex')
+  return id
+}
+
+export function getSessionID() {
+  const stored = storedSession() || newSession()
+
+  if (stored.ttl < Date.now()) {
+    stored.id = generateSessionID()
+  }
+  stored.ttl = fiveMinutesFromNow()
+  try {
+    storage.setItem('session_id', JSON.stringify(stored))
+  } catch (e) {
+    console.error(e)
+  }
+  return stored.id
+}

--- a/packages/lib-classifier/src/store/utils/session.js
+++ b/packages/lib-classifier/src/store/utils/session.js
@@ -2,6 +2,23 @@ import hash from 'hash.js'
 
 const storage = window.sessionStorage
 
+function storedSession() {
+  const storedSession = storage.getItem('session_id')
+  if (storedSession) {
+    const session = JSON.parse(storedSession)
+    session.ttl = new Date(session.ttl)
+    return session
+  }
+  return null
+}
+
+function newSession() {
+  return {
+    id: sessionUtils.generateSessionID(),
+    ttl: sessionUtils.fiveMinutesFromNow()
+  }
+}
+
 const sessionUtils = {
   fiveMinutesFromNow() {
     const d = new Date()
@@ -15,25 +32,8 @@ const sessionUtils = {
     return id
   },
 
-  storedSession() {
-    const storedSession = storage.getItem('session_id')
-    if (storedSession) {
-      const session = JSON.parse(storedSession)
-      session.ttl = new Date(session.ttl)
-      return session
-    }
-    return null
-  },
-
-  newSession() {
-    return {
-      id: this.generateSessionID(),
-      ttl: this.fiveMinutesFromNow()
-    }
-  },
-
   getSessionID() {
-    const stored = this.storedSession() || this.newSession()
+    const stored = storedSession() || newSession()
 
     if (stored.ttl < Date.now()) {
       stored.id = this.generateSessionID()

--- a/packages/lib-classifier/src/store/utils/session.spec.js
+++ b/packages/lib-classifier/src/store/utils/session.spec.js
@@ -49,7 +49,9 @@ describe('Store utils > sessionUtils', function () {
     })
 
     it('it should retrieve id from session or local storage if it exists', function () {
-      const stored = { id: 'foobar', ttl: (Date.now() + 50000) }
+      const ttl = new Date()
+      ttl.setMinutes(ttl.getMinutes() + 5)
+      const stored = { id: 'foobar', ttl }
       sessionStorage.setItem('session_id', JSON.stringify(stored))
       sessionUtils.getSessionID()
       expect(generateSessionIDSpy).to.have.not.been.called()
@@ -72,7 +74,9 @@ describe('Store utils > sessionUtils', function () {
 
     describe('when the stored token has expired', function () {
       before(function () {
-        const stored = { id: 'foobar', ttl: (Date.now() - 1) }
+        const ttl = new Date()
+        ttl.setMinutes(ttl.getMinutes() - 10)
+        const stored = { id: 'foobar', ttl }
         sessionStorage.setItem('session_id', JSON.stringify(stored))
       })
 

--- a/packages/lib-classifier/src/store/utils/session.spec.js
+++ b/packages/lib-classifier/src/store/utils/session.spec.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon'
 import hash from 'hash.js'
-import sessionUtils from './session'
+import * as sessionUtils from './session'
 
 describe('Store utils > sessionUtils', function () {
   describe('fiveMinutesFromNow', function () {

--- a/packages/lib-classifier/src/store/utils/session.spec.js
+++ b/packages/lib-classifier/src/store/utils/session.spec.js
@@ -117,26 +117,9 @@ describe('Store utils > sessionUtils', function () {
       dateSpy.restore()
     })
 
-    it('should call fiveMinutesFromNow', function () {
-      const fiveMinutesFromNowSpy = sinon.spy(sessionUtils, 'fiveMinutesFromNow')
-      sessionUtils.generateSessionID()
-      expect(fiveMinutesFromNowSpy).to.have.been.called()
-      fiveMinutesFromNowSpy.restore()
-    })
-
-    it('should return an object with the generated id and the result of calling fiveMinutesFromNow', function () {
+    it('should return the generated id', function () {
       const result = sessionUtils.generateSessionID()
-      expect(result).to.be.an('object')
-      expect(result).to.have.property('id')
-      expect(result.id).to.be.a('string')
-      expect(result).to.have.property('ttl')
-      expect(result.ttl).to.be.an.instanceof(Date)
-    })
-
-    it('should store the stringified generated id and Date object in session storage', function () {
-      const result = JSON.stringify(sessionUtils.generateSessionID())
-      const stored = sessionStorage.getItem('session_id')
-      expect(result).to.equal(stored)
+      expect(result).to.be.a('string')
     })
   })
 })


### PR DESCRIPTION
- fix the session ID tests so that they fail properly.
- fix `getSessionID` to pass the tests, by expiring a session ID after five minutes of inactivity.
- refactor `generateSessionID` so that it generates a session ID.
- refresh the session TTL whenever an annotation is updated.
- I added `storedSession()` and `newSession()` functions, to make it a little clearer what the code is doing.
- `store/utils/session.js` is now an ES module that can be copied straight into PFE. PFE and the monorepo both share the same `session_id` object in session storage, so the session code has to be synchronised for both repo's.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- fixes #6503.
- linked discussion: https://github.com/zooniverse/front-end-monorepo/issues/6493#issuecomment-2504436123
- this PR is an alternative to #6499, which sets a constant session ID for all classifications made in the same tab, regardless of inactivity.

## How to Review
All classifications made in a single session should still have the same session ID here. The difference from #6499 is that a new session ID should be generated if you do nothing for 5 minutes. It should be possible to record multiple classification sessions from a single browser session in the same tab.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
