### PR TITLE
lib-classifier: Refactor CenteredLayout and survey task spacing

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -21,40 +21,35 @@ const Relative = styled(Box)`
 const ContainerBox = styled(Box)`
   display: flex;
   flex-direction: row;
-  gap: 1.25rem;
+  gap: 20px;
   justify-content: center;
 
   ${props => props.hasSurveyTask && css`
     @media screen and (min-width: 769px) and (max-width: 70rem) {
       flex-direction: column;
-      margin: 0;
     }
   `}
 
   // small screens
   @media screen and (max-width: 768px) {
     flex-direction: column;
-    margin: 0;
   }
 `
 
 const ViewBox = styled(Box)`
-  display: flex;
   flex-direction: row;
-  margin: 0;
+`
 
-  // small screens
-  @media screen and (max-width: 768px) {
-    margin: auto;
-  }
+const StyledImageToolbarContainer = styled.div`
+  min-width: 3rem;
+  width: 3rem;
 `
 
 const StickyTaskArea = styled(Box)`
-  flex: initial; // Don't stretch vertically
-  height: 100%;
-  min-width: ${props => props.hasSurveyTask ? '33.75rem' : 'auto'};
+  height: fit-content;
   position: sticky;
   top: 10px;
+  min-width: ${props => props.hasSurveyTask ? '33.75rem' : 'auto'};
   width: ${props => props.hasSurveyTask ? '33.75rem' : '25rem'};
 
   ${props => props.hasSurveyTask && css`
@@ -85,13 +80,9 @@ export default function CenteredLayout({
             <MetaTools />
           </StyledSubjectContainer>
           {!separateFramesView && (
-            <Box
-              width='3rem'
-              fill='vertical'
-              style={{ minWidth: '3rem' }}
-            >
+            <StyledImageToolbarContainer>
               <StyledImageToolbar />
-            </Box>
+            </StyledImageToolbarContainer>
           )}
         </ViewBox>
         <StickyTaskArea hasSurveyTask={hasSurveyTask}>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -47,22 +47,38 @@ const ContainerGrid = styled(Grid)`
 `
 
 export const ViewerGrid = styled(Grid)`
-  ${props => props.hasSurveyTask ? css`
-    @media screen and (min-width: 70rem) {
-      position: sticky;
-      top: 10px;
-    }
-  ` : css`
-    @media screen and (min-width: 769px) {
-      position: sticky;
-      top: 10px;
-    }
-  `}
-
+  ${props => props.hasSurveyTask
+    ? css`
+        @media screen and (min-width: 70rem) {
+          position: sticky;
+          top: 10px;
+        }
+      ` 
+    : css`
+        @media screen and (min-width: 769px) {
+          position: sticky;
+          top: 10px;
+        }
+      `}
+  height: fit-content;
   grid-area: viewer;
   grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
   grid-template-rows: auto;
   grid-template-areas: 'subject toolbar';
+`
+
+const StyledSubjectContainer = styled(Box)`
+  grid-area: subject;
+  position: sticky;
+`
+
+const StyledImageToolbarContainer = styled.div`
+  grid-area: toolbar;
+`
+
+const StyledImageToolbar = styled(ImageToolbar)`
+  position: sticky;
+  top: 10px;
 `
 
 const StyledTaskAreaContainer = styled.div`
@@ -81,15 +97,6 @@ const StyledTaskArea = styled(Box)`
       top: 10px;
     }
   `}
-`
-
-const StyledImageToolbarContainer = styled.div`
-  grid-area: toolbar;
-`
-
-const StyledImageToolbar = styled(ImageToolbar)`
-  position: sticky;
-  top: 10px;
 `
 
 export default function CenteredLayout({
@@ -113,11 +120,11 @@ export default function CenteredLayout({
           forwardedAs='section'
           hasSurveyTask={hasSurveyTask}
         >
-          <Box gridArea='subject'>
+          <StyledSubjectContainer>
             <Banners />
             <SubjectViewer />
             <MetaTools />
-          </Box>
+          </StyledSubjectContainer>
           <StyledImageToolbarContainer>
             <StyledImageToolbar />
           </StyledImageToolbarContainer>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -1,6 +1,5 @@
-import { useContext } from 'react'
 import styled, { css } from 'styled-components'
-import { Box, ResponsiveContext } from 'grommet'
+import { Box } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
 import FeedbackModal from '@components/Classifier/components/Feedback'
@@ -19,44 +18,48 @@ export const Relative = styled(Box)`
   position: relative; // Used for QuickTalk and FeedbackModal positioning
 `
 
-const StickyTaskArea = styled(Box)`
-  flex: initial; // Don't stretch vertically
-  ${props =>
-    props.size !== 'small' &&
-    css`
-      position: sticky;
-      top: 10px;
-    `}
+const ContainerBox = styled(Box)`
+  display: flex;
+  flex-direction: row;
+  gap: 1.25rem;
+  justify-content: center;
+
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+    margin: 0;
+  }
 `
 
