### PR TITLE
lib-classifier: Refactor survey task CharacteristicValue image type

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
@@ -5,7 +5,7 @@ import SurveyAnnotation from './SurveyAnnotation'
 
 const CharacteristicValue = types.model('CharacteristicValue', {
   label: types.string,
-  image: types.string
+  image: types.maybe(types.string)
 })
 
 const Characteristic = types.model('Characteristic', {


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- noted in point 2 of this comment - https://github.com/zooniverse/front-end-monorepo/pull/6615#issuecomment-2603016534
- the Spyfish Aotearoa survey task characteristic values (filters) include some with images and some without
- when the workflow step store validated the (survey) task, the missing image values cause an error in staging or in dev mode that prevent the classifier from loading, but not in production 

## Describe your changes
- add `types.maybe` to CharacteristicValue model, image property

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - lib-classifier: https://local.zooniverse.org:8080/?project=14054&workflow=23920&env=production
  - app-project:  https://local.zooniverse.org:3000/projects/victorav/spyfish-aotearoa/classify/workflow/23920?env=production
- What user actions should my reviewer step through to review this PR? note survey task successfully loads 
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? n/a

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated