### PR TITLE
RegisterFormContainer: add DEFAULT_HANDLER for onSignIn

### DIFF
--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/RegisterFormContainer.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/RegisterFormContainer.js
@@ -30,7 +30,7 @@ function validationErrors({ email, emailConfirm, password, passwordConfirm, priv
 export default function RegisterFormContainer({
   closeModal = DEFAULT_HANDLER,
   project = null,
-  onSignIn
+  onSignIn = DEFAULT_HANDLER
 }) {
   const { t } = useTranslation()
   const [error, setError] = useState('')


### PR DESCRIPTION
## PR Overview

Fixes #6715 
Package: `lib-react-components`, but has downstream effects on `app-root` and possibly `app-project`

This PR fixes an issue where, if you try to Register a New User on the Zooniverse home page, then an error message appears and the Register modal doesn't close, _even though you've successfully created a new user account and signed in(!)._

- The error...
  - ...occurs in lib-react-component's RegisterFormContainer's onSubmit()
  - ...triggers when the onSignIn parameter isn't defined. (As is the case with app-project's PageHeader's AuthModal and lib-content's Introduction's AuthModal)
- The fix is to simply add a default handler to onSignIn, so it doesn't trigger an existential failure if it's undefined. (i.e. "onSignIn isn't a function" error.) 

Note:
- app-project's PageHeader's AuthModal does implement onSignIn (notably to register the user resource locally), so there's no issue registering a new user on a project page.

### Testing

Home Page, part 1:
- Run app-root and open the home page, i.e. https://local.zooniverse.org:3000/
  - Make sure you're not logged in. Log out, or use an incognito window.
- Click on the "Register" button on the **top menu,** to open the Register New User form (modal).
- Fill in the details for a test user. Click on the "Register" (submit) button at the bottom of the form.
  - Expected: user account created. User is logged in on FEM. Form should close.

Home Page, part 2:
- As above, but click on the "Register" button under the **Introduction** section on the Home Page.

Project Page:
- Run app-project and open any project page, e.g. https://local.zooniverse.org:3000/projects/darkeshard/test-project-2022
- Click on the "Register" button on the **top menu,** to open the Register New User form (modal) and etc etc etc you know the drill.

### Status

Ready for review _and/or enhancements._

As of commit c37621eb125b8c5b4c5856bd38113773b9c739eb, I'm only providing the minimum fix to the issue to get a patch out ASAP. There's room for additional enhancements:

- Review app-project's PageHeader and lib-content's Introduction to see if they actually need onSignIn.
- Update tests to account for onSignIn, if necessary.

If you'd like to take on these enhancements, please spin up a separate PR so we can merge that into this PR (if it's a quick update), or merge it into master _after_ this PR goes out (if the enhancements will take more than a day).