### PR TITLE
refactor(drawing-tools): revert non-scaling-size

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
@@ -34,8 +34,8 @@ const DragHandle = forwardRef(function DragHandle(
 
   return (
     <g ref={ref} transform={transform} data-testid={testid} >
-      <StyledCircle r={radius} {...styleProps} vectorEffect={'non-scaling-size'} />
-      <StyledCircle r={2 * radius} fill='transparent' stroke='transparent' vectorEffect={'non-scaling-size'} />
+      <StyledCircle r={radius} {...styleProps} vectorEffect={'non-scaling-stroke'} />
+      <StyledCircle r={2 * radius} fill='transparent' stroke='transparent' vectorEffect={'non-scaling-stroke'} />
     </g>
   )
 })

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
@@ -34,7 +34,7 @@ function Point({ active = false, children, mark = {DEFAULT_MARK}, onFinish, scal
         x2='0'
         y2={-1 * selectedRadius}
         strokeWidth={crosshairWidth}
-        vectorEffect={'non-scaling-size'}
+        vectorEffect={'non-scaling-stroke'}
       />
       <line
         x1={-1 * crosshairSpace * selectedRadius}
@@ -42,7 +42,7 @@ function Point({ active = false, children, mark = {DEFAULT_MARK}, onFinish, scal
         x2={-1 * selectedRadius}
         y2='0'
         strokeWidth={crosshairWidth}
-        vectorEffect={'non-scaling-size'}
+        vectorEffect={'non-scaling-stroke'}
       />
       <line
         x1='0'
@@ -50,7 +50,7 @@ function Point({ active = false, children, mark = {DEFAULT_MARK}, onFinish, scal
         x2='0'
         y2={selectedRadius}
         strokeWidth={crosshairWidth}
-        vectorEffect={'non-scaling-size'}
+        vectorEffect={'non-scaling-stroke'}
       />
       <line
         x1={crosshairSpace * selectedRadius}
@@ -58,9 +58,9 @@ function Point({ active = false, children, mark = {DEFAULT_MARK}, onFinish, scal
         x2={selectedRadius}
         y2='0'
         strokeWidth={crosshairWidth}
-        vectorEffect={'non-scaling-size'}
+        vectorEffect={'non-scaling-stroke'}
       />
-      <circle r={active ? selectedRadius : radius} vectorEffect={'non-scaling-size'} />
+      <circle r={active ? selectedRadius : radius} vectorEffect={'non-scaling-stroke'} />
     </g>
   )
 }

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/components/TranscriptionLineMark/TranscriptionLineMark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/components/TranscriptionLineMark/TranscriptionLineMark.js
@@ -10,7 +10,7 @@ const Circle = ({ fill, r, transform, ...props }) => (
       fill={fill}
       r={r}
       stroke='currentColor'
-      vectorEffect={'non-scaling-size'}
+      vectorEffect={'non-scaling-stroke'}
       {...props}
     />
   </g>


### PR DESCRIPTION
[`vector-effect: non-scaling-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/vector-effect) isn't implemented in browsers, so this reverts it back to `non-scaling-stroke` in drag handles, point marks, and transcription lines.

Test cases in the dev classifier:
- point, line, and rectangle tools on a relatively small image: https://localhost:8080/?project=908&workflow=3370
- transcription lines on a relatively large image: https://localhost:8080/?project=mainehistory/beyond-borders-transcribing-historic-maine-land-documents&env=production

This PR shouldn't change how drawn marks are rendered at all. Points and drag handles should remain the same size and width, regardless of image zoom level.

Here's a quick codepen which draws two identical SVG circles, one with 'non-scaling-stroke' and one with 'non-scaling-size'. Stroke scaling is only ignored in the first. The SVG spec says that it should be ignored in both.
https://codepen.io/eatyourgreens/pen/ZYEYqEv

If you resize the SVG image, by resizing the browser window, you'll see that the righthand circle gets thicker or thinner, but the lefthand circle remains the same.


_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
