### PR TITLE
fix(a11y): Volumetric Viewer slider control

### DIFF
--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/Slider.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/Slider.js
@@ -4,18 +4,17 @@ import { number, object, string } from 'prop-types'
 import styled, { css, useTheme } from 'styled-components'
 import { useEffect, useState } from 'react'
 
-/* RAW SVG FOR SLIDER | Needs to be URL encoded to view
+// RAW SVG FOR SLIDER | Needs to be URL encoded to view
 const SVGSlider = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 32'>
   <rect width='100%' height='100%' rx='8' ry='8' style='fill: rgb(0,93,105);' />
   <path d='M16 10 l-7 6 l7 6;' style='stroke:rgb(173, 221, 224); stroke-width:2; fill: none;'/>
   <path d='M24 10 l7 6 l-7 6;' style='stroke:rgb(173, 221, 224); stroke-width:2; fill: none;'/>
 </svg>`
-*/
+
 
 const StyledSlider = styled(Box)`
   align-items: center;
-  display: flex;
-  flex-direction: column;
+  gap: 10px;
   height: 60px;
   width: 60px;
 
@@ -25,21 +24,29 @@ const StyledSlider = styled(Box)`
         ? css`background: #FFF;`
         : css`background: #000;`
     }
-    -webkit-appearance: none;
+    appearance: none;
     border-radius: 5px;
     height: 4px;
     transform: rotate(-90deg) translateX(-125px);
     width: 250px;
-  }
-  
-  input[type="range"]::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 32'%3E%3Crect width='100%25' height='100%25' rx='8' ry='8' style='fill: rgb(0,93,105);' /%3E%3Cpath d='M16 10 l-7 6 l7 6;' style='stroke:rgb(173, 221, 224); stroke-width:2; fill: none;'/%3E%3Cpath d='M24 10 l7 6 l-7 6;' style='stroke:rgb(173, 221, 224); stroke-width:2; fill: none;'/%3E%3C/svg%3E");
-    background-size: cover;
-    cursor: pointer;
-    height: 32px;
-    width: 40px;
+
+    &::-webkit-slider-thumb {
+      appearance: none;
+      background-image: url("data:image/svg+xml,${encodeURIComponent(SVGSlider)}");
+      background-size: cover;
+      cursor: pointer;
+      height: 32px;
+      width: 40px;
+    }
+
+    &::-moz-range-thumb {
+      appearance: none;
+      background-image: url("data:image/svg+xml,${encodeURIComponent(SVGSlider)}");
+      background-size: cover;
+      cursor: pointer;
+      height: 32px;
+      width: 40px;
+    }
   }
   
   .plane-slider-forward {
@@ -49,15 +56,23 @@ const StyledSlider = styled(Box)`
         : css`color: #000;`
     }
 
-    height: 20px;
-    margin-bottom: 10px;
-    padding: 10px;
-    width: 20px;
+    height: fit-content;
+    width: fit-content;
+    padding: 0;
+    border: none;
+    background: none;
 
     &:active {
       background-color: #ADDDE0;
       border-radius: 20px;
       color: white;
+    }
+    
+    svg {
+      fill: currentColor;
+      height: 20px;
+      width: 20px;
+      padding: 10px;
     }
   }
 `
@@ -101,16 +116,19 @@ export const Slider = ({ dimension, viewer }) => {
 
   return (
     <StyledSlider>
-      <ForwardTen
+      <button
         className='plane-slider-forward'
         color={iconColor}
-        onMouseDown={inMouseDown}
-        onMouseUp={inMouseUp}
-      />
+        onPointerDown={inMouseDown}
+        onPointerUp={inMouseUp}
+        aria-label='Advance 10 Frames'
+      >
+        <ForwardTen height={20} width={20} />
+      </button>
       <input
         aria-label={`Plane ${dimension} Slider`}
         max={viewer.base - 1}
-        min='0'
+        min={0}
         onChange={inChange}
         orient='vertical'
         type='range'

--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/Slider.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/Slider.js
@@ -12,42 +12,42 @@ const SVGSlider = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 32'>
 </svg>`
 
 
+const StyledRangeInput = styled.input`
+  ${props =>
+    props.theme.dark
+      ? css`background: #FFF;`
+      : css`background: #000;`
+  }
+  appearance: none;
+  border-radius: 5px;
+  height: 4px;
+  transform: rotate(-90deg) translateX(-125px);
+  width: 250px;
+
+  &::-webkit-slider-thumb {
+    appearance: none;
+    background-image: url("data:image/svg+xml,${encodeURIComponent(SVGSlider)}");
+    background-size: cover;
+    cursor: pointer;
+    height: 32px;
+    width: 40px;
+  }
+
+  &::-moz-range-thumb {
+    appearance: none;
+    background-image: url("data:image/svg+xml,${encodeURIComponent(SVGSlider)}");
+    background-size: cover;
+    cursor: pointer;
+    height: 32px;
+    width: 40px;
+  }
+`
+
 const StyledSlider = styled(Box)`
   align-items: center;
   gap: 10px;
   height: 60px;
   width: 60px;
-
-  input[type="range"] {
-    ${props =>
-      props.theme.dark
-        ? css`background: #FFF;`
-        : css`background: #000;`
-    }
-    appearance: none;
-    border-radius: 5px;
-    height: 4px;
-    transform: rotate(-90deg) translateX(-125px);
-    width: 250px;
-
-    &::-webkit-slider-thumb {
-      appearance: none;
-      background-image: url("data:image/svg+xml,${encodeURIComponent(SVGSlider)}");
-      background-size: cover;
-      cursor: pointer;
-      height: 32px;
-      width: 40px;
-    }
-
-    &::-moz-range-thumb {
-      appearance: none;
-      background-image: url("data:image/svg+xml,${encodeURIComponent(SVGSlider)}");
-      background-size: cover;
-      cursor: pointer;
-      height: 32px;
-      width: 40px;
-    }
-  }
   
   .plane-slider-forward {
     ${props =>
@@ -125,12 +125,11 @@ export const Slider = ({ dimension, viewer }) => {
       >
         <ForwardTen height={20} width={20} />
       </button>
-      <input
+      <StyledRangeInput
         aria-label={`Plane ${dimension} Slider`}
         max={viewer.base - 1}
         min={0}
-        onChange={inChange}
-        orient='vertical'
+        onInput={inChange}
         type='range'
         value={viewer.getPlaneFrameIndex({ dimension })}
       />

--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/Slider.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/Slider.js
@@ -42,39 +42,36 @@ const StyledRangeInput = styled.input`
     width: 40px;
   }
 `
+const StyledButton = styled.button`
+  ${props =>
+    props.theme.dark
+      ? css`color: #FFF;`
+      : css`color: #000;`
+  }
+  height: fit-content;
+  width: fit-content;
+  padding: 0;
+  border: none;
+  background: none;
 
+  &:active {
+    background-color: #ADDDE0;
+    border-radius: 20px;
+    color: white;
+  }
+  
+  svg {
+    fill: currentColor;
+    height: 20px;
+    width: 20px;
+    padding: 10px;
+  }
+`
 const StyledSlider = styled(Box)`
   align-items: center;
   gap: 10px;
   height: 60px;
   width: 60px;
-  
-  .plane-slider-forward {
-    ${props =>
-      props.theme.dark
-        ? css`color: #FFF;`
-        : css`color: #000;`
-    }
-
-    height: fit-content;
-    width: fit-content;
-    padding: 0;
-    border: none;
-    background: none;
-
-    &:active {
-      background-color: #ADDDE0;
-      border-radius: 20px;
-      color: white;
-    }
-    
-    svg {
-      fill: currentColor;
-      height: 20px;
-      width: 20px;
-      padding: 10px;
-    }
-  }
 `
 
 export const Slider = ({ dimension, viewer }) => {
@@ -116,15 +113,14 @@ export const Slider = ({ dimension, viewer }) => {
 
   return (
     <StyledSlider>
-      <button
+      <StyledButton
         className='plane-slider-forward'
-        color={iconColor}
         onPointerDown={inMouseDown}
         onPointerUp={inMouseUp}
         aria-label='Advance 10 Frames'
       >
-        <ForwardTen height={20} width={20} />
-      </button>
+        <ForwardTen color={iconColor} height={20} width={20} />
+      </StyledButton>
       <StyledRangeInput
         aria-label={`Plane ${dimension} Slider`}
         max={viewer.base - 1}

--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/Slider.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/Slider.js
@@ -12,6 +12,17 @@ const SVGSlider = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 32'>
 </svg>`
 
 
+/**
+ * A custom thumb for the range input slider.
+ */
+const customThumbStyles = `
+  appearance: none;
+  background-image: url("data:image/svg+xml,${encodeURIComponent(SVGSlider)}");
+  background-size: cover;
+  cursor: pointer;
+  height: 32px;
+  width: 40px;
+`
 const StyledRangeInput = styled.input`
   ${props =>
     props.theme.dark
@@ -25,21 +36,11 @@ const StyledRangeInput = styled.input`
   width: 250px;
 
   &::-webkit-slider-thumb {
-    appearance: none;
-    background-image: url("data:image/svg+xml,${encodeURIComponent(SVGSlider)}");
-    background-size: cover;
-    cursor: pointer;
-    height: 32px;
-    width: 40px;
+    ${customThumbStyles}
   }
 
   &::-moz-range-thumb {
-    appearance: none;
-    background-image: url("data:image/svg+xml,${encodeURIComponent(SVGSlider)}");
-    background-size: cover;
-    cursor: pointer;
-    height: 32px;
-    width: 40px;
+    ${customThumbStyles}
   }
 `
 const StyledButton = styled.button`


### PR DESCRIPTION
A couple of small fixes for the slider control:
- a labelled button to advance by 10 frames (keyboard and screen reader operability is a level A WCAG requirement for clickable controls.)
- `::moz-range-thumb` styling for Firefox.
- fixes the range input so that you can slide it in Firefox.

Tested with Chrome, Firefox, and Safari on MacOS 14.7.3.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-subject-viewers

## How to Review
You can try out these changes in the storybook. The slider control should be operable from the keyboard on this branch, but not on the main branch.
http://localhost:6008/?path=/story/components-volumetricviewer--volume-64-x-64-x-64

~~Note that the slider control can't be used with a pointer device (mouse, trackpad etc.) in Firefox. That isn't fixed here.~~ I've also fixed the slider so that you can now use it in Firefox.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
