### PR TITLE
refactor(drawing-tools): drag handle sizing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,3 +32,4 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: false

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
@@ -2,6 +2,7 @@ import { forwardRef } from 'react';
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import draggable from '../draggable'
+import { STROKE_WIDTH } from '../Mark/Mark';
 
 const StyledCircle = styled('circle')`
   stroke-width: 2;
@@ -9,19 +10,18 @@ const StyledCircle = styled('circle')`
     cursor: move;
   }
 `
-const RADIUS = screen.width > 900 ? 4 : 10
+const RADIUS = screen.width > 900 ? 3 * STROKE_WIDTH : 5 * STROKE_WIDTH
 
 const DragHandle = forwardRef(function DragHandle(
   {
-    fill,
-    radius,
-    scale,
+    fill = 'currentColor',
+    radius = RADIUS,
+    scale = 1,
     x,
     y,
     dragging = false,
     invisibleWhenDragging = false,
     testid,
-    ...props
   },
   ref
 ) {
@@ -33,9 +33,9 @@ const DragHandle = forwardRef(function DragHandle(
   }
 
   return (
-    <g ref={ref} transform={transform} data-testid={testid} {...props} >
-      <StyledCircle r={radius} {...styleProps} vectorEffect={'non-scaling-stroke'} />
-      <StyledCircle r={2 * radius} fill='transparent' stroke='transparent' vectorEffect={'non-scaling-stroke'} />
+    <g ref={ref} transform={transform} data-testid={testid} >
+      <StyledCircle r={radius} {...styleProps} vectorEffect={'non-scaling-size'} />
+      <StyledCircle r={2 * radius} fill='transparent' stroke='transparent' vectorEffect={'non-scaling-size'} />
     </g>
   )
 })
@@ -46,12 +46,6 @@ DragHandle.propTypes = {
   scale: PropTypes.number,
   x: PropTypes.number.isRequired,
   y: PropTypes.number.isRequired
-}
-
-DragHandle.defaultProps = {
-  fill: 'currentColor',
-  radius: RADIUS,
-  scale: 1
 }
 
 export default draggable(DragHandle)

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -4,8 +4,8 @@ import { forwardRef, useEffect, useRef } from 'react';
 import styled, { css, useTheme } from 'styled-components'
 import draggable from '../draggable'
 
-const STROKE_WIDTH = 3
-const SELECTED_STROKE_WIDTH = 6
+export const STROKE_WIDTH = 2
+export const SELECTED_STROKE_WIDTH = 4
 
 const StyledGroup = styled.g`
   stroke-width: ${STROKE_WIDTH}px;

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
@@ -14,22 +14,27 @@ const SELECTED_RADIUS = {
 const CROSSHAIR_SPACE = 0.2
 const CROSSHAIR_WIDTH = 1
 
-function Point({ active, children, mark, onFinish, scale }) {
+const DEFAULT_MARK = {
+  tool: {
+    size: 'large'
+  }
+}
+function Point({ active = false, children, mark = {DEFAULT_MARK}, onFinish, scale = 1 }) {
   const { size } = mark.tool
   const crosshairSpace = CROSSHAIR_SPACE
   const crosshairWidth = CROSSHAIR_WIDTH
-  const selectedRadius = SELECTED_RADIUS[size] / scale
-  const radius = RADIUS[size] / scale
+  const selectedRadius = SELECTED_RADIUS[size]
+  const radius = RADIUS[size]
 
   return (
-    <g onPointerUp={active ? onFinish : undefined}>
+    <g transform={`scale(${1 / scale})`} onPointerUp={active ? onFinish : undefined}>
       <line
         x1='0'
         y1={-1 * crosshairSpace * selectedRadius}
         x2='0'
         y2={-1 * selectedRadius}
         strokeWidth={crosshairWidth}
-        vectorEffect={'non-scaling-stroke'}
+        vectorEffect={'non-scaling-size'}
       />
       <line
         x1={-1 * crosshairSpace * selectedRadius}
@@ -37,7 +42,7 @@ function Point({ active, children, mark, onFinish, scale }) {
         x2={-1 * selectedRadius}
         y2='0'
         strokeWidth={crosshairWidth}
-        vectorEffect={'non-scaling-stroke'}
+        vectorEffect={'non-scaling-size'}
       />
       <line
         x1='0'
@@ -45,7 +50,7 @@ function Point({ active, children, mark, onFinish, scale }) {
         x2='0'
         y2={selectedRadius}
         strokeWidth={crosshairWidth}
-        vectorEffect={'non-scaling-stroke'}
+        vectorEffect={'non-scaling-size'}
       />
       <line
         x1={crosshairSpace * selectedRadius}
@@ -53,9 +58,9 @@ function Point({ active, children, mark, onFinish, scale }) {
         x2={selectedRadius}
         y2='0'
         strokeWidth={crosshairWidth}
-        vectorEffect={'non-scaling-stroke'}
+        vectorEffect={'non-scaling-size'}
       />
-      <circle r={active ? selectedRadius : radius} vectorEffect={'non-scaling-stroke'} />
+      <circle r={active ? selectedRadius : radius} vectorEffect={'non-scaling-size'} />
     </g>
   )
 }
@@ -64,16 +69,6 @@ Point.propTypes = {
   active: PropTypes.bool,
   mark: PropTypes.object,
   scale: PropTypes.number
-}
-
-Point.defaultProps = {
-  active: false,
-  mark: {
-    tool: {
-      size: 'large'
-    }
-  },
-  scale: 1
 }
 
 export default observer(Point)

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
@@ -6,7 +6,6 @@ import { Tooltip } from '@zooniverse/react-components'
 import { useTranslation } from '@translations/i18n'
 
 import TooltipIcon from './components/TooltipIcon'
-import { HANDLE_RADIUS } from './helpers/constants'
 import TranscriptionLineMark from './components/TranscriptionLineMark'
 
 function storeMapper(stores) {
@@ -35,7 +34,6 @@ function TranscriptionLine(props) {
     lineState = 'active'
   }
   const colorToRender = (usesTranscriptionTask) ? transcriptionTaskColors[lineState] : color
-  const handleRadius = HANDLE_RADIUS / scale
 
   function onHandleDrag(coords) {
     mark.setCoordinates(coords)
@@ -66,7 +64,6 @@ function TranscriptionLine(props) {
           color={colorToRender}
           handlePointerDown={handlePointerDown}
           handleFinishClick={handleFinishClick}
-          handleRadius={handleRadius}
           mark={mark}
           onHandleDrag={onHandleDrag}
           scale={scale}
@@ -81,7 +78,6 @@ function TranscriptionLine(props) {
       color={colorToRender}
       handlePointerDown={handlePointerDown}
       handleFinishClick={handleFinishClick}
-      handleRadius={handleRadius}
       mark={mark}
       onHandleDrag={onHandleDrag}
       scale={scale}

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.spec.js
@@ -92,7 +92,7 @@ describe('Components > Drawing marks > Transcription line', function () {
           }
         }
       )
-      expect(wrapper.find(DragHandle).find('[x=100]').at(0)).to.have.lengthOf(1)
+      expect(wrapper.find(DragHandle).find({ x: 100 }).at(0)).to.have.lengthOf(1)
     })
 
     it('should have a transparent start point', function () {
@@ -229,7 +229,7 @@ describe('Components > Drawing marks > Transcription line', function () {
       )
       const dragMove = wrapper.find(DragHandle).find('[x=300]').at(0).prop('dragMove')
 
-      wrapper.find('circle[cx=300]').at(0).simulate('pointerdown')
+      wrapper.find('circle.endPoint').at(0).simulate('pointerdown')
       expect(mark.x2).to.equal(300)
       expect(mark.y2).to.equal(400)
       dragMove({}, { x: 10, y: 20 })
@@ -262,9 +262,9 @@ describe('Components > Drawing marks > Transcription line', function () {
       )
       const dragMove = wrapper.find(DragHandle).find('[x=300]').at(0).prop('dragMove')
 
-      wrapper.find('circle[cx=300]').at(0).simulate('pointerdown')
+      wrapper.find('circle.endPoint').at(0).simulate('pointerdown')
       expect(mark.finished).to.be.false()
-      wrapper.find('circle[cx=300]').at(0).simulate('pointerup')
+      wrapper.find('circle.endPoint').at(0).simulate('pointerup')
       expect(mark.finished).to.be.true()
       dragMove({}, { x: 10, y: 20 })
       expect(mark.finished).to.be.true()


### PR DESCRIPTION
- Remove `defaultProps` from functional components.
- Refactor transcription lines to use translation and scale transforms for the line handles.
- Style drag handles and point marks with `non-scaling-size`.
- Fixes a small issue, introduced by #6066, where drag handles aren't rendered in the correct proportion with respect to marks.

Here are screenshots of the sizing issue:

Main branch (drag handles are too small):
![A green rectangle drawn on top of a small subject image. The drag handles at the corners of the rectangle are too small, not much bigger than the line stroke width.](https://github.com/user-attachments/assets/d8fd8ff5-fc14-4ff8-8cbb-7a1d720520c3)

This branch (drag handles are correctly proportioned):
![A green rectangle drawn on top of a small subject image. The drag handles at the corners of the rectangle are correctly proportioned with respect to the line stroke width.](https://github.com/user-attachments/assets/82dc1db1-3509-4628-891c-b8fdb3c4d497)

Test cases in the dev classifier:
- point, line, and rectangle tools on a relatively small image: https://localhost:8080/?project=908&workflow=3370
- transcription lines on a relatively large image: https://localhost:8080/?project=mainehistory/beyond-borders-transcribing-historic-maine-land-documents&env=production


_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
