### PR TITLE
Create Volumetric Layout

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
@@ -5,15 +5,20 @@ import getLayout from './helpers/getLayout'
 
 function storeMapper(classifierStore) {
   const workflow = classifierStore.workflows.active
-  const limitSubjectHeight = workflow?.configuration?.limit_subject_height
-  const layout = limitSubjectHeight ? 'centered' : workflow?.layout
-  const separateFramesView = classifierStore.subjectViewer.separateFramesView
   const hasSurveyTask = workflow?.hasSurveyTask
+  const limitSubjectHeight = workflow?.configuration?.limit_subject_height
+  const separateFramesView = classifierStore.subjectViewer.separateFramesView
 
+  const layout = (classifierStore.projects?.active?.isVolumetricViewer)
+    ? 'volumetric'
+    : limitSubjectHeight
+      ? 'centered'
+      : workflow?.layout
+  
   return {
+    hasSurveyTask,
     layout,
-    separateFramesView,
-    hasSurveyTask
+    separateFramesView
   }
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/Volumetric/VolumetricLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/Volumetric/VolumetricLayout.js
@@ -1,0 +1,69 @@
+import styled from 'styled-components'
+import { Box } from 'grommet'
+import Banners from '@components/Classifier/components/Banners'
+import FeedbackModal from '@components/Classifier/components/Feedback'
+import MetaTools from '@components/Classifier/components/MetaTools'
+import QuickTalk from '@components/Classifier/components/QuickTalk'
+import SubjectViewer from '@components/Classifier/components/SubjectViewer'
+import TaskArea from '@components/Classifier/components/TaskArea'
+import { StyledSubjectContainer } from '../shared/StyledContainers'
+
+const Relative = styled(Box)`
+  position: relative; // Used for QuickTalk and FeedbackModal positioning
+`
+
+const ContainerBox = styled(Box)`
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  justify-content: center;
+
+  .metatools-centered {
+    justify-content: center;
+  }
+
+  // small screens
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+  }
+`
+
+const ViewBox = styled(Box)`
+  flex-direction: row;
+`
+
+const StickyTaskArea = styled(Box)`
+  height: fit-content;
+  position: sticky;
+  top: 10px;
+  min-width: auto;
+  width: 25rem;
+
+  // small screens
+  @media screen and (max-width: 768px) {
+    min-width: auto;
+    position: static;
+    width: 100%;
+  }
+`
+
+export default function VolumetricLayout() {
+  return (
+    <Relative>
+      <ContainerBox>
+        <ViewBox forwardedAs='section'>
+          <StyledSubjectContainer>
+            <Banners />
+            <SubjectViewer />
+            <MetaTools className='metatools-centered' />
+          </StyledSubjectContainer>
+        </ViewBox>
+        <StickyTaskArea>
+          <TaskArea />
+        </StickyTaskArea>
+      </ContainerBox>
+      <FeedbackModal />
+      <QuickTalk />
+    </Relative>
+  )
+}

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/Volumetric/VolumetricLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/Volumetric/VolumetricLayout.js
@@ -37,7 +37,7 @@ const StickyTaskArea = styled(Box)`
   position: sticky;
   top: 10px;
   min-width: auto;
-  width: 25rem;
+  width: 20rem;
 
   // small screens
   @media screen and (max-width: 768px) {

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/Volumetric/VolumetricLayout.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/Volumetric/VolumetricLayout.stories.js
@@ -1,0 +1,55 @@
+import mockStore from '@test/mockStore'
+import { Provider } from 'mobx-react'
+import { ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
+import VolumetricLayout from './VolumetricLayout'
+
+const workflowMock = {
+  configuration: {},
+  first_task: 'T0',
+  strings: {},
+  tasks: {
+    T0: {
+      strings: {
+        instruction: 'Annotate subject with a volumetric annotation',
+      },
+      taskKey: 'T0',
+      type: 'volumetric'
+    }
+  }
+}
+
+Object.entries(workflowMock.tasks).forEach(([taskKey, task]) => {
+  if (task.strings) {
+    const taskEntries = Object.entries(task.strings)
+    taskEntries.forEach(([key, value]) => {
+      const translationKey = `tasks.${taskKey}.${key}`
+      workflowMock.strings[translationKey] = value
+    })
+  }
+})
+
+const store = mockStore({
+  project: ProjectFactory.build({
+    experimental_tools: ['volumetricProject']
+  }),
+  subject: SubjectFactory.build({
+    id: 'mock_subject',
+    locations: [
+      { 'application/json': 'https://panoptes-uploads.zooniverse.org/subject_location/34898ede-7e3d-4f83-b6ee-920769f01288.json' }
+    ]
+  }),
+  workflow: WorkflowFactory.build(workflowMock)
+})
+
+export default {
+  title: 'Layouts / Volumetric',
+  component: VolumetricLayout,
+}
+
+export function Default() {
+  return (
+    <Provider classifierStore={store}>
+      <VolumetricLayout />
+    </Provider>
+  )
+}

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/Volumetric/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/Volumetric/index.js
@@ -1,0 +1,1 @@
+export { default } from './VolumetricLayout'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/index.js
@@ -1,10 +1,12 @@
+import CenteredLayout from './CenteredLayout'
 import MaxWidth from './MaxWidth'
 import NoMaxWidth from './NoMaxWidth'
-import CenteredLayout from './CenteredLayout'
+import Volumetric from './Volumetric'
 
 export default MaxWidth
 export {
   CenteredLayout as centered,
   MaxWidth as maxWidth,
-  NoMaxWidth as noMaxWidth
+  NoMaxWidth as noMaxWidth,
+  Volumetric as volumetric
 }

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -23,9 +23,8 @@ function storeMapper(store) {
   }
 }
 
-const MetaTools = ({ className: classNameParam = '' }) => {
+const MetaTools = ({ className = '' }) => {
   const {
-    className = classNameParam,
     interactionTask = {},
     isThereMetadata = false,
     subject = null,

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -23,9 +23,9 @@ function storeMapper(store) {
   }
 }
 
-const MetaTools = () => {
+const MetaTools = ({ className: classNameParam = '' }) => {
   const {
-    className = '',
+    className = classNameParam,
     interactionTask = {},
     isThereMetadata = false,
     subject = null,

--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/ComponentViewer.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/ComponentViewer.js
@@ -34,7 +34,7 @@ const StyledBox = styled(Box)`
     }
   }
 
-  @media (width >= 1280px) {
+  @media (width > 1200px) {
     max-width: 975px;
 
     .planes-container {
@@ -45,6 +45,7 @@ const StyledBox = styled(Box)`
       height: 575px;
       min-width: 330px;
       padding: 20px;
+      border-top-right-radius: 16px;
 
       .volume-cube {
         max-width: 460px;
@@ -58,7 +59,7 @@ const StyledBox = styled(Box)`
     }
   }
   
-  @media (width < 1280px) {
+  @media (width <= 1200px) {
     background: none;
     border: none;
     flex-direction: column-reverse;
@@ -70,7 +71,6 @@ const StyledBox = styled(Box)`
 
     .volume-container {
       border-radius: 16px;
-      border-top-right-radius: 0;
       margin: 0 0 0 20px;
       width: 390px;
 


### PR DESCRIPTION
## Package
- lib-classifier

## Describe your changes
Created a new Layout that is focused on the Volumetric Viewer. The motivation being that because the viewer is new and the design ideas are relatively unique, having a separate Layout makes it easier to manage the changes that are unique to this new Viewer. In specific, this new Layout does not include the ImageToolbar because panning, rotating, and selecting tools are incorporated within both the volumetric and planar views respectively.. Which means there is no need for a global ImageToolbar of actions.

While this is a new Viewer, there are plenty of design decisions yet to be made. There are larger questions of what should happen at different breakpoints for content in combination with other page elements (specifically, Banners and related whitespace / spacing).

## How to Review
- Run `lib-classifier` Storybook locally and check out the [Layout > Volumetric](http://localhost:6006/?path=/story/layouts-volumetric--default)
- Alternatively, you can run the local [app-project](https://local.zooniverse.org:3000/projects/kieftrav/volumetric-viewer/classify/workflow/3831)

Review Questions
- What should we do with the layout around 800px - fully center? Make larger/smaller?
- What should we do with banners, specifically the "Finished: You've seen everything"

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).