-export const verticalLayout = {
-  direction: 'column',
-  gap: 'medium',
-  margin: 'none'
-}
+const ViewBox = styled(Box)`
+  display: flex;
+  flex-direction: row;
+  margin: 0;
 
-export const horizontalLayout = {
-  direction: 'row',
-  gap: 'small',
-  justify: 'center'
-}
+  @media screen and (max-width: 768px) {
+    margin: auto;
+  }
+`
+
+const StickyTaskArea = styled(Box)`
+  flex: initial; // Don't stretch vertically
+  width: 100%;
+  
+  @media screen and (min-width: 769px) {
+    height: 100%;
+    position: sticky;
+    top: 10px;
+    width: ${props => props.hasSurveyTask ? '33.75rem' : '25rem'};
+  }
+`
 
 export default function CenteredLayout({
   separateFramesView = false,
   hasSurveyTask = false
 }) {
-  const size = useContext(ResponsiveContext)
-  const containerProps = size === 'small' ? verticalLayout : horizontalLayout
-  const taskAreaWidth = hasSurveyTask ? '33.75rem' : '25rem'
-
   return (
     <Relative>
-      <Box {...containerProps}>
-        <Box
-          as='section'
-          direction='row'
-          margin={size === 'small' ? 'auto' : 'none'}
-        >
+      <ContainerBox>
+        <ViewBox forwardedAs='section'>
           <StyledSubjectContainer>
             <Banners />
             <SubjectViewer />
@@ -71,16 +74,14 @@ export default function CenteredLayout({
               <StyledImageToolbar />
             </Box>
           )}
-        </Box>
+        </ViewBox>
         <StickyTaskArea
-          width={size === 'small' ? '100%' : taskAreaWidth}
-          fill={size === 'small' ? 'horizontal' : 'vertical'}
-          size={size}
+          hasSurveyTask={hasSurveyTask}
         >
           <TaskArea />
           {separateFramesView && <FieldGuide />}
         </StickyTaskArea>
-      </Box>
+      </ContainerBox>
       <FeedbackModal />
       <QuickTalk />
     </Relative>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -3,12 +3,19 @@ import { Box, Grid } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
 import FeedbackModal from '@components/Classifier/components/Feedback'
-import ImageToolbar from '@components/Classifier/components/ImageToolbar'
 import MetaTools from '@components/Classifier/components/MetaTools'
 import QuickTalk from '@components/Classifier/components/QuickTalk'
 import SubjectViewer from '@components/Classifier/components/SubjectViewer'
 import TaskArea from '@components/Classifier/components/TaskArea'
 import FieldGuide from '@components/Classifier/components/FieldGuide'
+import {
+  ViewerGrid,
+  StyledSubjectContainer,
+  StyledImageToolbarContainer,
+  StyledImageToolbar,
+  StyledTaskAreaContainer,
+  StyledTaskArea
+} from '../shared/StyledContainers'
 
 const ContainerGrid = styled(Grid)`
   position: relative;
@@ -28,6 +35,7 @@ const ContainerGrid = styled(Grid)`
       margin: 0;
     }
   ` : css`
+    // proportional 9:5 subject/task sizing up to a maximum subject/task width of 45rem/25rem  
     @media screen and (min-width: 769px) and (max-width: 70rem) {
       grid-gap: 1.25rem;
       grid-template-areas: 'viewer task';
@@ -44,59 +52,6 @@ const ContainerGrid = styled(Grid)`
     grid-template-rows: auto auto;
     margin: 0;
   }
-`
-
-export const ViewerGrid = styled(Grid)`
-  ${props => props.hasSurveyTask
-    ? css`
-        @media screen and (min-width: 70rem) {
-          position: sticky;
-          top: 10px;
-        }
-      ` 
-    : css`
-        @media screen and (min-width: 769px) {
-          position: sticky;
-          top: 10px;
-        }
-      `}
-  height: fit-content;
-  grid-area: viewer;
-  grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
-  grid-template-rows: auto;
-  grid-template-areas: 'subject toolbar';
-`
-
-const StyledSubjectContainer = styled(Box)`
-  grid-area: subject;
-  position: sticky;
-`
-
-const StyledImageToolbarContainer = styled.div`
-  grid-area: toolbar;
-`
-
-const StyledImageToolbar = styled(ImageToolbar)`
-  position: sticky;
-  top: 10px;
-`
-
-const StyledTaskAreaContainer = styled.div`
-  grid-area: task;
-`
-
-const StyledTaskArea = styled(Box)`
-  ${props => props.hasSurveyTask ? css`
-    @media screen and (min-width: 70rem) {
-      position: sticky;
-      top: 10px;
-    }
-  ` : css`
-    @media screen and (min-width: 769px) {
-      position: sticky;
-      top: 10px;
-    }
-  `}
 `
 
 export default function CenteredLayout({

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -1,5 +1,6 @@
+import { useContext } from 'react'
 import styled, { css } from 'styled-components'
-import { Box, Grid } from 'grommet'
+import { Box, ResponsiveContext } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
 import FeedbackModal from '@components/Classifier/components/Feedback'
@@ -8,91 +9,80 @@ import QuickTalk from '@components/Classifier/components/QuickTalk'
 import SubjectViewer from '@components/Classifier/components/SubjectViewer'
 import TaskArea from '@components/Classifier/components/TaskArea'
 import FieldGuide from '@components/Classifier/components/FieldGuide'
+
 import {
-  ViewerGrid,
-  StyledSubjectContainer,
-  StyledImageToolbarContainer,
   StyledImageToolbar,
-  StyledTaskAreaContainer,
-  StyledTaskArea
+  StyledSubjectContainer
 } from '../shared/StyledContainers'
 
-const ContainerGrid = styled(Grid)`
-  position: relative;
-  grid-gap: 1.875rem;
-  grid-template-areas: 'viewer task';
-  grid-template-columns: auto ${props => (props.hasSurveyTask ? '33.75rem' : '25rem')};
-  justify-content: center;
-
-  ${props => props.hasSurveyTask ? css`
-    @media screen and (min-width: 769px) and (max-width: 70rem) {
-      grid-gap: 1.25rem;
-      grid-template-areas:
-        'viewer'
-        'task';
-      grid-template-columns: 100%;
-      grid-template-rows: auto auto;
-      margin: 0;
-    }
-  ` : css`
-    // proportional 9:5 subject/task sizing up to a maximum subject/task width of 45rem/25rem  
-    @media screen and (min-width: 769px) and (max-width: 70rem) {
-      grid-gap: 1.25rem;
-      grid-template-areas: 'viewer task';
-      grid-template-columns: 9fr 5fr;
-    }
-  `}
-
-  @media screen and (max-width: 768px) {
-    grid-gap: 1.25rem;
-    grid-template-areas:
-      'viewer'
-      'task';
-    grid-template-columns: 100%;
-    grid-template-rows: auto auto;
-    margin: 0;
-  }
+export const Relative = styled(Box)`
+  position: relative; // Used for QuickTalk and FeedbackModal positioning
 `
 
+const StickyTaskArea = styled(Box)`
+  flex: initial; // Don't stretch vertically
+  ${props =>
+    props.size !== 'small' &&
+    css`
+      position: sticky;
+      top: 10px;
+    `}
+`
+
+export const verticalLayout = {
+  direction: 'column',
+  gap: 'medium',
+  margin: 'none'
+}
+
+export const horizontalLayout = {
+  direction: 'row',
+  gap: 'small',
+  justify: 'center'
+}
+
 export default function CenteredLayout({
-  className = '',
   separateFramesView = false,
   hasSurveyTask = false
 }) {
+  const size = useContext(ResponsiveContext)
+  const containerProps = size === 'small' ? verticalLayout : horizontalLayout
+  const taskAreaWidth = hasSurveyTask ? '33.75rem' : '25rem'
+
   return (
-    <ContainerGrid
-      className={className}
-      hasSurveyTask={hasSurveyTask}
-    >
-      {separateFramesView ? (
-        <Box>
-          <Banners />
-          <SubjectViewer />
-          <MetaTools />
-        </Box>
-      ) : (
-        <ViewerGrid
-          forwardedAs='section'
-          hasSurveyTask={hasSurveyTask}
+    <Relative>
+      <Box {...containerProps}>
+        <Box
+          as='section'
+          direction='row'
+          margin={size === 'small' ? 'auto' : 'none'}
         >
           <StyledSubjectContainer>
             <Banners />
             <SubjectViewer />
             <MetaTools />
           </StyledSubjectContainer>
-          <StyledImageToolbarContainer>
-            <StyledImageToolbar />
-          </StyledImageToolbarContainer>
-        </ViewerGrid>
-      )}
-      <StyledTaskAreaContainer>
-        <StyledTaskArea hasSurveyTask={hasSurveyTask}>
+          {!separateFramesView && (
+            <Box
+              width='3rem'
+              fill='vertical'
+              style={{ minWidth: '3rem' }}
+            >
+              <StyledImageToolbar />
+            </Box>
+          )}
+        </Box>
+        <StickyTaskArea
+          width={size === 'small' ? '100%' : taskAreaWidth}
+          fill={size === 'small' ? 'horizontal' : 'vertical'}
+          size={size}
+        >
           <TaskArea />
           {separateFramesView && <FieldGuide />}
-        </StyledTaskArea>
-      </StyledTaskAreaContainer>
+        </StickyTaskArea>
+      </Box>
       <FeedbackModal />
       <QuickTalk />
-    </ContainerGrid>
+    </Relative>
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -74,7 +74,7 @@ export default function CenteredLayout({
     <Relative>
       <ContainerBox hasSurveyTask={hasSurveyTask}>
         <ViewBox forwardedAs='section'>
-          <StyledSubjectContainer>
+          <StyledSubjectContainer hasSurveyTask={hasSurveyTask}>
             <Banners />
             <SubjectViewer />
             <MetaTools />

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -1,6 +1,5 @@
-import { useContext } from 'react'
 import styled, { css } from 'styled-components'
-import { Box, ResponsiveContext } from 'grommet'
+import { Box, Grid } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
 import FeedbackModal from '@components/Classifier/components/Feedback'
@@ -11,84 +10,127 @@ import SubjectViewer from '@components/Classifier/components/SubjectViewer'
 import TaskArea from '@components/Classifier/components/TaskArea'
 import FieldGuide from '@components/Classifier/components/FieldGuide'
 
-export const Relative = styled(Box)`
-  position: relative; // Used for QuickTalk and FeedbackModal positioning
+const ContainerGrid = styled(Grid)`
+  position: relative;
+  grid-gap: 1.875rem;
+  grid-template-areas: 'viewer task';
+  grid-template-columns: auto ${props => (props.hasSurveyTask ? '33.75rem' : '25rem')};
+  justify-content: center;
+
+  ${props => props.hasSurveyTask ? css`
+    @media screen and (min-width: 769px) and (max-width: 70rem) {
+      grid-gap: 1.25rem;
+      grid-template-areas:
+        'viewer'
+        'task';
+      grid-template-columns: 100%;
+      grid-template-rows: auto auto;
+      margin: 0;
+    }
+  ` : css`
+    @media screen and (min-width: 769px) and (max-width: 70rem) {
+      grid-gap: 1.25rem;
+      grid-template-areas: 'viewer task';
+      grid-template-columns: 9fr 5fr;
+    }
+  `}
+
+  @media screen and (max-width: 768px) {
+    grid-gap: 1.25rem;
+    grid-template-areas:
+      'viewer'
+      'task';
+    grid-template-columns: 100%;
+    grid-template-rows: auto auto;
+    margin: 0;
+  }
 `
 
-const StickySubjectViewer = styled(Box)`
-  ${props =>
-    props.size !== 'small' &&
-    css`
+export const ViewerGrid = styled(Grid)`
+  ${props => props.hasSurveyTask ? css`
+    @media screen and (min-width: 70rem) {
       position: sticky;
       top: 10px;
-    `}
-`
-
-const StickyTaskArea = styled(Box)`
-  flex: initial; // Don't stretch vertically
-  ${props =>
-    props.size !== 'small' &&
-    css`
+    }
+  ` : css`
+    @media screen and (min-width: 769px) {
       position: sticky;
       top: 10px;
-    `}
+    }
+  `}
+
+  grid-area: viewer;
+  grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
+  grid-template-rows: auto;
+  grid-template-areas: 'subject toolbar';
 `
 
-const StickyImageToolbar = styled(ImageToolbar)`
+const StyledTaskAreaContainer = styled.div`
+  grid-area: task;
+`
+
+const StyledTaskArea = styled(Box)`
+  ${props => props.hasSurveyTask ? css`
+    @media screen and (min-width: 70rem) {
+      position: sticky;
+      top: 10px;
+    }
+  ` : css`
+    @media screen and (min-width: 769px) {
+      position: sticky;
+      top: 10px;
+    }
+  `}
+`
+
+const StyledImageToolbarContainer = styled.div`
+  grid-area: toolbar;
+`
+
+const StyledImageToolbar = styled(ImageToolbar)`
   position: sticky;
   top: 10px;
 `
 
-export const verticalLayout = {
-  direction: 'column',
-  gap: 'medium',
-  margin: 'none'
-}
-
-export const horizontalLayout = {
-  direction: 'row',
-  gap: 'small',
-  justify: 'center'
-}
-
 export default function CenteredLayout({
+  className = '',
   separateFramesView = false,
   hasSurveyTask = false
 }) {
-  const size = useContext(ResponsiveContext)
-  const containerProps = size === 'small' ? verticalLayout : horizontalLayout
-  const taskAreaWidth = hasSurveyTask ? '33.75rem' : '25rem'
-
   return (
-    <Relative>
-      <Box {...containerProps}>
-        <Box
-          as='section'
-          direction='row'
-          margin={size === 'small' ? 'auto' : 'none'}
+    <ContainerGrid
+      className={className}
+      hasSurveyTask={hasSurveyTask}
+    >
+      {separateFramesView ? (
+        <Box>
+          <Banners />
+          <SubjectViewer />
+          <MetaTools />
+        </Box>
+      ) : (
+        <ViewerGrid
+          forwardedAs='section'
+          hasSurveyTask={hasSurveyTask}
         >
-          <StickySubjectViewer size={size}>
+          <Box gridArea='subject'>
             <Banners />
             <SubjectViewer />
             <MetaTools />
-          </StickySubjectViewer>
-          {!separateFramesView && (
-            <Box width='3rem' fill='vertical' style={{ minWidth: '3rem' }}>
-              <StickyImageToolbar />
-            </Box>
-          )}
-        </Box>
-        <StickyTaskArea
-          width={size === 'small' ? '100%' : taskAreaWidth}
-          fill={size === 'small' ? 'horizontal' : 'vertical'}
-          size={size}
-        >
+          </Box>
+          <StyledImageToolbarContainer>
+            <StyledImageToolbar />
+          </StyledImageToolbarContainer>
+        </ViewerGrid>
+      )}
+      <StyledTaskAreaContainer>
+        <StyledTaskArea hasSurveyTask={hasSurveyTask}>
           <TaskArea />
           {separateFramesView && <FieldGuide />}
-        </StickyTaskArea>
-      </Box>
+        </StyledTaskArea>
+      </StyledTaskAreaContainer>
       <FeedbackModal />
       <QuickTalk />
-    </Relative>
+    </ContainerGrid>
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -14,7 +14,7 @@ import {
   StyledSubjectContainer
 } from '../shared/StyledContainers'
 
-export const Relative = styled(Box)`
+const Relative = styled(Box)`
   position: relative; // Used for QuickTalk and FeedbackModal positioning
 `
 
@@ -24,6 +24,14 @@ const ContainerBox = styled(Box)`
   gap: 1.25rem;
   justify-content: center;
 
+  ${props => props.hasSurveyTask && css`
+    @media screen and (min-width: 769px) and (max-width: 70rem) {
+      flex-direction: column;
+      margin: 0;
+    }
+  `}
+
+  // small screens
   @media screen and (max-width: 768px) {
     flex-direction: column;
     margin: 0;
@@ -35,6 +43,7 @@ const ViewBox = styled(Box)`
   flex-direction: row;
   margin: 0;
 
+  // small screens
   @media screen and (max-width: 768px) {
     margin: auto;
   }
@@ -42,13 +51,23 @@ const ViewBox = styled(Box)`
 
 const StickyTaskArea = styled(Box)`
   flex: initial; // Don't stretch vertically
-  width: 100%;
-  
-  @media screen and (min-width: 769px) {
-    height: 100%;
-    position: sticky;
-    top: 10px;
-    width: ${props => props.hasSurveyTask ? '33.75rem' : '25rem'};
+  height: 100%;
+  min-width: ${props => props.hasSurveyTask ? '33.75rem' : 'auto'};
+  position: sticky;
+  top: 10px;
+  width: ${props => props.hasSurveyTask ? '33.75rem' : '25rem'};
+
+  ${props => props.hasSurveyTask && css`
+    @media screen and (min-width: 769px) and (max-width: 70rem) {
+      position: static;
+      width: 100%;
+    }
+  `}
+
+  // small screens
+  @media screen and (max-width: 768px) {
+    position: static;
+    width: 100%;
   }
 `
 
@@ -58,7 +77,7 @@ export default function CenteredLayout({
 }) {
   return (
     <Relative>
-      <ContainerBox>
+      <ContainerBox hasSurveyTask={hasSurveyTask}>
         <ViewBox forwardedAs='section'>
           <StyledSubjectContainer>
             <Banners />
@@ -75,9 +94,7 @@ export default function CenteredLayout({
             </Box>
           )}
         </ViewBox>
-        <StickyTaskArea
-          hasSurveyTask={hasSurveyTask}
-        >
+        <StickyTaskArea hasSurveyTask={hasSurveyTask}>
           <TaskArea />
           {separateFramesView && <FieldGuide />}
         </StickyTaskArea>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
@@ -3,42 +3,45 @@ import { Box, Grid } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
 import FeedbackModal from '@components/Classifier/components/Feedback'
-import ImageToolbar from '@components/Classifier/components/ImageToolbar'
 import MetaTools from '@components/Classifier/components/MetaTools'
 import QuickTalk from '@components/Classifier/components/QuickTalk'
 import SubjectViewer from '@components/Classifier/components/SubjectViewer'
 import TaskArea from '@components/Classifier/components/TaskArea'
 import FieldGuide from '@components/Classifier/components/FieldGuide'
+import {
+  ViewerGrid,
+  StyledSubjectContainer,
+  StyledImageToolbarContainer,
+  StyledImageToolbar,
+  StyledTaskAreaContainer,
+  StyledTaskArea
+} from '../shared/StyledContainers'
 
 export const ContainerGrid = styled(Grid)`
   position: relative;
   grid-gap: 1.875rem;
   grid-template-areas: 'viewer task';
-  grid-template-columns: minmax(auto, 100rem) ${props =>
-      props.hasSurveyTask ? '33.75rem' : '25rem'};
+  grid-template-columns: minmax(auto, 100rem) ${props => props.hasSurveyTask ? '33.75rem' : '25rem'};
   margin: auto;
 
-  ${props =>
-    props.hasSurveyTask
-      ? css`
-          @media screen and (min-width: 769px) and (max-width: 70rem) {
-            grid-gap: 1.25rem;
-            grid-template-areas:
-              'viewer'
-              'task';
-            grid-template-columns: 100%;
-            grid-template-rows: auto auto;
-            margin: 0;
-          }
-        `
-      : css`
-          // proportional 9:5 subject/task sizing up to a maximum subject/task width of 45rem/25rem
-          @media screen and (min-width: 769px) and (max-width: 70rem) {
-            grid-gap: 1.25rem;
-            grid-template-areas: 'viewer task';
-            grid-template-columns: 9fr 5fr;
-          }
-        `}
+  ${props => props.hasSurveyTask ? css`
+    @media screen and (min-width: 769px) and (max-width: 70rem) {
+      grid-gap: 1.25rem;
+      grid-template-areas:
+        'viewer'
+        'task';
+      grid-template-columns: 100%;
+      grid-template-rows: auto auto;
+      margin: 0;
+    }
+  ` : css`
+    // proportional 9:5 subject/task sizing up to a maximum subject/task width of 45rem/25rem
+    @media screen and (min-width: 769px) and (max-width: 70rem) {
+      grid-gap: 1.25rem;
+      grid-template-areas: 'viewer task';
+      grid-template-columns: 9fr 5fr;
+    }
+  `}
 
   @media screen and (max-width: 768px) {
     grid-gap: 1.25rem;
@@ -49,63 +52,6 @@ export const ContainerGrid = styled(Grid)`
     grid-template-rows: auto auto;
     margin: 0;
   }
-`
-
-export const ViewerGrid = styled(Grid)`
-  ${props =>
-    props.hasSurveyTask
-      ? css`
-          @media screen and (min-width: 70rem) {
-            position: sticky;
-            top: 10px;
-          }
-        `
-      : css`
-          @media screen and (min-width: 769px) {
-            position: sticky;
-            top: 10px;
-          }
-        `}
-  height: fit-content;
-  grid-area: viewer;
-  grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
-  grid-template-rows: auto;
-  grid-template-areas: 'subject toolbar';
-`
-
-const StyledSubjectContainer = styled(Box)`
-  grid-area: subject;
-  position: sticky;
-`
-
-const StyledImageToolbarContainer = styled.div`
-  grid-area: toolbar;
-`
-
-const StyledImageToolbar = styled(ImageToolbar)`
-  position: sticky;
-  top: 10px;
-`
-
-const StyledTaskAreaContainer = styled.div`
-  grid-area: task;
-`
-
-const StyledTaskArea = styled(Box)`
-  ${props =>
-    props.hasSurveyTask
-      ? css`
-          @media screen and (min-width: 70rem) {
-            position: sticky;
-            top: 10px;
-          }
-        `
-      : css`
-          @media screen and (min-width: 769px) {
-            position: sticky;
-            top: 10px;
-          }
-        `}
 `
 
 export default function MaxWidth({

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
@@ -66,12 +66,25 @@ export const ViewerGrid = styled(Grid)`
             top: 10px;
           }
         `}
-
   height: fit-content;
   grid-area: viewer;
   grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
   grid-template-rows: auto;
   grid-template-areas: 'subject toolbar';
+`
+
+const StyledSubjectContainer = styled(Box)`
+  grid-area: subject;
+  position: sticky;
+`
+
+const StyledImageToolbarContainer = styled.div`
+  grid-area: toolbar;
+`
+
+const StyledImageToolbar = styled(ImageToolbar)`
+  position: sticky;
+  top: 10px;
 `
 
 const StyledTaskAreaContainer = styled.div`
@@ -95,15 +108,6 @@ const StyledTaskArea = styled(Box)`
         `}
 `
 
-const StyledImageToolbarContainer = styled.div`
-  grid-area: toolbar;
-`
-
-const StyledImageToolbar = styled(ImageToolbar)`
-  position: sticky;
-  top: 10px;
-`
-
 export default function MaxWidth({
   className = '',
   separateFramesView = false,
@@ -118,12 +122,15 @@ export default function MaxWidth({
           <MetaTools />
         </Box>
       ) : (
-        <ViewerGrid forwardedAs='section' hasSurveyTask={hasSurveyTask}>
-          <Box gridArea='subject'>
+        <ViewerGrid
+          forwardedAs='section'
+          hasSurveyTask={hasSurveyTask}
+        >
+          <StyledSubjectContainer>
             <Banners />
             <SubjectViewer />
             <MetaTools />
-          </Box>
+          </StyledSubjectContainer>
           <StyledImageToolbarContainer>
             <StyledImageToolbar />
           </StyledImageToolbarContainer>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
@@ -68,11 +68,8 @@ export default function MaxWidth({
           <MetaTools />
         </Box>
       ) : (
-        <ViewerGrid
-          forwardedAs='section'
-          hasSurveyTask={hasSurveyTask}
-        >
-          <StyledSubjectContainer>
+        <ViewerGrid forwardedAs='section'>
+          <StyledSubjectContainer hasSurveyTask={hasSurveyTask}>
             <Banners />
             <SubjectViewer />
             <MetaTools />

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.stories.js
@@ -80,7 +80,7 @@ taskEntries.forEach(([key, value]) => {
 const surveyWorkflowSnapshot = WorkflowFactory.build({
   configuration: {
     invert_subject: true,
-    limit_subject_height: true
+    limit_subject_height: false
   },
   first_task: 'T0',
   strings: surveyTaskStrings,

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
@@ -47,23 +47,38 @@ const ContainerGrid = styled(Grid)`
 `
 
 export const ViewerGrid = styled(Grid)`
-  ${props => props.hasSurveyTask ? css`
-    @media screen and (min-width: 70rem) {
-      position: sticky;
-      top: 10px;
-    }
-  ` : css`
-    @media screen and (min-width: 769px) {
-      position: sticky;
-      top: 10px;
-    }
-  `}
-
+  ${props => props.hasSurveyTask
+    ? css`
+        @media screen and (min-width: 70rem) {
+          position: sticky;
+          top: 10px;
+        }
+      `
+    : css`
+        @media screen and (min-width: 769px) {
+          position: sticky;
+          top: 10px;
+        }
+      `}
   height: fit-content;
   grid-area: viewer;
   grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
   grid-template-rows: auto;
   grid-template-areas: 'subject toolbar';
+`
+
+const StyledSubjectContainer = styled(Box)`
+  grid-area: subject;
+  position: sticky;
+`
+
+const StyledImageToolbarContainer = styled.div`
+  grid-area: toolbar;
+`
+
+const StyledImageToolbar = styled(ImageToolbar)`
+  position: sticky;
+  top: 10px;
 `
 
 const StyledTaskAreaContainer = styled.div`
@@ -82,15 +97,6 @@ const StyledTaskArea = styled(Box)`
       top: 10px;
     }
   `}
-`
-
-const StyledImageToolbarContainer = styled.div`
-  grid-area: toolbar;
-`
-
-const StyledImageToolbar = styled(ImageToolbar)`
-  position: sticky;
-  top: 10px;
 `
 
 export default function NoMaxWidth({
@@ -114,11 +120,11 @@ export default function NoMaxWidth({
           forwardedAs='section'
           hasSurveyTask={hasSurveyTask}
         >
-          <Box gridArea='subject'>
+          <StyledSubjectContainer>
             <Banners />
             <SubjectViewer />
             <MetaTools />
-          </Box>
+          </StyledSubjectContainer>
           <StyledImageToolbarContainer>
             <StyledImageToolbar />
           </StyledImageToolbarContainer>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
@@ -3,12 +3,19 @@ import { Box, Grid } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
 import FeedbackModal from '@components/Classifier/components/Feedback'
-import ImageToolbar from '@components/Classifier/components/ImageToolbar'
 import MetaTools from '@components/Classifier/components/MetaTools'
 import QuickTalk from '@components/Classifier/components/QuickTalk'
 import SubjectViewer from '@components/Classifier/components/SubjectViewer'
 import TaskArea from '@components/Classifier/components/TaskArea'
 import FieldGuide from '@components/Classifier/components/FieldGuide'
+import {
+  ViewerGrid,
+  StyledSubjectContainer,
+  StyledImageToolbarContainer,
+  StyledImageToolbar,
+  StyledTaskAreaContainer,
+  StyledTaskArea
+} from '../shared/StyledContainers'
 
 const ContainerGrid = styled(Grid)`
   position: relative;
@@ -44,59 +51,6 @@ const ContainerGrid = styled(Grid)`
     grid-template-rows: auto auto;
     margin: 0;
   }
-`
-
-export const ViewerGrid = styled(Grid)`
-  ${props => props.hasSurveyTask
-    ? css`
-        @media screen and (min-width: 70rem) {
-          position: sticky;
-          top: 10px;
-        }
-      `
-    : css`
-        @media screen and (min-width: 769px) {
-          position: sticky;
-          top: 10px;
-        }
-      `}
-  height: fit-content;
-  grid-area: viewer;
-  grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
-  grid-template-rows: auto;
-  grid-template-areas: 'subject toolbar';
-`
-
-const StyledSubjectContainer = styled(Box)`
-  grid-area: subject;
-  position: sticky;
-`
-
-const StyledImageToolbarContainer = styled.div`
-  grid-area: toolbar;
-`
-
-const StyledImageToolbar = styled(ImageToolbar)`
-  position: sticky;
-  top: 10px;
-`
-
-const StyledTaskAreaContainer = styled.div`
-  grid-area: task;
-`
-
-const StyledTaskArea = styled(Box)`
-  ${props => props.hasSurveyTask ? css`
-    @media screen and (min-width: 70rem) {
-      position: sticky;
-      top: 10px;
-    }
-  ` : css`
-    @media screen and (min-width: 769px) {
-      position: sticky;
-      top: 10px;
-    }
-  `}
 `
 
 export default function NoMaxWidth({

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
@@ -70,11 +70,8 @@ export default function NoMaxWidth({
           <MetaTools />
         </Box>
       ) : (
-        <ViewerGrid
-          forwardedAs='section'
-          hasSurveyTask={hasSurveyTask}
-        >
-          <StyledSubjectContainer>
+        <ViewerGrid forwardedAs='section'>
+          <StyledSubjectContainer hasSurveyTask={hasSurveyTask}>
             <Banners />
             <SubjectViewer />
             <MetaTools />

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
@@ -80,7 +80,7 @@ taskEntries.forEach(([key, value]) => {
 const surveyWorkflowSnapshot = WorkflowFactory.build({
   configuration: {
     invert_subject: true,
-    limit_subject_height: true
+    limit_subject_height: false
   },
   first_task: 'T0',
   strings: surveyTaskStrings,

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/shared/StyledContainers.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/shared/StyledContainers.js
@@ -3,20 +3,6 @@ import { Box, Grid } from 'grommet'
 import ImageToolbar from '@components/Classifier/components/ImageToolbar'
 
 export const ViewerGrid = styled(Grid)`
-  ${props => props.hasSurveyTask
-    ? css`
-        @media screen and (min-width: 70rem) {
-          position: sticky;
-          top: 10px;
-        }
-      `
-    : css`
-        @media screen and (min-width: 769px) {
-          position: sticky;
-          top: 10px;
-        }
-      `}
-  height: fit-content;
   grid-area: viewer;
   grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
   grid-template-rows: auto;
@@ -25,7 +11,21 @@ export const ViewerGrid = styled(Grid)`
 
 export const StyledSubjectContainer = styled(Box)`
   grid-area: subject;
-  position: sticky;
+  height: fit-content;
+
+  ${props => props.hasSurveyTask
+  ? css`
+      @media screen and (min-width: 70rem) {
+        position: sticky;
+        top: 10px;
+      }
+    `
+  : css`
+      @media screen and (min-width: 769px) {
+        position: sticky;
+        top: 10px;
+      }
+    `}
 `
 
 export const StyledImageToolbarContainer = styled.div`

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/shared/StyledContainers.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/shared/StyledContainers.js
@@ -1,0 +1,56 @@
+import styled, { css } from 'styled-components'
+import { Box, Grid } from 'grommet'
+import ImageToolbar from '@components/Classifier/components/ImageToolbar'
+
+export const ViewerGrid = styled(Grid)`
+  ${props => props.hasSurveyTask
+    ? css`
+        @media screen and (min-width: 70rem) {
+          position: sticky;
+          top: 10px;
+        }
+      `
+    : css`
+        @media screen and (min-width: 769px) {
+          position: sticky;
+          top: 10px;
+        }
+      `}
+  height: fit-content;
+  grid-area: viewer;
+  grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
+  grid-template-rows: auto;
+  grid-template-areas: 'subject toolbar';
+`
+
+export const StyledSubjectContainer = styled(Box)`
+  grid-area: subject;
+  position: sticky;
+`
+
+export const StyledImageToolbarContainer = styled.div`
+  grid-area: toolbar;
+`
+
+export const StyledImageToolbar = styled(ImageToolbar)`
+  position: sticky;
+  top: 10px;
+`
+
+export const StyledTaskAreaContainer = styled.div`
+  grid-area: task;
+`
+
+export const StyledTaskArea = styled(Box)`
+  ${props => props.hasSurveyTask ? css`
+    @media screen and (min-width: 70rem) {
+      position: sticky;
+      top: 10px;
+    }
+  ` : css`
+    @media screen and (min-width: 769px) {
+      position: sticky;
+      top: 10px;
+    }
+  `}
+`

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -63,8 +63,8 @@ function Chooser ({
     <Box
       as={task.instruction ? 'fieldset' : 'div'}
       alignSelf='center'
-      margin='none'
-      pad='none'
+      margin='0'
+      pad='0'
       style={{ border: 'none' }}
       width='100%'
     >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -63,8 +63,8 @@ function Chooser ({
     <Box
       as={task.instruction ? 'fieldset' : 'div'}
       alignSelf='center'
-      margin='0'
-      pad='0'
+      margin='none'
+      pad='none'
       style={{ border: 'none' }}
       width='100%'
     >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -63,6 +63,8 @@ function Chooser ({
     <Box
       as={task.instruction ? 'fieldset' : 'div'}
       alignSelf='center'
+      margin='0'
+      pad='0'
       style={{ border: 'none' }}
       width='100%'
     >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
@@ -18,8 +18,8 @@ const StyledGrid = styled.ul`
   gap: ${props => props.$hideThumbnails ? '1px' : '0'};
   grid-auto-flow: column;
   grid-template-columns: repeat(${props => props.$columnsCount}, ${props => {
-    if (props.$columnsCount === 3) return '166px';
-    if (props.$columnsCount === 2) return '250px';
+    if (props.$columnsCount === 3) return (props.$hideThumbnails ? '165.33px' : '166px');
+    if (props.$columnsCount === 2) return (props.$hideThumbnails ? '248.5px' : '249px');
     return '1fr';
   }});
   grid-template-rows: repeat(${props => props.$rowsCount}, ${props => props.$hideThumbnails ? '40px' : '60px'});

--- a/packages/lib-classifier/src/stories/components/MockTask/MockTask.js
+++ b/packages/lib-classifier/src/stories/components/MockTask/MockTask.js
@@ -151,7 +151,7 @@ export default function MockTask({
   }
 
   /** mimic task area per Layout and TaskArea components */
-  const taskAreaWidth = MockTask.store?.workflows?.active?.hasSurveyTask ? '540px' : '400px';
+  const taskAreaWidth = MockTask.store?.workflows?.active?.hasSurveyTask ? '538px' : '400px';
   
   return (
     <Provider classifierStore={MockTask.store}>


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- layout issue noted during review of #6494 

## Describe your changes
- fix MaxWidth with survey task and NoMaxWidth with survey task stories
- refactor MockTask component to reflect lib-react-components Tabs styling
- refactor Choices grid columns to reflect grid gap (if applicable)
- refactor Chooser spacing
- refactor CenteredLayout similar to MaxWidth and NoMaxWidth to handle small, medium, and large screen sizes, with different break points for survey task and other tasks

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - with layout issues:
    - ⚠️ live project - https://fe-project-branch.preview.zooniverse.org/projects/elwest/woodpecker-cavity-cam/classify/workflow/16997
  - with fix: 
    - ⚠️ live project - local app-project, https://local.zooniverse.org:3000/projects/elwest/woodpecker-cavity-cam/classify/workflow/16997?env=production
    - local lib-classifier, https://local.zooniverse.org:8080/?project=1634&workflow=2434
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
  - compare default and survey task stories at different screen sizes for all layouts, but notably: http://localhost:6006/?path=/story/layouts-centered--with-survey-task
  - http://localhost:6006/?path=/story/tasks-survey--default
  - http://localhost:6006/?path=/story/tasks-survey-chooser-choices--less-thirty-more-twenty
  - http://localhost:6006/?path=/story/tasks-survey-chooser-choices--hide-thumbnails
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected