### PR TITLE
lib-classifier: Refactor thumbnail size per task setting and choices

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
@@ -67,12 +67,11 @@ export function Choices({
 
   const rowsCount = Math.ceil(filteredChoiceIds.length / columnsCount)
   
-  let thumbnailSize
-  if (task.thumbnails === 'hide') {
-    thumbnailSize = 'none'
-  } else {
-    thumbnailSize = whatSizeThumbnail(filteredChoiceIds)
-  }
+  const thumbnailSetting = task.thumbnails || (task.alwaysShowThumbnails ? 'show' : 'default')
+  const thumbnailSize = whatSizeThumbnail({
+    length: filteredChoiceIds.length,
+    thumbnailSetting
+  })
 
   function handleKeyDown (choiceId, event) {
     const index = filteredChoiceIds.indexOf(choiceId)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/helpers/whatSizeThumbnail.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/helpers/whatSizeThumbnail.js
@@ -1,14 +1,22 @@
 import howManyColumns from './howManyColumns'
 
-export default function whatSizeThumbnail({ length }) {
-  switch (howManyColumns({ length })) {
-    case 1:
-      return 'large'
-    case 2:
-      return 'large'
-    case 3:
-      return 'small'
-    default:
-      return 'none'
+export default function whatSizeThumbnail({ length, thumbnailSetting = 'default' }) {
+  if (thumbnailSetting === 'hide') {
+    return 'none'
   }
+
+  const columns = howManyColumns({ length })
+  
+  if (thumbnailSetting === 'show') {
+    return columns === 3 ? 'small' : 'large'
+  }
+
+  // Default behavior
+  
+  if (length > 30) {
+    return 'none'
+  } else if (columns === 3) {
+    return 'small'
+  }
+  return 'large'
 }

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/helpers/whatSizeThumbnail.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/helpers/whatSizeThumbnail.spec.js
@@ -5,15 +5,43 @@ describe('Function > whatSizeThumbnail', function () {
     expect(whatSizeThumbnail).to.be.a('function')
   })
 
-  it('should return \'small\' if there are 3 columns', function () {
-    expect(whatSizeThumbnail(Array(21))).to.equal('small')
+  describe('with default thumbnailSetting', function () {
+    it('should return \'none\' if the length is greater than 30', function () {
+      expect(whatSizeThumbnail({ length: 31 })).to.equal('none')
+    })
+
+    it('should return \'small\' if there are 3 columns', function () {
+      expect(whatSizeThumbnail({ length: 21 })).to.equal('small')
+    })
+
+    it('should return \'large\' if there are 2 columns', function () {
+      expect(whatSizeThumbnail({ length: 19 })).to.equal('large')
+    })
+
+    it('should return \'large\' if there is 1 column', function () {
+      expect(whatSizeThumbnail({ length: 4 })).to.equal('large')
+    })
   })
 
-  it('should return \'large\' if there are 2 columns', function () {
-    expect(whatSizeThumbnail(Array(19))).to.equal('large')
+  describe('with thumbnailSetting: "show"', function () {
+    it('should return \'small\' for 3 columns', function () {
+      expect(whatSizeThumbnail({ length: 21, thumbnailSetting: 'show' })).to.equal('small')
+    })
+
+    it('should return \'large\' for 2 columns', function () {
+      expect(whatSizeThumbnail({ length: 19, thumbnailSetting: 'show' })).to.equal('large')
+    })
+
+    it('should return \'large\' for 1 column', function () {
+      expect(whatSizeThumbnail({ length: 4, thumbnailSetting: 'show' })).to.equal('large')
+    })
   })
 
-  it('should return \'large\' if there is 1 column', function () {
-    expect(whatSizeThumbnail(Array(4))).to.equal('large')
+  describe('with thumbnailSetting: "hide"', function () {
+    it('should always return \'none\'', function () {
+      expect(whatSizeThumbnail({ length: 4, thumbnailSetting: 'hide' })).to.equal('none')
+      expect(whatSizeThumbnail({ length: 19, thumbnailSetting: 'hide' })).to.equal('none')
+      expect(whatSizeThumbnail({ length: 31, thumbnailSetting: 'hide' })).to.equal('none')
+    })
   })
 })


### PR DESCRIPTION
## Package
- lib-classifier

## Describe your changes
- if survey task `alwaysShowThumbnails` is true, then show small or large thumbnails per choices shown
- if survey task `thumbnails` is 'hide', then always hide thumbnails
- if survey task `thumbnails` is 'show', then show small or large thumbnails per choices shown
- if survey task `thumbnails` is 'default' or undefined, then hide thumbnails if choices shown are greater than 30, and show small or large thumbnails per choices shown if choices shown are 30 or less

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - lib-classifier: https://local.zooniverse.org:8080/?project=1634&workflow=3765
  - app-project: https://local.zooniverse.org:3000/projects/markb-panoptes/survey-task-test-project/classify/workflow/3765
- What user actions should my reviewer step through to review this PR?
  - filter choices, note thumbnail size
  - review other workflows in the same project
- Which storybook stories should be reviewed?
  - http://localhost:6006/?path=/story/tasks-survey-chooser-choices--less-thirty-more-twenty - though not really any change
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected