### PR TITLE
lib-user: Refactor usePanoptesUserGroup for signed-out user access to public group

### DIFF
--- a/packages/lib-user/src/hooks/usePanoptesProjects.js
+++ b/packages/lib-user/src/hooks/usePanoptesProjects.js
@@ -55,7 +55,7 @@ async function fetchProjects({ query, token }) {
 export function usePanoptesProjects(query) {
   const token = usePanoptesAuthToken()
   let key = null
-  if (token && query?.id) {
+  if (query?.id) {
     key = { query, token }
   }
   return useSWR(key, fetchProjects, SWROptions)

--- a/packages/lib-user/src/hooks/usePanoptesUserGroup.js
+++ b/packages/lib-user/src/hooks/usePanoptesUserGroup.js
@@ -29,6 +29,6 @@ async function fetchPanoptesUserGroup({ groupId, token }) {
 
 export function usePanoptesUserGroup({ adminMode, authUserId, groupId, membershipId }) {
   const token = usePanoptesAuthToken()
-  const key = token && groupId ? { groupId, token } : null
+  const key = groupId ? { groupId, token } : null
   return useSWR(key, fetchPanoptesUserGroup, SWROptions)
 }

--- a/packages/lib-user/src/hooks/useStats.js
+++ b/packages/lib-user/src/hooks/useStats.js
@@ -49,6 +49,6 @@ export function useStats({
   sourceId
 }) {
   const token = usePanoptesAuthToken()
-  const key = token && sourceId ? { endpoint, query, sourceId, token } : null
+  const key = sourceId ? { endpoint, query, sourceId, token } : null
   return useSWR(key, fetchStats, SWROptions)
 }


### PR DESCRIPTION
## Package
- lib-user

## Linked Issue and/or Talk Post
- public user group like https://www.zooniverse.org/groups/2620016 should be visible for a signed out user
- small changes from #6345 , I don't think this re-introduces any related bugs, but worth double-checking

## Describe your changes
- remove conditional check for token before defining swr keys (usePanoptesUserGroup, useStats, and usePanoptesProjects), allowing key to be defined for signed out (token = `null`) user, and then request made for user group and related stats and projects

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
  - staging public user group: https://local.zooniverse.org:3000/groups/1326989?env=staging
  - production public user group: https://local.zooniverse.org:3000/groups/2630510?env=production
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
