### PR TITLE
refactor(app-project): optimistic updates for YourProjectStats

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -11,8 +11,7 @@ import { useAdminMode } from '@hooks'
 import addQueryParams from '@helpers/addQueryParams'
 import logToSentry from '@helpers/logger/logToSentry.js'
 import ErrorMessage from './components/ErrorMessage'
-import useYourProjectStats from '../YourProjectStats/useYourProjectStats.js'
-import incrementStats from '../YourProjectStats/helpers/incrementStats.js'
+import { updateYourStats } from '../YourProjectStats/useYourProjectStats.js'
 
 function onError(error, errorInfo = {}) {
   logToSentry(error, errorInfo)
@@ -61,18 +60,17 @@ export default function ClassifierWrapper({
     Add the recently classified subject to the signed-in user's Recents.
   */
   const projectID = project?.id
-  const { mutate } = useYourProjectStats({ projectID, userID })
 
   const addRecents = recents?.add
   const onCompleteClassification = useCallback((classification, subject) => {
     personalization.incrementSessionCount()
-    incrementStats(mutate, projectID, userID)
+    updateYourStats(projectID, userID)
     addRecents({
       favorite: subject.favorite,
       subjectId: subject.id,
       locations: subject.locations
     })
-  }, [addRecents, mutate, projectID, userID])
+  }, [addRecents, projectID, userID])
 
   /*
     If the page URL contains a subject ID, update that ID when the classification subject changes.


### PR DESCRIPTION
- [x] a new [module-scoped](https://developer.mozilla.org/en-US/docs/Glossary/Scope) bound function, [`mutate`](https://swr.vercel.app/docs/mutation), in the `useYourProjectStats` module. `mutate` is generated each time that stats data is fetched from ERAS, and bound to the current cache key. It can be used to update the fetched stats.
- [x] a new export from the `useYourProjectStats` module. `updateYourStats` runs an optimistic update of your stats for the current cache key, incrementing both counts when you press Done or Done & Talk, without revalidating the SWR cache.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## Linked Issue and/or Talk Post
- closes #6588.
- a description of the stuck counters on Daily Minor Planet: https://www.zooniverse.org/talk/17/3531984?comment=5819128

## How to Review
https://local.zooniverse.org:3000/projects/eatyourgreens/-project-testing-ground/classify/workflow/3599?env=staging

You should see your stats increment instantly after each classification, but the fetched stats aren't revalidated (there won't be any HTTP requests to `eras.zooniverse.org`.) This should decrease the load on the ERAS service when lots of classifications are coming into Panoptes. It should remove any errors in the counts when the ERAS API fails eg. the stuck counters that `mutabilitie` has reported on Talk.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

