### PR TITLE
VV Mark Creation has max number of points per click/action

### DIFF
--- a/packages/lib-subject-viewers/src/VolumetricViewer/helpers/AlgorithmAStar.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/helpers/AlgorithmAStar.js
@@ -5,6 +5,7 @@ export const AlgorithmAStar = ({
   point: pointOriginal,
   viewer
 }) => {
+  let pointsMax = 1000;
   const pointValueStart = viewer.getPointValue({ point: pointOriginal })
   const traversedPoints = []
   const connectedPoints = SortedSet({ data: [pointOriginal] })
@@ -50,7 +51,8 @@ export const AlgorithmAStar = ({
     }
   }
 
-  while (pointsToCheck.length > 0) {
+  while (pointsToCheck.length > 0 && pointsMax > 0) {
+    --pointsMax; // prevents creating accidental marks that are extremely large
     checkConnectedPoints()
   }
 


### PR DESCRIPTION
## Package
- lib-subject-viewers

## Linked Issue and/or Talk Post

## Describe your changes
Add a max limit to how many points are checked to connect to prevent extremely large marks from being created

## How to Review
- All tests should pass
- Load up the `lib-subject-viewers` storybook, choose the 64x64x64 cube, and click on a neutral grey spot. Notice how it doesn't highlight a significant chunk of the whole cube but rather makes a nice-sized mark instead.

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser