### PR TITLE
Filter Volumetric Project Research Team to only show the Project Owner.

### DIFF
--- a/packages/app-project/pages/[panoptesEnv]/[owner]/[project]/about/team.js
+++ b/packages/app-project/pages/[panoptesEnv]/[owner]/[project]/about/team.js
@@ -7,11 +7,18 @@ import fetchTeam from '@helpers/fetchTeam'
 export async function getStaticProps({ locale, params }) {
   const { notFound, props } = await getDefaultPageProps({ locale, params })
   const { panoptesEnv } = params
+
   const { project } = props.initialState
   const page = await fetchProjectPage(project, locale, 'team', panoptesEnv)
   const pageTitle = page?.strings?.title ?? 'Team'
 
   const teamArray = await fetchTeam(project, panoptesEnv)
+
+  // Axonal Pathfinders Project is the 1st Volumetric Project and requests only showing the owner due to animal ethics concerns and researcher privacy
+  const isVolumetricProject = project.experimental_tools.indexOf('volumetricProject') > -1
+  const teamArrayFiltered = (isVolumetricProject)
+    ? teamArray.filter(user => user.roles.indexOf('owner') > -1)
+    : teamArray
 
   return {
     notFound,
@@ -20,7 +27,7 @@ export async function getStaticProps({ locale, params }) {
       pageTitle,
       pageType: 'team',
       ...props,
-      teamArray: teamArray
+      teamArray: teamArrayFiltered
     },
     revalidate: 60
   }


### PR DESCRIPTION
## Package
- app-project

## Describe your changes
In the Teams page, check the project's `experimental_tools` attribute for a volumetric project, and if so, limit to showing just the project owner

## How to Review
- Run `app-project` locally and then check a [Volumetric Project](https://local.zooniverse.org:3000/projects/cmcbrain/axonal-pathfinders/about/team?env=production&demo=true) to see its only showing the CMCBrain user and compare to [Daily Minor Planet](https://local.zooniverse.org:3000/projects/fulsdavid/the-daily-minor-planet/about/team?env=production&demo=true) having its full team. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
