### PR TITLE
Adjust timeout of GroupForm's unit test

### DIFF
--- a/packages/lib-user/package.json
+++ b/packages/lib-user/package.json
@@ -39,7 +39,7 @@
     "panoptes-client": "~5.6.0",
     "react-i18next": "~14.1.3",
     "swr": "~2.2.4",
-    "uuid": "~11.0.3"
+    "uuid": "~11.0.4"
   },
   "peerDependencies": {
     "@zooniverse/grommet-theme": "3.x.x",

--- a/packages/lib-user/src/components/shared/GroupForm/GroupForm.spec.js
+++ b/packages/lib-user/src/components/shared/GroupForm/GroupForm.spec.js
@@ -9,109 +9,112 @@ describe('components > shared > GroupForm', function() {
 
     const user = userEvent.setup()
     const CreateStory = composeStory(Create, Meta)
-  
+
     it('should collect group display name', function() {
       render(<CreateStory />)
-  
+
       const displayName = screen.getByRole('textbox', { name: 'Group Name' })
       expect(displayName).to.be.ok()
     })
-  
+
     it('should have radio buttons for public or private visibility', function() {
       render(<CreateStory />)
-  
+
       const privateRadio = screen.getByRole('radio', { name: 'Private - only members can view this group' })
       const publicRadio = screen.getByRole('radio', { name: 'Public - you can share this group with anyone' })
       expect(privateRadio).to.be.ok()
       expect(publicRadio).to.be.ok()
     })
-  
+
     it('should default to private visibility', function() {
       render(<CreateStory />)
-  
+
       const privateRadio = screen.getByRole('radio', { name: 'Private - only members can view this group' })
       expect(privateRadio.checked).to.be.true()
     })
-  
+
     it('should have a select for stats visibility', function() {
       render(<CreateStory />)
-  
+
       // the Grommet Select component renders as a button with a textbox. The statsVisibility input uses the Grommet Select, therefore we need to find the textbox role. The textbox name includes the value of the select, which by default is 'private_agg_only'.
       const statsVisibility = screen.getByRole('textbox', { name: 'Stats Visibility, private_agg_only' })
       expect(statsVisibility).to.be.ok()
     })
-  
+
     describe('with private visibility', function() {
       it('should show private stats visibility options', async function() {
         render(<CreateStory />)
-  
+
         // by default, the visibility is private
         const privateRadio = screen.getByRole('radio', { name: 'Private - only members can view this group' })
         expect(privateRadio.checked).to.be.true()
-  
+
         const statsVisibility = screen.getByRole('textbox', { name: 'Stats Visibility, private_agg_only' })
         await user.click(statsVisibility)
-  
+
         const options = screen.getAllByRole('option')
-        
+
         // the private visibility options are 'private_agg_only' and 'private_show_agg_and_ind'
         expect(options.length).to.equal(2)
       })
     })
-  
+
     describe('with public visibility', function() {
       it('should show public stats visibility options', async function() {
         render(<CreateStory />)
-  
+
         const publicRadio = screen.getByRole('radio', { name: 'Public - you can share this group with anyone' })
         await user.click(publicRadio)
         expect(publicRadio.checked).to.be.true()
-  
+
         const statsVisibility = screen.getByRole('textbox', { name: 'Stats Visibility, public_agg_only' })
         await user.click(statsVisibility)
-  
+
         const options = screen.getAllByRole('option')
-        
+
         // the public visibility options are 'public_agg_only', 'public_show_agg_and_ind', and 'public_show_all'
         expect(options.length).to.equal(3)
       })
     })
-  
+
     describe('without a display name', function() {
       it('should show display name is required', async function() {
         render(<CreateStory />)
-  
+
         const submit = screen.getByRole('button', { name: 'Create new group' })
         await user.click(submit)
-  
+
         const error = screen.getByText('required')
         expect(error).to.be.ok()
       })
     })
-  
+
     describe('with an invalid display name, below minimum characters', function() {
       it('should show display name is invalid', async function() {
         render(<CreateStory />)
-  
+
         const displayName = screen.getByRole('textbox', { name: 'Group Name' })
         await user.type(displayName, 'abc')
         const submit = screen.getByRole('button', { name: 'Create new group' })
         await user.click(submit)
-  
+
         const error = screen.getByText('must be > 3 characters')
         expect(error).to.be.ok()
       })
     })
 
     describe('with an invalid display name, above maximum characters', function() {
+      // this turns off Mocha's time limit for slow tests
+      this.timeout(0)
+
       it('should show display name is invalid', async function() {
         render(<CreateStory />)
-  
+
         const displayName = screen.getByRole('textbox', { name: 'Group Name' })
         await user.type(displayName, 'a'.repeat(61))
         const submit = screen.getByRole('button', { name: 'Create new group' })
         await user.click(submit)
-  
+
         const error = screen.getByText('must be < 60 characters')
         expect(error).to.be.ok()
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -18235,10 +18235,10 @@ uuid@^9.0.0, uuid@^9.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
-uuid@~11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.3.tgz#248451cac9d1a4a4128033e765d137e2b2c49a3d"
-  integrity sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==
+uuid@~11.0.4:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.5.tgz#07b46bdfa6310c92c3fb3953a8720f170427fc62"
+  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
 
 valid-url@~1.0.9:
   version "1.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18236,9 +18236,9 @@ uuid@^9.0.0, uuid@^9.0.1:
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 uuid@~11.0.3:
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.4.tgz#37943977894ef806d2919a7ca3f89d6e23c60bac"
-  integrity sha512-IzL6VtTTYcAhA/oghbFJ1Dkmqev+FpQWnCBaKq/gUluLxliWvO8DPFWfIviRmYbtaavtSQe4WBL++rFjdcGWEg==
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.3.tgz#248451cac9d1a4a4128033e765d137e2b2c49a3d"
+  integrity sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==
 
 valid-url@~1.0.9:
   version "1.0.9"


### PR DESCRIPTION
~~There's a lib-user unit test for GroupForm fails regularly with a timeout in Github Actions. I think that behavior originated from this dependency bump, so this PR is for testing.~~

It must of just been a coincidence that `uuid` is used in lib-user and that's when the GroupFrom test started timing out. Adding `this.timeout(0)` in the unit test solved it instead. We use this technique a few other places in FEM.