### PR TITLE
Fix sticky css rules in CenteredLayout components

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -21,40 +21,35 @@ const Relative = styled(Box)`
 const ContainerBox = styled(Box)`
   display: flex;
   flex-direction: row;
-  gap: 1.25rem;
+  gap: 20px;
   justify-content: center;
 
   ${props => props.hasSurveyTask && css`
     @media screen and (min-width: 769px) and (max-width: 70rem) {
       flex-direction: column;
-      margin: 0;
     }
   `}
 
   // small screens
   @media screen and (max-width: 768px) {
     flex-direction: column;
-    margin: 0;
   }
 `
 
 const ViewBox = styled(Box)`
-  display: flex;
   flex-direction: row;
-  margin: 0;
+`
 
-  // small screens
-  @media screen and (max-width: 768px) {
-    margin: auto;
-  }
+const StyledImageToolbarContainer = styled.div`
+  min-width: 3rem;
+  width: 3rem;
 `
 
 const StickyTaskArea = styled(Box)`
-  flex: initial; // Don't stretch vertically
-  height: 100%;
-  min-width: ${props => props.hasSurveyTask ? '33.75rem' : 'auto'};
+  height: fit-content;
   position: sticky;
   top: 10px;
+  min-width: ${props => props.hasSurveyTask ? '33.75rem' : 'auto'};
   width: ${props => props.hasSurveyTask ? '33.75rem' : '25rem'};
 
   ${props => props.hasSurveyTask && css`
@@ -85,13 +80,9 @@ export default function CenteredLayout({
             <MetaTools />
           </StyledSubjectContainer>
           {!separateFramesView && (
-            <Box
-              width='3rem'
-              fill='vertical'
-              style={{ minWidth: '3rem' }}
-            >
+            <StyledImageToolbarContainer>
               <StyledImageToolbar />
-            </Box>
+            </StyledImageToolbarContainer>
           )}
         </ViewBox>
         <StickyTaskArea hasSurveyTask={hasSurveyTask}>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/shared/StyledContainers.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/shared/StyledContainers.js
@@ -3,20 +3,6 @@ import { Box, Grid } from 'grommet'
 import ImageToolbar from '@components/Classifier/components/ImageToolbar'
 
 export const ViewerGrid = styled(Grid)`
-  ${props => props.hasSurveyTask
-    ? css`
-        @media screen and (min-width: 70rem) {
-          position: sticky;
-          top: 10px;
-        }
-      `
-    : css`
-        @media screen and (min-width: 769px) {
-          position: sticky;
-          top: 10px;
-        }
-      `}
-  height: fit-content;
   grid-area: viewer;
   grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
   grid-template-rows: auto;
@@ -25,7 +11,21 @@ export const ViewerGrid = styled(Grid)`
 
 export const StyledSubjectContainer = styled(Box)`
   grid-area: subject;
-  position: sticky;
+  height: fit-content;
+
+  ${props => props.hasSurveyTask
+  ? css`
+      @media screen and (min-width: 70rem) {
+        position: sticky;
+        top: 10px;
+      }
+    `
+  : css`
+      @media screen and (min-width: 769px) {
+        position: sticky;
+        top: 10px;
+      }
+    `}
 `
 
 export const StyledImageToolbarContainer = styled.div`


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Minor changes and based on top of https://github.com/zooniverse/front-end-monorepo/pull/6615

## Describe your changes
- Remove nested sticky-positioned elements in the shared StyledContainers.js file.
- Ensure sticky behavior for subject viewer, image toolbar, and the task area for CenteredLayout projets.

## How to Review

I tested the following projects at length by using Chrome on a desktop, but if there's any screen size you'd like to double check, run app-project locally:
- CenteredLayout non-survey task project: [Daily Minor Planet](https://local.zooniverse.org:3000/projects/fulsdavid/the-daily-minor-planet/classify/workflow/22354?env=production)
- CenteredLayout survey task project: [Woodpecker Cavity Cam](https://local.zooniverse.org:3000/projects/elwest/woodpecker-cavity-cam/classify/workflow/16998?env=production)
- MaxWidth survey task project: [Survey Task Test Project](https://local.zooniverse.org:3000/projects/markb-panoptes/survey-task-test-project/classify/workflow/3765?env=staging)
- MaxWidth non-survey task project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats/classify/workflow/693?env=staging)
- NoMaxWidth transcription project: [Transcription Task Testing](https://local.zooniverse.org:3000/projects/blicksam/transcription-task-testing/classify/workflow/13898?env=production)

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected