### PR TITLE
Panoptes.js Experimental Auth: add signOut()

### DIFF
--- a/packages/lib-panoptes-js/dev/index.html
+++ b/packages/lib-panoptes-js/dev/index.html
@@ -24,6 +24,7 @@
     <section>
       <h2>Functions</h2>
       <button id="check-current-user-button">checkCurrentUser()</button>
+      <button id="sign-out-button">signOut()</button>
     </section>
     <form
       id="login-form"

--- a/packages/lib-panoptes-js/dev/index.js
+++ b/packages/lib-panoptes-js/dev/index.js
@@ -2,6 +2,7 @@ import {
   checkBearerToken,
   checkCurrentUser,
   signIn,
+  signOut,
   addEventListener,
 } from '@src/experimental-auth.js'
 
@@ -9,11 +10,13 @@ class App {
   constructor () {
     this.html = {
       checkCurrentUserButton: document.getElementById('check-current-user-button'),
+      signOutButton: document.getElementById('sign-out-button'),
       loginForm: document.getElementById('login-form'),
       message: document.getElementById('message'),
     }
 
     this.html.checkCurrentUserButton.addEventListener('click', this.checkCurrentUserButton_onClick.bind(this))
+    this.html.signOutButton.addEventListener('click', this.signOutButton_onClick.bind(this))
     this.html.loginForm.addEventListener('submit', this.loginForm_onSubmit.bind(this))
     addEventListener('change', this.onAuthChange)
   }
@@ -22,13 +25,28 @@ class App {
     try {
       const user = await checkCurrentUser()
       if (user) {
-        this.html.message.innerHTML += `> Current user: ${user.login}\n`
+        this.html.message.innerHTML += `> Current user: ${user.login} \n`
       } else {
         this.html.message.innerHTML += `> Current user: [nobody] \n`
       }
     } catch (err) {
       console.error(err)
-      this.html.message.innerHTML += `> [ERROR] ${err.toString()}\n`
+      this.html.message.innerHTML += `> [ERROR] ${err.toString()} \n`
+    }
+    return false
+  }
+
+  async signOutButton_onClick (e) {
+    try {
+      const success = await signOut()
+      if (success) {
+        this.html.message.innerHTML += `> Successfully signed out \n`
+      } else {
+        this.html.message.innerHTML += `> There's no user to sign out \n`
+      }
+    } catch (err) {
+      console.error(err)
+      this.html.message.innerHTML += `> [ERROR] ${err.toString()} \n`
     }
     return false
   }
@@ -41,13 +59,13 @@ class App {
       // Note: await is necessary to catch sign in errors.
       const user = await signIn(formData.get('login'), formData.get('password'))
       if (user) {
-        this.html.message.innerHTML += `> Logged in as ${user.login}\n`
+        this.html.message.innerHTML += `> Logged in as ${user.login} \n`
       } else {
         throw new Error('No user?')
       }
     } catch (err) {
       console.error(err)
-      this.html.message.innerHTML += `> [ERROR] ${err.toString()}\n`
+      this.html.message.innerHTML += `> [ERROR] ${err.toString()} \n`
     }
     return false
   }

--- a/packages/lib-panoptes-js/src/experimental-auth.js
+++ b/packages/lib-panoptes-js/src/experimental-auth.js
@@ -35,9 +35,9 @@ Notes:
   nothing happens.
  */
 function addEventListener (eventType, listener, _store) {
-  console.log('+++ experimental auth client: addEventListener()')
-
   const store = _store || globalStore
+  console.log('+++ experimental auth client: addEventListener()')
+  
   if (!eventType || !listener) {
     console.log('Panoptes.js auth.addEventListener(): requires event type (string) and listener (callback function).')
     return false
@@ -101,6 +101,8 @@ Output: n/a
  */
 function _broadcastEvent (eventType, args, _store) {
   const store = _store || globalStore
+  console.log('+++ experimental auth client: broadcastEvent()')
+
   store.eventListeners?.[eventType]?.forEach(listener => {
     listener(args)
   })
@@ -133,7 +135,7 @@ Possible Errors:
  */
 async function signIn (login, password, _store) {
   const store = _store || globalStore
-  console.log('+++ experimental auth client: signIn() ', login, password)
+  console.log('+++ experimental auth client: signIn()')
 
   // Here's how to sign in to Panoptes!
 
@@ -272,6 +274,14 @@ async function signIn (login, password, _store) {
 }
 
 /*
+Sign out from the Zooniverse.
+ */
+async function signOut(_store) {
+  const store = _store || globalStore
+  console.log('+++ experimental auth client: signOut()')
+}
+
+/*
 Check for current signed-in Zooniverse user.
 This function attempts to check if there's currently a signed-in user. First,
 it checks the store to see if there's any user data. If there isn't, then it
@@ -299,6 +309,7 @@ Possible Errors:
  */
 async function checkCurrentUser (_store) {
   const store = _store || globalStore
+  console.log('+++ experimental auth client: checkCurrentUser() ')
 
   // Step 1: do we already have a user in the store?
   if (store.userData) {
@@ -432,6 +443,7 @@ export {
   checkCurrent,
   checkCurrentUser,
   signIn,
+  signOut,
   addEventListener,
   removeEventListener,
 }


### PR DESCRIPTION
## PR Overview

Package: Package: lib-panoptes-js
Part of: replacing PJC with Panoptes JS
Follows and requires: #6552 

This PR continues the experiment to remove PJC from FEM. We now have the ability to Sign Out from the Zooniverse!

- Experimental Auth: added **signOut()**
  - signOut() will sign the user out of the Panoptes server, and reset the data store. Returns true on success.
  - ⚠️ Note one difference in the behaviour of the new signOut() vs old PJC signOut.
    - New: if a user isn't signed in, signOut() exits with return false.
    - Old: if a user isn't signed in, signOut() _throws an error._
    - I personally don't think attempting to sign out while not signed in is bad enough to throw an error, but I'm happy to discuss this. I may be missing actual use cases where thrown errors would be appropriate.
- Dev server: new "sign out" button added, to manually trigger the action.

### Status

Ready for **internal team review.**

Again, please note that the code is verbose on purpose.

For an overall overview of the auth, please see "Understanding Auth with Panoptes.js & PJC": https://docs.google.com/presentation/d/1KwqAjUcFa7QENV2N-qpDs7deILp_nIHl_K-ZBx8G9K4/edit (Zooniverse team only)