### PR TITLE
Adjust drawing Mark stroke widths

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -4,8 +4,8 @@ import { forwardRef, useEffect, useRef } from 'react';
 import styled, { css, useTheme } from 'styled-components'
 import draggable from '../draggable'
 
-const STROKE_WIDTH = 3
-const SELECTED_STROKE_WIDTH = 6
+const STROKE_WIDTH = 2
+const SELECTED_STROKE_WIDTH = 4
 
 const StyledGroup = styled.g`
   stroke-width: ${STROKE_WIDTH}px;


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- iteration on #6066 

## Describe your changes
- adjusts Mark stroke width to 2px and selected stroke width to 4px
- this impacts circle, ellipse, line, rectangle, point, and polygon, NOT freehand line or transcription line

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected