### PR TITLE
SelectCollection: make collectionNameFilter() and collectionLabel() more robust

### DIFF
--- a/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -47,6 +47,21 @@ function SelectCollection ({
     return displayNameLowerCase.includes(searchText.toLowerCase())
   }
 
+  /*
+  Determines the display label for the specific collection.
+  Returns "Example Collection" if that collection belongs to the current user,
+  otherwise returns "Example Collection (Another User's Name)"
+
+  NOTE: sometime between Grommet > 2.41.0 and <= 2.45.1, the behaviour of
+  <Select> changed. Now, when <Select> initially renders and _nothing_ is
+  selected, labelKey is called with an empty object {} argument. Prior to this
+  change, collectionLabel() was only called when there's a valid collection
+  object to render. (e.g. when clicking on Select to display list of options.)
+  
+  As a result, collectionLabel() now handles "no selection" (collection === {})
+  without crashing, returning a meaningless "undefined (undefined)". The
+  <Select> still shows blank ("") when there's no selection, though. Go figure.
+   */
   function collectionLabel(collection) {
     if (collection?.links?.owner?.id === userID) {
       return collection?.display_name

--- a/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -42,15 +42,16 @@ function SelectCollection ({
   }
 
   function collectionNameFilter(collection) {
-    const displayNameLowerCase = collection.display_name.toLowerCase()
+    const displayNameLowerCase = collection?.display_name?.toLowerCase()
+    if (!displayNameLowerCase) return false
     return displayNameLowerCase.includes(searchText.toLowerCase())
   }
 
   function collectionLabel(collection) {
-    if (collection.links.owner.id === userID) {
-      return collection.display_name
+    if (collection?.links?.owner?.id === userID) {
+      return collection?.display_name
     }
-    return `${collection.display_name} (${collection.links.owner.display_name})`
+    return `${collection?.display_name} (${collection?.links?.owner?.display_name})`
   }
 
   /*


### PR DESCRIPTION
## PR Overview

Package: `app-project`
Affects: `<SelectCollection />`

This PR updates the SelectCollection component's collectionNameFilter() and collectionLabel() functions to be more robust, with respect to unexpected data.

### Dev Notes

This issue was brought in Dependabot PR #6667 , where a seemingly innocent bump from Grommet 2.41.0 to 2.45.1 caused the `CollectionModal` components to suddenly fail. The issue can be traced to SelectCollection's collectionLabel() not receiving its 'collection' data in a proper format - the function's a bit brittle in that sense.

⚠️ HOWEVER, I'm not sure why Grommet 2.45.1 (or its predecessors) suddenly caused the tests to fail. Something's changing the parameters of how `<SelectCollection>` is rendered... or something. I'm going to run some manual Storybook before/after comparisons to make sure nothing's too broken.

### Testing

Automated tests should pass. Uh, there's no manual test for this, really.

### Status

Ready for review.

Low priority 😴 since no new functionality is added, but I'll sound an alarm if it turns out that grommet bump is way more borked than we expect.

Once this is merged, Dependabot PR #6667 (or whatever new version replaces it) should be re-reviewed.