### PR TITLE
fix(classifier): Survey task delete button label

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/DeleteButton.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/DeleteButton.js
@@ -63,7 +63,7 @@ function DeleteButton ({
   disabled = false,
   tabIndex = -1
 }) {
-  const { t } = useTranslation()
+  const { t } = useTranslation('plugins')
 
   return (
     <StyledButton


### PR DESCRIPTION
Fix the survey task delete button label, which currently reads "SurveyTask.DeleteButton.delete".

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier/plugins/tasks/survey

## How to Review
Check the delete button label for a selected choice in the survey task.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
