### PR TITLE
Add bluesky icon to ZooFooter

### DIFF
--- a/packages/lib-react-components/src/ZooFooter/ZooFooter.js
+++ b/packages/lib-react-components/src/ZooFooter/ZooFooter.js
@@ -159,6 +159,7 @@ export default function ZooFooter({
           >
             <SocialAnchor service='facebook' />
             <SocialAnchor service='twitter' />
+            <SocialAnchor service='bluesky' />
             <SocialAnchor service='instagram' />
           </Box>
         </Box>

--- a/packages/lib-react-components/src/ZooFooter/components/SocialAnchor/SocialAnchor.js
+++ b/packages/lib-react-components/src/ZooFooter/components/SocialAnchor/SocialAnchor.js
@@ -1,5 +1,5 @@
 import { Anchor } from 'grommet'
-import { FacebookOption, Instagram, X } from 'grommet-icons'
+import { Blank, FacebookOption, Instagram, X } from 'grommet-icons'
 import { objectOf, string } from 'prop-types'
 import styled from 'styled-components'
 
@@ -7,19 +7,38 @@ const StyledAnchor = styled(Anchor)`
   padding: 0;
 `
 
+// Can replace with grommet-icon once that library includes Bluesky
+function BlueSkyIcon(props) {
+  return (
+    <Blank
+      viewBox='0 0 600 530'
+      width='100'
+      height='88'
+      aria-label='BlueSky'
+      {...props}
+    >
+      <path
+        d='m135.7 44c66.5 50 138 151.2 164.3 205.5 26.3-54.3 97.8-155.5 164.3-205.5 48-36 125.7-63.9 125.7 24.8 0 17.7-10.2 148.8-16.1 170.1-20.7 74-96.2 92.8-163.3 81.4 117.3 20 147.2 86.1 82.7 152.2-122.4 125.6-175.9-31.5-189.6-71.7-2.5-7.4-3.7-10.8-3.7-7.9 0-3-1.2 0.5-3.7 7.9-13.7 40.2-67.2 197.3-189.6 71.7-64.5-66.1-34.6-132.2 82.7-152.2-67.2 11.4-142.6-7.4-163.3-81.4-5.9-21.3-16.1-152.4-16.1-170.1 0-88.7 77.7-60.8 125.7-24.8z'
+      />
+    </Blank>
+  )
+}
+
 const defaultHrefs = {
+  bluesky: 'https://bsky.app/profile/zooniverse.bsky.social',
   facebook: 'https://www.facebook.com/therealzooniverse',
   instagram: 'https://www.instagram.com/the.zooniverse/',
   twitter: 'https://x.com/the_zooniverse',
 }
 
-function SocialAnchor ({ className = '', hrefs = defaultHrefs, service }) {
-  const icons = {
-    facebook: <FacebookOption size='25px' />,
-    instagram: <Instagram size='25px' />,
-    twitter: <X size='25px' />
-  }
+const icons = {
+  bluesky: <BlueSkyIcon size='25px' />,
+  facebook: <FacebookOption size='25px' />,
+  instagram: <Instagram size='25px' />,
+  twitter: <X size='25px' />
+}
 
+function SocialAnchor ({ className = '', hrefs = defaultHrefs, service }) {
   return (
       <StyledAnchor
         a11yTitle={service}


### PR DESCRIPTION
## Package
lib-react-components

## Linked Issue and/or Talk Post
Slack: https://zooniverse.slack.com/archives/C4RJRAGKA/p1738087706161429?thread_ts=1737988588.679469&cid=C4RJRAGKA
Corresponds to: https://github.com/zooniverse/Panoptes-Front-End/pull/7254

## Describe your changes
- Add a SocialAnchor for bluesky to ZooFooter

## How to Review
- Run lib-react-components locally and see the new icon in ZooFooter.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser