### PR TITLE
lib-user: Setup react-i18next for HeaderDropdown, ProfileHeader, and TopProjects

### DIFF
--- a/packages/lib-user/src/components/shared/Layout/components/HeaderDropdown.js
+++ b/packages/lib-user/src/components/shared/Layout/components/HeaderDropdown.js
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components'
 import { Box, DropButton } from 'grommet'
 import { FormDown } from 'grommet-icons'
 import { SpacedText } from '@zooniverse/react-components'
+import { useTranslation } from '../../../../translations/i18n.js'
 
 const StyledDropButton = styled(DropButton)`
   position: relative;
@@ -57,6 +58,7 @@ const StyledLi = styled.li`
 `
 
 function HeaderDropdown({ secondaryHeaderItems = [] }) {
+  const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
 
   const handleOpen = () => {
@@ -98,7 +100,7 @@ function HeaderDropdown({ secondaryHeaderItems = [] }) {
         pad={{ horizontal: 'medium', vertical: 'xsmall' }}
       >
         <SpacedText size='.78rem' weight={700}>
-          Group Options
+          {t('HeaderDropdown.label')}
         </SpacedText>
         <FormDown color='white' />
       </Box>

--- a/packages/lib-user/src/components/shared/MainContent/MainContent.js
+++ b/packages/lib-user/src/components/shared/MainContent/MainContent.js
@@ -3,6 +3,7 @@ import { Anchor, Box, Calendar, ResponsiveContext, Text } from 'grommet'
 import { arrayOf, bool, func, number, shape, string } from 'prop-types'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useTranslation, Trans } from '../../../translations/i18n.js'
 
 import {
   convertStatsSecondsToHours,
@@ -51,6 +52,7 @@ function MainContent({
   source = DEFAULT_SOURCE,
   totalProjects = 0
 }) {
+  const { t } = useTranslation()
   const [activeTab, setActiveTab] = useState(0)
   const [showCalendar, setShowCalendar] = useState(false)
   const [customDateRange, setCustomDateRange] = useState([selectedDateRange.startDate, selectedDateRange.endDate])
@@ -74,10 +76,11 @@ function MainContent({
   const { dateRangeOptions, selectedDateRangeOption } = getDateRangeSelectOptions({
     sourceCreatedAtDate,
     paramsValidationMessage,
-    selectedDateRange
+    selectedDateRange,
+    t
   })
 
-  const { projectOptions, selectedProjectOption } = getProjectSelectOptions({ projects, selectedProject })
+  const { projectOptions, selectedProjectOption } = getProjectSelectOptions({ projects, selectedProject, t })
 
   const todayUTC = getStatsDateString(new Date())
 
@@ -123,7 +126,7 @@ function MainContent({
         active={showCalendar}
         closeFn={handleCalendarClose}
         position='top'
-        title='Custom Date Range'
+        title={t('MainContent.calendarTitle')}
       >
         <Calendar
           bounds={[
@@ -140,7 +143,7 @@ function MainContent({
           margin={{ top: 'small' }}
         >
           <StyledCalendarButton
-            label='DONE'
+            label={t('MainContent.calendarBtn')}
             onClick={handleCalendarSave}
           />
         </Box>
@@ -179,7 +182,7 @@ function MainContent({
                 aria-expanded={activeTab === 0}
                 aria-selected={activeTab === 0}
                 active={activeTab === 0}
-                label='CLASSIFICATIONS'
+                label={t('common.classifications')}
                 onClick={() => handleActiveTab(0)}
                 plain
                 fill={size === 'small' ? 'horizontal' : false}
@@ -189,14 +192,14 @@ function MainContent({
                 aria-expanded={activeTab === 1}
                 aria-selected={activeTab === 1}
                 active={activeTab === 1}
-                label='HOURS'
+                label={t('common.hours')}
                 onClick={() => handleActiveTab(1)}
                 plain
                 fill={size === 'small' ? 'horizontal' : false}
               />
             </Box>
             <Tip
-              contentText='Hours are calculated based on the start and end times of your classification efforts. Hours do not reflect your time spent on Talk.'
+              contentText={t('MainContent.hoursTip')}
             />
           </Box>
           <Box
@@ -224,7 +227,7 @@ function MainContent({
         </Box>
         <Box
           role='tabpanel'
-          aria-label={activeTab === 0 ? 'CLASSIFICATIONS Tab Contents' : 'HOURS Tab Contents'}
+          aria-label={activeTab === 0 ? `${t('common.classifications')} ${t('MainContent.tabContents')}` : `${t('common.hours')} ${t('MainContent.tabContents')}`}
           height='15rem'
           width='100%'
         >
@@ -254,7 +257,7 @@ function MainContent({
               pad='medium'
             >
               <SpacedText uppercase={false}>
-                There was an error.
+                {t('MainContent.error')}
               </SpacedText>
               <SpacedText uppercase={false}>
                 {error?.message}
@@ -267,13 +270,17 @@ function MainContent({
               justify='center'
               pad='medium'
             >
-              <SpacedText uppercase={false}>No data found.</SpacedText>
+              <Text>{t('MainContent.noData')}</Text>
               <Text>
-                Start by{' '}
-                <Anchor href='https://www.zooniverse.org/projects'>
-                  classifying a project
-                </Anchor>
-                {' ' }now, or change the date range.
+                <Trans
+                  i18nKey='MainContent.start'
+                  components={[
+                    <Anchor
+                      key='projects-page'
+                      href='https://www.zooniverse.org/projects'
+                    />
+                  ]}
+                />
               </Text>
             </Box>
           ) : (
@@ -294,7 +301,7 @@ function MainContent({
               forwardedAs={Link}
               color='neutral-1'
               href={`/users/${source.login}/stats/certificate${window.location.search}`}
-              label='Generate Volunteer Certificate'
+              label={t('MainContent.certificate')}
             />
           </Box>
         ) : null}

--- a/packages/lib-user/src/components/shared/MainContent/MainContent.spec.js
+++ b/packages/lib-user/src/components/shared/MainContent/MainContent.spec.js
@@ -30,7 +30,7 @@ describe('components > shared > MainContent', function () {
 
   it('should show "CLASSIFICATIONS" as the active tab', function () {
     render(<DefaultStory />)
-    const activeTab = screen.getByRole('tab', { name: 'CLASSIFICATIONS', selected: true })
+    const activeTab = screen.getByRole('tab', { name: 'Classifications', selected: true })
 
     expect(activeTab).to.be.ok()
   })

--- a/packages/lib-user/src/components/shared/MainContent/components/StyledCalendarButton.js
+++ b/packages/lib-user/src/components/shared/MainContent/components/StyledCalendarButton.js
@@ -6,6 +6,7 @@ const StyledCertificateButton = styled(Button)`
   border-radius: 4px;
   color: ${props => props.theme.dark ? props.theme.global.colors['light-3'] : props.theme.global.colors['dark-5']};
   min-width: 100px;
+  text-transform: uppercase;
 `
 
 export default StyledCertificateButton

--- a/packages/lib-user/src/components/shared/MainContent/components/StyledTab.js
+++ b/packages/lib-user/src/components/shared/MainContent/components/StyledTab.js
@@ -7,6 +7,7 @@ const StyledTab = styled(Button)`
   color: ${props => props.theme.dark ? props.theme.global.colors['light-3'] : props.theme.global.colors['dark-5']};
   font-size: 1em;
   text-align: center;
+  text-transform: uppercase;
 
   ${props => props.active && css`
     border-bottom: 4px solid ${props.theme.global.colors['neutral-1']};

--- a/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.js
+++ b/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.js
@@ -9,50 +9,52 @@ function getNextMonth(month) {
   return month === 11 ? 0 : month + 1
 }
 
-function getPresetSelectOptions({ sourceCreatedAtDate, today }) {
+function getPresetSelectOptions({ sourceCreatedAtDate, today, t }) {
   return [
     {
-      label: 'LAST 7 DAYS',
+      label: t('MainContent.dateRange.lastSevenDays').toUpperCase(),
       value: getStatsDateString(new Date(new Date().setUTCDate(today.getUTCDate() - 6)))
     },
     {
-      label: 'LAST 30 DAYS',
+      label: t('MainContent.dateRange.lastThirtyDays').toUpperCase(),
       value: getStatsDateString(new Date(new Date().setUTCDate(today.getUTCDate() - 29)))
     },
     {
-      label: 'THIS MONTH',
+      label: t('MainContent.dateRange.thisMonth').toUpperCase(),
       value: getStatsDateString(new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1)))
     },
     {
-      label: 'LAST 3 MONTHS',
+      label: t('MainContent.dateRange.lastThreeMonths').toUpperCase(),
       value: getStatsDateString(new Date(new Date().setUTCDate(today.getUTCDate() - 90)))
     },
     {
-      label: 'THIS YEAR',
+      label: t('MainContent.dateRange.thisYear').toUpperCase(),
       value: getStatsDateString(new Date(Date.UTC(today.getUTCFullYear(), 0, 1)))
     },
     {
-      label: 'LAST 12 MONTHS',
+      label: t('MainContent.dateRange.lastTwelveMonths').toUpperCase(),
       value: getStatsDateString(new Date(Date.UTC((today.getUTCFullYear() - 1), getNextMonth(today.getUTCMonth()), 1)))
     },
     {
-      label: 'ALL TIME',
+      label: t('MainContent.dateRange.allTime').toUpperCase(),
       value: sourceCreatedAtDate
     }
   ]
 }
 
 const DEFAULT_DATE_RANGE = getDefaultDateRange()
+const DEFAULT_HANDLER = key => key
 
 export function getDateRangeSelectOptions({
   sourceCreatedAtDate = '',
   paramsValidationMessage = '',
-  selectedDateRange = DEFAULT_DATE_RANGE
+  selectedDateRange = DEFAULT_DATE_RANGE,
+  t = DEFAULT_HANDLER
 }) {
   const today = new Date()
   const todayUTC = getStatsDateString(today)
 
-  const dateRangeOptions = getPresetSelectOptions({ sourceCreatedAtDate, today })
+  const dateRangeOptions = getPresetSelectOptions({ sourceCreatedAtDate, today, t })
 
   let selectedDateRangeOption = dateRangeOptions.find(option =>
     (selectedDateRange.endDate === todayUTC) &&
@@ -68,7 +70,7 @@ export function getDateRangeSelectOptions({
     selectedDateRangeOption = customDateRangeOption
   } else {
     dateRangeOptions.push({
-      label: 'CUSTOM',
+      label: t('MainContent.dateRange.custom').toUpperCase(),
       value: 'custom'
     })
   }

--- a/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
+++ b/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
@@ -29,35 +29,35 @@ describe('components > MainContent > getDateRangeSelectOptions', function () {
       // the following expected values are based on the UTC date April 15, 11PM, **NOT** the user's date of April 16, 1AM
       expect(dateRangeOptions).to.deep.equal([
         {
-          label: 'LAST 7 DAYS',
+          label: 'MAINCONTENT.DATERANGE.LASTSEVENDAYS',
           value: '2023-04-09'
         },
         {
-          label: 'LAST 30 DAYS',
+          label: 'MAINCONTENT.DATERANGE.LASTTHIRTYDAYS',
           value: '2023-03-17'
         },
         {
-          label: 'THIS MONTH',
+          label: 'MAINCONTENT.DATERANGE.THISMONTH',
           value: '2023-04-01'
         },
         {
-          label: 'LAST 3 MONTHS',
+          label: 'MAINCONTENT.DATERANGE.LASTTHREEMONTHS',
           value: '2023-01-15'
         },
         {
-          label: 'THIS YEAR',
+          label: 'MAINCONTENT.DATERANGE.THISYEAR',
           value: '2023-01-01'
         },
         {
-          label: 'LAST 12 MONTHS',
+          label: 'MAINCONTENT.DATERANGE.LASTTWELVEMONTHS',
           value: '2022-05-01'
         },
         {
-          label: 'ALL TIME',
+          label: 'MAINCONTENT.DATERANGE.ALLTIME',
           value: '2015-07-01'
         },
-        { 
-          label: 'CUSTOM',
+        {
+          label: 'MAINCONTENT.DATERANGE.CUSTOM',
           value: 'custom'
         }
       ])
@@ -72,14 +72,14 @@ describe('components > MainContent > getDateRangeSelectOptions', function () {
         }
       })
       expect(selectedDateRangeOption).to.deep.equal({
-        label: 'LAST 7 DAYS',
+        label: 'MAINCONTENT.DATERANGE.LASTSEVENDAYS',
         value: '2023-04-09'
       })
     })
   })
 
   describe('when the user\'s date is the day before UTC', function () {
-      
+
     beforeEach(function () {
       // Set the user's clock April 14, 11PM, in a timezone 2 hours behind UTC,
       // so that the UTC date is April 15, 1AM
@@ -102,35 +102,35 @@ describe('components > MainContent > getDateRangeSelectOptions', function () {
       // the following expected values are based on the UTC date April 15, 1AM, **NOT** the user's date of April 14, 11PM
       expect(dateRangeOptions).to.deep.equal([
         {
-          label: 'LAST 7 DAYS',
+          label: 'MAINCONTENT.DATERANGE.LASTSEVENDAYS',
           value: '2023-04-09'
         },
         {
-          label: 'LAST 30 DAYS',
+          label: 'MAINCONTENT.DATERANGE.LASTTHIRTYDAYS',
           value: '2023-03-17'
         },
         {
-          label: 'THIS MONTH',
+          label: 'MAINCONTENT.DATERANGE.THISMONTH',
           value: '2023-04-01'
         },
         {
-          label: 'LAST 3 MONTHS',
+          label: 'MAINCONTENT.DATERANGE.LASTTHREEMONTHS',
           value: '2023-01-15'
         },
         {
-          label: 'THIS YEAR',
+          label: 'MAINCONTENT.DATERANGE.THISYEAR',
           value: '2023-01-01'
         },
         {
-          label: 'LAST 12 MONTHS',
+          label: 'MAINCONTENT.DATERANGE.LASTTWELVEMONTHS',
           value: '2022-05-01'
         },
         {
-          label: 'ALL TIME',
+          label: 'MAINCONTENT.DATERANGE.ALLTIME',
           value: '2015-07-01'
         },
-        { 
-          label: 'CUSTOM',
+        {
+          label: 'MAINCONTENT.DATERANGE.CUSTOM',
           value: 'custom'
         }
       ])
@@ -145,7 +145,7 @@ describe('components > MainContent > getDateRangeSelectOptions', function () {
         }
       })
       expect(selectedDateRangeOption).to.deep.equal({
-        label: 'LAST 7 DAYS',
+        label: 'MAINCONTENT.DATERANGE.LASTSEVENDAYS',
         value: '2023-04-09'
       })
     })
@@ -171,31 +171,31 @@ describe('components > MainContent > getDateRangeSelectOptions', function () {
       })
       expect(dateRangeOptions).to.deep.equal([
         {
-          label: 'LAST 7 DAYS',
+          label: 'MAINCONTENT.DATERANGE.LASTSEVENDAYS',
           value: '2023-04-09'
         },
         {
-          label: 'LAST 30 DAYS',
+          label: 'MAINCONTENT.DATERANGE.LASTTHIRTYDAYS',
           value: '2023-03-17'
         },
         {
-          label: 'THIS MONTH',
+          label: 'MAINCONTENT.DATERANGE.THISMONTH',
           value: '2023-04-01'
         },
         {
-          label: 'LAST 3 MONTHS',
+          label: 'MAINCONTENT.DATERANGE.LASTTHREEMONTHS',
           value: '2023-01-15'
         },
         {
-          label: 'THIS YEAR',
+          label: 'MAINCONTENT.DATERANGE.THISYEAR',
           value: '2023-01-01'
         },
         {
-          label: 'LAST 12 MONTHS',
+          label: 'MAINCONTENT.DATERANGE.LASTTWELVEMONTHS',
           value: '2022-05-01'
         },
         {
-          label: 'ALL TIME',
+          label: 'MAINCONTENT.DATERANGE.ALLTIME',
           value: '2015-11-01'
         },
         {
@@ -240,35 +240,35 @@ describe('components > MainContent > getDateRangeSelectOptions', function () {
       })
       expect(dateRangeOptions).to.deep.equal([
         {
-          label: 'LAST 7 DAYS',
+          label: 'MAINCONTENT.DATERANGE.LASTSEVENDAYS',
           value: '2023-04-09'
         },
         {
-          label: 'LAST 30 DAYS',
+          label: 'MAINCONTENT.DATERANGE.LASTTHIRTYDAYS',
           value: '2023-03-17'
         },
         {
-          label: 'THIS MONTH',
+          label: 'MAINCONTENT.DATERANGE.THISMONTH',
           value: '2023-04-01'
         },
         {
-          label: 'LAST 3 MONTHS',
+          label: 'MAINCONTENT.DATERANGE.LASTTHREEMONTHS',
           value: '2023-01-15'
         },
         {
-          label: 'THIS YEAR',
+          label: 'MAINCONTENT.DATERANGE.THISYEAR',
           value: '2023-01-01'
         },
         {
-          label: 'LAST 12 MONTHS',
+          label: 'MAINCONTENT.DATERANGE.LASTTWELVEMONTHS',
           value: '2022-05-01'
         },
         {
-          label: 'ALL TIME',
+          label: 'MAINCONTENT.DATERANGE.ALLTIME',
           value: '2020-04-15'
         },
-        { 
-          label: 'CUSTOM',
+        {
+          label: 'MAINCONTENT.DATERANGE.CUSTOM',
           value: 'custom'
         }
       ])

--- a/packages/lib-user/src/components/shared/MainContent/helpers/getProjectSelectOptions.js
+++ b/packages/lib-user/src/components/shared/MainContent/helpers/getProjectSelectOptions.js
@@ -1,6 +1,8 @@
-export function getProjectSelectOptions({ projects = [], selectedProject = undefined }) {
+const DEFAULT_HANDLER = key => key
+
+export function getProjectSelectOptions({ projects = [], selectedProject = undefined, t = DEFAULT_HANDLER }) {
   let projectOptions = [
-    { label: 'ALL PROJECTS', value: undefined },
+    { label: t('MainContent.allProjects').toUpperCase(), value: undefined },
     ...projects
       .map(project => ({
         label: project.display_name,

--- a/packages/lib-user/src/components/shared/ProfileHeader/ProfileHeader.js
+++ b/packages/lib-user/src/components/shared/ProfileHeader/ProfileHeader.js
@@ -2,6 +2,7 @@ import { SpacedText, ZooniverseLogo } from '@zooniverse/react-components'
 import { Box, ResponsiveContext } from 'grommet'
 import { number, string } from 'prop-types'
 import { useContext } from 'react'
+import { useTranslation } from '../../../translations/i18n.js'
 
 import {
   Avatar,
@@ -17,6 +18,7 @@ function ProfileHeader({
   login = '',
   projects = undefined
 }) {
+  const { t } = useTranslation()
   const size = useContext(ResponsiveContext)
 
   return (
@@ -65,25 +67,25 @@ function ProfileHeader({
       >
         {classifications !== undefined ?
           <TitledStat
-            title='Classifications'
+            title={t('common.classifications')}
             value={classifications}
           />
           : null}
         {hours !== undefined ?
           <TitledStat
-            title='Hours'
+            title={t('common.hours')}
             value={hours}
           />
           : null}
         {contributors !== undefined ?
           <TitledStat
-            title='Contributors'
+            title={t('common.contributors')}
             value={contributors}
           />
           : null}
         {projects !== undefined ?
           <TitledStat
-            title='Projects'
+            title={t('common.projects')}
             value={projects}
           />
           : null}

--- a/packages/lib-user/src/components/shared/Select/Select.js
+++ b/packages/lib-user/src/components/shared/Select/Select.js
@@ -1,11 +1,17 @@
 import { Select as GrommetSelect, ThemeContext } from 'grommet'
 import { arrayOf, func, shape, string } from 'prop-types'
 import { useEffect, useState } from 'react'
+import styled from 'styled-components'
 
 import selectTheme from './theme'
 
 const DEFAULT_HANDLER = () => {}
 const DEFAULT_VALUE = { label: '', value: '' }
+
+const StyledSelect = styled(GrommetSelect)`
+  text-align: center;
+  text-transform: uppercase;
+`
 
 function Select({
   id = '',
@@ -27,7 +33,7 @@ function Select({
 
   return (
     <ThemeContext.Extend value={selectTheme}>
-      <GrommetSelect
+      <StyledSelect
         a11yTitle={name}
         id={id}
         name={name}
@@ -35,7 +41,6 @@ function Select({
         onChange={({ option }) => handleSelect(option)}
         options={options}
         size='medium'
-        style={{ textAlign: 'center' }}
         value={selected}
       />
     </ThemeContext.Extend>

--- a/packages/lib-user/src/components/shared/TopProjects/TopProjects.js
+++ b/packages/lib-user/src/components/shared/TopProjects/TopProjects.js
@@ -3,6 +3,7 @@ import { arrayOf, bool, node, number, string, shape } from 'prop-types'
 import { useContext } from 'react'
 import styled from 'styled-components'
 import { Loader, ProjectCard } from '@zooniverse/react-components'
+import { useTranslation } from '../../../translations/i18n.js'
 
 import { ContentBox } from '@components/shared'
 
@@ -23,9 +24,10 @@ const StyledRowList = styled(Box)`
 `
 
 function CardsGrid({ children }) {
+  const { t } = useTranslation()
   return (
     <StyledGridList
-      a11yTitle='Top Projects'
+      a11yTitle={t('TopProjects.title')}
       columns={['1fr', '1fr', '1fr']}
       forwardedAs='ul'
       gap='xsmall'
@@ -43,9 +45,10 @@ CardsGrid.propTypes = {
 }
 
 function CardsRow({ children }) {
+  const { t } = useTranslation()
   return (
     <StyledRowList
-      a11yTitle='Top Projects'
+      a11yTitle={t('TopProjects.title')}
       direction='row'
       forwardedAs='ul'
       gap='small'
@@ -71,6 +74,7 @@ function TopProjects({
   loading = false,
   projects = []
 }) {
+  const { t } = useTranslation()
   const size = useContext(ResponsiveContext)
   const cardSize = grid ? 'small' : size
 
@@ -96,7 +100,7 @@ function TopProjects({
 
   return (
     <ContentBox
-      title='Top Projects'
+      title={t('TopProjects.title')}
     >
       {loading ? (
         <Box

--- a/packages/lib-user/src/translations/en.json
+++ b/packages/lib-user/src/translations/en.json
@@ -96,6 +96,9 @@
       "title": "Top Contributors"
     }
   },
+  "HeaderDropdown": {
+    "label": "Group Options"
+  },
   "MyGroups": {
     "createNew": "Create new group",
     "error": "There was an error fetching your groups",
@@ -109,6 +112,9 @@
     "PreviewLayout": {
       "seeAll": "See all"
     }
+  },
+  "TopProjects": {
+    "title": "Top Projects"
   },
   "UserHome": {
     "Dashboard": {

--- a/packages/lib-user/src/translations/en.json
+++ b/packages/lib-user/src/translations/en.json
@@ -99,6 +99,27 @@
   "HeaderDropdown": {
     "label": "Group Options"
   },
+  "MainContent": {
+    "allProjects": "All Projects",
+    "calendarTitle": "Custom Date Range",
+    "calendarBtn": "Done",
+    "certificate": "Generate Volunteer Certificate",
+    "dateRange": {
+      "allTime": "All Time",
+      "custom": "Custom",
+      "lastSevenDays": "Last 7 Days",
+      "lastThirtyDays": "Last 30 Days",
+      "lastThreeMonths": "Last 3 Months",
+      "lastTwelveMonths": "Last 12 Months",
+      "thisMonth": "This Month",
+      "thisYear": "This Year"
+    },
+    "error": "There was an error.",
+    "hoursTip": "Hours are calculated based on the start and end times of your classification efforts. Hours do not reflect your time spent on Talk.",
+    "noData": "No data found.",
+    "start": "Start by <0>classifying a project</0> now, or change the date range.",
+    "tabContents": "Tab Contents"
+  },
   "MyGroups": {
     "createNew": "Create new group",
     "error": "There was an error fetching your groups",


### PR DESCRIPTION
## Package
lib-user

## Linked Issue and/or Talk Post
Builds on top of https://github.com/zooniverse/front-end-monorepo/pull/6558

## Describe your changes
Setup react-i18next for HeaderDropdown, ProfileHeader, and TopProjects components

## How to Review
The expected text should display for the above components when lib-user is run locally, in Storybook, or as app-root pages.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).