### PR TITLE
fix(drawing-tools): ignore pointers in 'pan and zoom' mode

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -147,14 +147,14 @@ function InteractionLayer({
         onDelete={inactivateMark}
       />
       <DrawingToolMarks
-        activeMark={activeMark}
+        activeMark={move ? null : activeMark}
         marks={marks}
         onDelete={inactivateMark}
         onDeselectMark={inactivateMark}
         onFinish={onFinish}
         onSelectMark={onSelectMark}
         onMove={(mark, difference) => mark.move(difference)}
-        pointerEvents={creating ? 'none' : 'painted'}
+        pointerEvents={creating || move ? 'none' : 'painted'}
         played={played}
       />
     </>


### PR DESCRIPTION
When 'Pan' is selected in the image toolbar:
- deactivate the active mark, so that it doesn't capture the pointer.
- style all inactive drawn marks with [`pointer-events: none;`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events).

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier
## Linked Issue and/or Talk Post
- fixes #6746.

## How to Review
https://localhost:8080/?env=staging&project=markb-panoptes/test-project-1-mb-fem-lab&workflow=3847

Draw a large ellipse, or rectangle, then switch to Pan mode. Pan and zoom the image with a trackpad or touchscreen. Switch back to drawing mode to continue editing the active mark. 


https://github.com/user-attachments/assets/25693a8c-c20e-46d2-b6c9-565af0b73166


https://github.com/user-attachments/assets/f76c9074-958c-44e4-8909-b26d758a1920





# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

