### PR TITLE
fix(drawing-tools): scale rotated subjects correctly

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -46,6 +46,7 @@ function SVGPanZoom({
     width: naturalWidth
   }
   const zoom = useRef(1)
+  const [scale, setScale] = useState(1)
   const [viewBox, setViewBox] = useState(defaultViewBox)
 
   function enableZoom() {
@@ -136,7 +137,9 @@ function SVGPanZoom({
   }
 
   const { x, y, width, height } = viewBox
-  const scale = imageScale(imgRef)
+  setTimeout(() => {
+    setScale(imageScale(imgRef))
+  })
 
   return (
     <FullWidthDiv>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -6,11 +6,21 @@ const FullWidthDiv = styled.div`
   width: 100%;
 `
 
-function imageScale(imgRef, naturalWidth) {
-  const { width: clientWidth, height: clientHeight } = imgRef?.current
+function imageScale(imgRef) {
+  const { width: clientWidth, height: clientHeight } = imgRef.current
     ? imgRef.current.getBoundingClientRect()
     : {}
-  const scale = clientWidth / naturalWidth
+  const actualWidth = imgRef.current?.getBBox().width
+  // get the g element that rotates the image.
+  const transformRoot = imgRef.current?.closest('g[transform]')
+  const transformList = transformRoot?.transform.baseVal
+  // the rotation transform is the only item in the list.
+  const transform = transformList?.numberOfItems > 0
+    ? transformList.getItem(0)
+    : null
+  const scale = (transform?.angle % 180 === 0)
+    ? clientWidth / actualWidth // rotation is 0 or 180 degrees.
+    : clientHeight / actualWidth // rotation is 90 or 270 degrees.
   return !Number.isNaN(scale) ? scale : 1
 }
 
@@ -126,7 +136,7 @@ function SVGPanZoom({
   }
 
   const { x, y, width, height } = viewBox
-  const scale = imageScale(imgRef, naturalWidth)
+  const scale = imageScale(imgRef)
 
   return (
     <FullWidthDiv>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -7,21 +7,24 @@ const FullWidthDiv = styled.div`
 `
 
 function imageScale(imgRef) {
-  const { width: clientWidth, height: clientHeight } = imgRef.current
-    ? imgRef.current.getBoundingClientRect()
-    : {}
-  const actualWidth = imgRef.current?.getBBox().width
-  // get the g element that rotates the image.
-  const transformRoot = imgRef.current?.closest('g[transform]')
-  const transformList = transformRoot?.transform.baseVal
-  // the rotation transform is the only item in the list.
-  const transform = transformList?.numberOfItems > 0
-    ? transformList.getItem(0)
-    : null
-  const scale = (transform?.angle % 180 === 0)
-    ? clientWidth / actualWidth // rotation is 0 or 180 degrees.
-    : clientHeight / actualWidth // rotation is 90 or 270 degrees.
-  return !Number.isNaN(scale) ? scale : 1
+  if (imgRef?.current) {
+    const { width: clientWidth, height: clientHeight } = imgRef.current.getBoundingClientRect()
+    const actualWidth = imgRef.current.getBBox
+      ? imgRef.current.getBBox().width
+      : imgRef.current.naturalWidth
+    // get the g element that rotates the image.
+    const transformRoot = imgRef.current.closest('g[transform]')
+    const transformList = transformRoot?.transform?.baseVal
+    // the rotation transform is the only item in the list.
+    const transform = transformList?.numberOfItems > 0
+      ? transformList.getItem(0)
+      : null
+    const scale = (transform?.angle % 180 === 0)
+      ? clientWidth / actualWidth // rotation is 0 or 180 degrees.
+      : clientHeight / actualWidth // rotation is 90 or 270 degrees.
+    return !Number.isNaN(scale) ? scale : 1
+  }
+  return 1
 }
 
 const DEFAULT_HANDLER = () => true
@@ -138,7 +141,10 @@ function SVGPanZoom({
 
   const { x, y, width, height } = viewBox
   setTimeout(() => {
-    setScale(imageScale(imgRef))
+    const newScale = imageScale(imgRef)
+    if (scale !== newScale) {
+      setScale(newScale)
+    }
   })
 
   return (


### PR DESCRIPTION
Rewrite the `imageScale` function to reflect on the rotation transform for a subject before calculating the scale factor. Use the rotated image height to get the scaled width when the rotation is 90º or 270º.

Defer setting the image scale until after the image has rerendered, so that `imageScale` uses the correct dimensions and rotation.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- fixes #6695.
- fixes #6676.

## How to Review
Test cases in the dev classifier:
- point, line, and rectangle tools on a relatively small image: https://localhost:8080/?project=908&workflow=3370
- transcription lines on a relatively large image: https://localhost:8080/?project=mainehistory/beyond-borders-transcribing-historic-maine-land-documents&env=production


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
