### PR TITLE
refactor(classifier): use VisX's built-in wheel zoom

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -1,6 +1,6 @@
 import { localPoint } from '@visx/event'
 import { Zoom } from '@visx/zoom'
-import { throttle } from 'lodash'
+import throttle from 'lodash/throttle'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { useEffect, useRef } from 'react'
@@ -123,11 +123,15 @@ function VisXZoom({
     zoomRef.current.dragEnd()
   }
 
+  function wheelDelta(event) {
+    const { zoomInValue, zoomOutValue } = zoomConfiguration
+    const zoomValue = (-event.deltaY > 0) ? zoomInValue : zoomOutValue
+    return { scaleX: zoomValue, scaleY: zoomValue }
+  }
+
   function onWheel(event) {
-    // performance of this is pretty bad
     if (zooming) {
-      const zoomDirection = (-event.deltaY > 0) ? 'in' : 'out'
-      zoomToPoint(event, zoomDirection)
+      zoomRef.current.handleWheel(event)
     }
   }
   const throttledOnWheel = throttle(onWheel, zoomConfiguration?.onWheelThrottleWait)
@@ -145,6 +149,7 @@ function VisXZoom({
       passive
       top={top}
       width={width}
+      wheelDelta={wheelDelta}
     >
       {_zoom => {
         zoomRef.current = _zoom


### PR DESCRIPTION
A small refactor of `VisXZoom` to use [`zoom.handleWheel`](https://github.com/airbnb/visx/blob/86738178e86fdc0feacf83ac96e68724da0627c2/packages/visx-zoom/src/Zoom.tsx#L263-L271), from `@visx/zoom`, for wheel events. Wheel zoom speed is configured with the [`wheelDelta`](https://airbnb.io/visx/docs/zoom#Zoom_wheelDelta) prop.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## How to Review
https://localhost:8080/?env=staging&project=markb-panoptes/test-project-1-mb-fem-lab&workflow=3847

Wheel zoom shouldn't have changed. Scrolling up zooms out, scrolling down zooms in. The zoom speed is set by the `wheelDelta` function. I've left  wheel event throttling in, but it might not be needed with the `@visx/zoom` wheel handler.

http://localhost:6006/?path=/story/subject-viewers-scatterplotviewer--selected-x-ranges

Light curves should still zoom in the x-axis without zooming in y.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
