### PR TITLE
Remove pjc experiment pt3

### DIFF
--- a/packages/lib-panoptes-js/dev/index.html
+++ b/packages/lib-panoptes-js/dev/index.html
@@ -21,10 +21,15 @@
   </head>
   <body>
     <h1>Panoptes.js dev app</h1>
+    <section>
+      <h2>Functions</h2>
+      <button id="check-current-user-button">checkCurrentUser()</button>
+    </section>
     <form
       id="login-form"
       method="POST"
     >
+      <h2>Sign In</h2>
       <input type="text" name="login" />
       <br>
       <input type="password" name="password" />

--- a/packages/lib-panoptes-js/dev/index.js
+++ b/packages/lib-panoptes-js/dev/index.js
@@ -1,14 +1,36 @@
-import { signIn, addEventListener } from '@src/experimental-auth.js'
+import {
+  checkBearerToken,
+  checkCurrentUser,
+  signIn,
+  addEventListener,
+} from '@src/experimental-auth.js'
 
 class App {
   constructor () {
     this.html = {
+      checkCurrentUserButton: document.getElementById('check-current-user-button'),
       loginForm: document.getElementById('login-form'),
       message: document.getElementById('message'),
     }
 
+    this.html.checkCurrentUserButton.addEventListener('click', this.checkCurrentUserButton_onClick.bind(this))
     this.html.loginForm.addEventListener('submit', this.loginForm_onSubmit.bind(this))
     addEventListener('change', this.onAuthChange)
+  }
+
+  async checkCurrentUserButton_onClick (e) {
+    try {
+      const user = await checkCurrentUser()
+      if (user) {
+        this.html.message.innerHTML += `> Current user: ${user.login}\n`
+      } else {
+        this.html.message.innerHTML += `> Current user: [nobody] \n`
+      }
+    } catch (err) {
+      console.error(err)
+      this.html.message.innerHTML += `> [ERROR] ${err.toString()}\n`
+    }
+    return false
   }
 
   async loginForm_onSubmit (e) {
@@ -25,7 +47,7 @@ class App {
       }
     } catch (err) {
       console.error(err)
-      this.html.message.innerHTML += `> ${err.toString()}\n`
+      this.html.message.innerHTML += `> [ERROR] ${err.toString()}\n`
     }
     return false
   }

--- a/packages/lib-panoptes-js/src/experimental-auth.js
+++ b/packages/lib-panoptes-js/src/experimental-auth.js
@@ -279,7 +279,8 @@ async function checkCurrentUser (_store) {
   const store = _store || globalStore
 
   // Step 1: do we already have a user in the store?
-  if (store.userData) {
+  // DEBUG if (store.userData) {
+    if (false) {
     
     // If yes, just return the user.
     return store.userData
@@ -337,7 +338,7 @@ async function checkCurrentUser (_store) {
       const bearerTokenExpiry = Date.now() + (jsonData1?.expires_in * 1000)  // Use Date.now() instead of response.created_at, because it keeps future "has expired?" comparisons consistent to the client's clock instead of the server's clock.
       
       if (!bearerToken || !refreshToken) {
-        // throw new Error('Impossible API response. access_token and/or refresh_token unavailable.')
+        throw new Error('Impossible API response. access_token and/or refresh_token unavailable.')
       } else if (jsonData1?.token_type !== 'Bearer') {
         throw new Error('Impossible API response. Token wasn\'t of type "Bearer".')
       } else if (isNaN(bearerTokenExpiry)) {
@@ -346,12 +347,18 @@ async function checkCurrentUser (_store) {
         throw new Error('Impossible API response. Token has already expired for some reason.')
       }
 
-      return
-
-      const request2 = new Request(`https://panoptes-staging.zooniverse.org/api/me`, {
-        credentials: 'include',
+      // TODO: figure out why /me specifically requires such an odd header + credentials 
+      
+      const request2 = new Request(`https://panoptes-staging.zooniverse.org/api/me?http_cache=true`, {
+        // credentials: 'include',  // ❗️ Don't use 'include'.
+        credentials: 'same-origin',
         method: 'GET',
-        headers: PANOPTES_HEADERS,
+        headers: {
+          // ...PANOPTES_HEADERS,  // ❗️ Don't use standard headers.
+          'Content-Type': 'application/json',
+          'Accept': 'application/vnd.api+json; version=1',
+          Authorization: `Bearer ${bearerToken}`
+        },
       })
 
       const response2 = await fetch(request2)

--- a/packages/lib-panoptes-js/src/experimental-auth.js
+++ b/packages/lib-panoptes-js/src/experimental-auth.js
@@ -271,7 +271,32 @@ async function signIn (login, password, _store) {
   }
 }
 
+/*
+Checks if there's a current, signed-in user.
+ */
+async function checkCurrentUser (_store) {
+
+}
+
+// Alias for checkCurrentUser
+async function checkCurrent(_store) { return checkCurrentUser(_store) }
+
+/*
+Fetches current user from Panoptes's /me endpoint.
+ */
+async function fetchCurrentUser (_store) {
+
+}
+
+/*
+Checks if there's an existing Bearer Token.
+ */
+async function checkBearerToken (_store) {}
+
 export {
+  checkBearerToken,
+  checkCurrent,
+  checkCurrentUser,
   signIn,
   addEventListener,
   removeEventListener,


### PR DESCRIPTION
## PR Overview

Package: Package: lib-panoptes-js
Part of: replacing PJC with Panoptes JS
Follows and requires: #6375 

This PR continues the experiment to remove PJC from FEM. In this PR, we add the ability to check the current user, via checkCurrentUser(), to the Experimental Auth system.

- Experimental Auth: added **checkCurrentUser()** (and its alias for backwards compatibility, **checkCurrent()** )
  - checkCurrentUser() will return the current signed-in User _if the Panoptes API recognises there's one, based on the http-only Panoptes session cookies._
  - In the context of FEM, this is pretty much always used at the start of app load, start of page load, and/or the start of API function calls.
- Dev server: new "check current user" button added, to manually trigger the action.

### Status

Ready for **internal team review.**

Please note that **the code is verbose on purpose.** I can fold a lot of the functionality into reusable functions (e.g. checkBearerToken() / fetchBearerToken() ) but I want to make sure that everyone on the team can read through & understand the process as easily as possible.