### PR TITLE
Remove visx packages from app-project

### DIFF
--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -19,11 +19,6 @@
   "dependencies": {
     "@sentry/nextjs": "~8.42.0",
     "@sindresorhus/string-hash": "~1.2.0",
-    "@visx/axis": "~3.12.0",
-    "@visx/group": "~3.12.0",
-    "@visx/scale": "~3.12.0",
-    "@visx/shape": "~3.12.0",
-    "@visx/text": "~3.12.0",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/classifier": "^0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5618,7 +5618,7 @@
     lodash "^4.17.21"
     prop-types "^15.5.10"
 
-"@visx/text@3.12.0", "@visx/text@~3.12.0":
+"@visx/text@3.12.0":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@visx/text/-/text-3.12.0.tgz#2d023a6ac561557c5a7e7538bea4015d987e5238"
   integrity sha512-0rbDYQlbuKPhBqXkkGYKFec1gQo05YxV45DORzr6hCyaizdJk1G+n9VkuKSHKBy1vVQhBA0W3u/WXd7tiODQPA==


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Follow-up to https://github.com/zooniverse/front-end-monorepo/pull/6472

## Describe your changes
Remove the unused VisX packages from app-project.

## How to Review

- This is a simple change I've tested locally by building app-project and will double check on frontend.preview.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)