### PR TITLE
lib-classifier: Fix survey task FilterStatus images not showing

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
@@ -103,9 +103,9 @@ export default function FilterStatus ({
         onOpen={handleFilterDropOpen}
       />
       {selectedCharacteristicIds.map(characteristicId => {
-        const characteristic = characteristics?.[characteristicId] || {}
+        const characteristic = characteristics?.get(characteristicId) || {}
         const selectedValueId = filters?.[characteristicId] || ''
-        const value = characteristic.values?.[selectedValueId] || {}
+        const value = characteristic.values?.get(selectedValueId) || {}
         const valueImageSrc = images?.get(value.image) || ''
         const label = strings.get(`characteristics.${characteristicId}.values.${selectedValueId}.label`)
         function clearSelection() {


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- go to project with survey task, like production project https://www.zooniverse.org/projects/zooniverse/gravity-spy/classify/workflow/7766 
- apply filters, close filters drop content
- note filter characteristic images do not display in FilterStatus component

## Describe your changes
- refactors `characteristics` and `characteristic.values` with `.get` because they are maps

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - any survey task project, including:
    - staging: https://local.zooniverse.org:3000/projects/markb-panoptes/survey-task-test-project?env=staging
    - production: https://local.zooniverse.org:3000/projects/zooniverse/gravity-spy/classify/workflow/7766?env=production
- What user actions should my reviewer step through to review this PR?
  - with a survey task, select filters
  - close survey task filters drop content
  - note selected filters show related image
- Which storybook stories should be reviewed?
  - http://localhost:6006/?path=/story/tasks-survey-chooser-characteristicsfilter-filterstatus--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? yes, further styling updates included in [link to filter styling update PR here]

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated