### PR TITLE
fix(classifier): ctrl to zoom images and wheel zoom for drawn marks

### DIFF
--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@babel/runtime": "~7.26.0",
     "@sentry/browser": "~8.54.0",
+    "@use-gesture/react": "~10.3.1",
     "@visx/axis": "~3.12.0",
     "@visx/brush": "~3.12.0",
     "@visx/event": "~3.12.0",

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -44,8 +44,9 @@ const DEFAULT_HANDLER = () => true
  *     }}
  *     setOnPan={setOnPan}
  *     setOnZoom={setOnZoom}
- *     zoomingComponent={SVGComponent}
- *     {...SVGComponentProps}
+ *     zoomingComponent={(zoomProps) => (
+ *       <SVGComponent {...zoomProps} {...SVGComponentProps} />
+ *     )}
  *   />
  * ```
  */
@@ -63,7 +64,6 @@ function VisXZoom({
   zoomConfiguration = defaultZoomConfig,
   zoomingComponent,
   zooming = false,
-  ...props
 }) {
   const { onKeyZoom } = useKeyZoom()
   const zoomRef = useRef(null)
@@ -232,7 +232,6 @@ function VisXZoom({
               move={move}
               transformMatrix={_zoom.transformMatrix}
               transform={_zoom.toString()}
-              {...props}
             >
               <ZoomEventLayer
                 focusable
@@ -296,7 +295,20 @@ VisXZoom.propTypes = {
   }),
   /** Enable zooming. true by default. */
   zooming: PropTypes.bool,
-  /** A React component to zoom. It must render SVG, **not** HTML. */
+  /** A React component to zoom. It must render SVG, **not** HTML.
+   * `VisXZoom` will inject the following props into this component:
+   * - `initialTransformMatrix`: the initial transformation matrix.
+   * - `transformMatrix`: the current transformation matrix.
+   * - `transform`: a string representation of the matrix transform.
+   * - `children`: `ZoomEventLayer`, an SVG `<rect>` which handles zoom pointer and wheel events.
+   * ```jsx
+   * ({ children, ...zoomProps }) => (
+   *   <SVGComponent {...zoomProps} {...SVGComponentProps} >
+   *     {children}
+   *   </SVGComponent>
+   * )
+   * ```
+  */
   zoomingComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -34,7 +34,7 @@ const DEFAULT_HANDLER = () => true
  *     move
  *     zooming
  *     panning
- *     disablesScrolling
+ *     allowsScrolling
  *     zoomConfiguration={{
  *       direction: 'both',
  *       minZoom: 1,
@@ -51,8 +51,8 @@ const DEFAULT_HANDLER = () => true
  * ```
  */
 function VisXZoom({
+  allowsScrolling = false,
   constrain,
-  disablesScrolling = true,
   height,
   left = 0,
   move = false,
@@ -87,7 +87,7 @@ function VisXZoom({
     Cancel the default event (ignored unless the listener explicitly
     sets passive: false) and call the wheel handler with a throttled delay.
     */
-    if (disablesScrolling) {
+    if (!allowsScrolling) {
       /* event.preventDefault() will throw a warning in the browser
       for passive events. To avoid that, use addEventListener with 
       { passive: false }.
@@ -191,7 +191,7 @@ function VisXZoom({
   }
 
   function onPointerEnter() {
-    if (zooming && disablesScrolling) {
+    if (zooming && !allowsScrolling) {
       const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
       document.body.style.paddingRight = `${scrollbarWidth}px`
       document.body.style.overflow = 'hidden'
@@ -257,13 +257,13 @@ function VisXZoom({
 }
 
 VisXZoom.propTypes = {
+  /** Allow window scrolling with the mouse wheel. */
+  allowsScrolling: PropTypes.bool,
   /** 
    * Custom constraints on the SVG transformation matrix.
    * https://airbnb.io/visx/docs/zoom#Zoom_constrain
   */
   constrain: PropTypes.func,
-  /** Disable window scrolling for the mouse wheel. */
-  disablesScrolling: PropTypes.bool,
   /** Height in SVG viewport. */
   height: PropTypes.number.isRequired,
   /** Left coordinate in SVG viewport. */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -55,7 +55,7 @@ function VisXZoom({
   function onWheel(event) {
     // allow the page to scroll unless scrolling is disabled.
     if (!disablesScrolling) document.body.style.overflow = ''
-    if (disablesScrolling || event.shiftKey) {
+    if (disablesScrolling || event.ctrlKey) {
       // override body overflow to prevent scrolling in Safari.
       document.body.style.overflow = 'hidden'
       event.preventDefault()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -54,16 +54,30 @@ function VisXZoom({
 
   const wheelHandler = zooming ? (e) => zoomRef.current?.handleWheel(e) : DEFAULT_HANDLER
   const throttledWheelHandler = throttle(wheelHandler, zoomConfiguration?.onWheelThrottleWait)
+  
   function onWheel(event) {
-    // allow the page to scroll unless scrolling is disabled.
-    if (!disablesScrolling) document.body.style.overflow = ''
-    if (disablesScrolling || event[ZOOM_HOT_KEY]) {
-      // override body overflow to prevent scrolling in Safari.
-      document.body.style.overflow = 'hidden'
+    if (disablesScrolling) {
       event.preventDefault()
       return throttledWheelHandler(event)
     }
+    
+    if (!disablesScrolling) {
+      if (event[ZOOM_HOT_KEY]) {
+        const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
+        if (scrollbarWidth) {
+          document.body.style.paddingRight = `${scrollbarWidth}px`
+          document.body.style.overflow = 'hidden'
+        }
+
+        event.preventDefault()
+        return throttledWheelHandler(event)
+      } else {
+        document.body.style.overflow = ''
+        document.body.style.paddingRight = ''
+      }
+    }
   }
+  
   useWheel(move ? ({ event }) => onWheel(event) : DEFAULT_HANDLER, {
     eventOptions: { passive: false },
     target: wheelEventLayer
@@ -133,12 +147,10 @@ function VisXZoom({
   }
 
   function onPointerEnter() {
-    if (zooming) {
+    if (zooming && disablesScrolling) {
       const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
       document.body.style.paddingRight = `${scrollbarWidth}px`
-      if (disablesScrolling) {
-        document.body.style.overflow = 'hidden'
-      }
+      document.body.style.overflow = 'hidden'
     }
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -22,6 +22,7 @@ const DEFAULT_HANDLER = () => true
 
 function VisXZoom({
   constrain,
+  disablesScrolling = true,
   height,
   left = 0,
   move = false,
@@ -52,7 +53,7 @@ function VisXZoom({
   const wheelHandler = move && zooming ? (e) => zoomRef.current?.handleWheel(e) : DEFAULT_HANDLER
   const throttledWheelHandler = throttle(wheelHandler, zoomConfiguration?.onWheelThrottleWait)
   useWheel(({ event }) => {
-    if (event.shiftKey) {
+    if (disablesScrolling || event.shiftKey) {
       event.preventDefault()
       return throttledWheelHandler(event)
     }
@@ -128,11 +129,15 @@ function VisXZoom({
     if (zooming) {
       const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
       document.body.style.paddingRight = `${scrollbarWidth}px`
+      if (disablesScrolling) {
+        document.body.style.overflow = 'hidden'
+      }
     }
   }
 
   function onPointerLeave() {
     if (zooming) {
+      document.body.style.overflow = ''
       document.body.style.paddingRight = ''
     }
 
@@ -185,7 +190,7 @@ function VisXZoom({
                 onPointerUp={panning ? _zoom.dragEnd : DEFAULT_HANDLER}
                 onPointerLeave={onPointerLeave}
                 onWheel={(event) => {
-                  if (event.shiftKey) {
+                  if (disablesScrolling || event.shiftKey) {
                     event.preventDefault()
                     return throttledOnWheel(event)
                   }
@@ -204,6 +209,7 @@ function VisXZoom({
 
 VisXZoom.propTypes = {
   constrain: PropTypes.func,
+  disablesScrolling: PropTypes.bool,
   height: PropTypes.number.isRequired,
   left: PropTypes.number,
   move: PropTypes.bool,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -52,8 +52,10 @@ function VisXZoom({
   const wheelHandler = move && zooming ? (e) => zoomRef.current?.handleWheel(e) : DEFAULT_HANDLER
   const throttledWheelHandler = throttle(wheelHandler, zoomConfiguration?.onWheelThrottleWait)
   useWheel(({ event }) => {
-    event.preventDefault()
-    return throttledWheelHandler(event)
+    if (event.shiftKey) {
+      event.preventDefault()
+      return throttledWheelHandler(event)
+    }
   }, {
     eventOptions: { passive: false },
     target: wheelEventLayer
@@ -125,14 +127,12 @@ function VisXZoom({
   function onPointerEnter() {
     if (zooming) {
       const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
-      document.body.style.overflow = 'hidden'
       document.body.style.paddingRight = `${scrollbarWidth}px`
     }
   }
 
   function onPointerLeave() {
     if (zooming) {
-      document.body.style.overflow = ''
       document.body.style.paddingRight = ''
     }
 
@@ -184,7 +184,12 @@ function VisXZoom({
                 onPointerMove={panning ? _zoom.dragMove : DEFAULT_HANDLER}
                 onPointerUp={panning ? _zoom.dragEnd : DEFAULT_HANDLER}
                 onPointerLeave={onPointerLeave}
-                onWheel={throttledOnWheel}
+                onWheel={(event) => {
+                  if (event.shiftKey) {
+                    event.preventDefault()
+                    return throttledOnWheel(event)
+                  }
+                }}
                 panning={panning}
                 tabIndex={0}
                 width={width}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -102,10 +102,12 @@ function VisXZoom({
     scrolling and remove scrollbars.
     */
     if (event[ZOOM_HOT_KEY]) {
+      // Get the scrollbar width, if the container can be scrolled.
+      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
       /* Disable scroll in Safari (or for passive wheel events.) */
       document.body.style.overflow = 'hidden'
-      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
       if (scrollbarWidth) {
+        // Prevent the page from jumping when the scrollbar is removed.
         document.body.style.paddingRight = `${scrollbarWidth}px`
       }
 
@@ -229,7 +231,6 @@ function VisXZoom({
           <g ref={wheelEventLayer}>
             <ZoomingComponent
               initialTransformMatrix={_zoom.initialTransformMatrix}
-              move={move}
               transformMatrix={_zoom.transformMatrix}
               transform={_zoom.toString()}
             >

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -53,7 +53,11 @@ function VisXZoom({
   const wheelHandler = zooming ? (e) => zoomRef.current?.handleWheel(e) : DEFAULT_HANDLER
   const throttledWheelHandler = throttle(wheelHandler, zoomConfiguration?.onWheelThrottleWait)
   function onWheel(event) {
+    // allow the page to scroll unless scrolling is disabled.
+    if (!disablesScrolling) document.body.style.overflow = ''
     if (disablesScrolling || event.shiftKey) {
+      // override body overflow to prevent scrolling in Safari.
+      document.body.style.overflow = 'hidden'
       event.preventDefault()
       return throttledWheelHandler(event)
     }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -50,14 +50,15 @@ function VisXZoom({
     return { scaleX: zoomValue, scaleY: zoomValue }
   }
 
-  const wheelHandler = move && zooming ? (e) => zoomRef.current?.handleWheel(e) : DEFAULT_HANDLER
+  const wheelHandler = zooming ? (e) => zoomRef.current?.handleWheel(e) : DEFAULT_HANDLER
   const throttledWheelHandler = throttle(wheelHandler, zoomConfiguration?.onWheelThrottleWait)
-  useWheel(({ event }) => {
+  function onWheel(event) {
     if (disablesScrolling || event.shiftKey) {
       event.preventDefault()
       return throttledWheelHandler(event)
     }
-  }, {
+  }
+  useWheel(move ? ({ event }) => onWheel(event) : DEFAULT_HANDLER, {
     eventOptions: { passive: false },
     target: wheelEventLayer
   })
@@ -146,13 +147,6 @@ function VisXZoom({
     zoomRef.current.dragEnd()
   }
 
-  function onWheel(event) {
-    if (zooming) {
-      zoomRef.current.handleWheel(event)
-    }
-  }
-  const throttledOnWheel = throttle(onWheel, zoomConfiguration?.onWheelThrottleWait)
-
   const ZoomingComponent = zoomingComponent
   return (
     <Zoom
@@ -189,12 +183,7 @@ function VisXZoom({
                 onPointerMove={panning ? _zoom.dragMove : DEFAULT_HANDLER}
                 onPointerUp={panning ? _zoom.dragEnd : DEFAULT_HANDLER}
                 onPointerLeave={onPointerLeave}
-                onWheel={(event) => {
-                  if (disablesScrolling || event.shiftKey) {
-                    event.preventDefault()
-                    return throttledOnWheel(event)
-                  }
-                }}
+                onWheel={onWheel}
                 panning={panning}
                 tabIndex={0}
                 width={width}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -22,6 +22,33 @@ const defaultZoomConfig = {
 
 const DEFAULT_HANDLER = () => true
 
+/**
+ * Decorate a React SVG component with zoom functionality from `@visx/zoom`.
+ * https://airbnb.io/visx/docs/zoom
+ * ```jsx
+ *   <VisXZoom
+ *     height={100}
+ *     width={100}
+ *     left={0}
+ *     top={0}
+ *     move
+ *     zooming
+ *     panning
+ *     disablesScrolling
+ *     zoomConfiguration={{
+ *       direction: 'both',
+ *       minZoom: 1,
+ *       maxZoom: 10,
+ *       zoomInValue: 1.2,
+ *       zoomOutValue: 0.8
+ *     }}
+ *     setOnPan={setOnPan}
+ *     setOnZoom={setOnZoom}
+ *     zoomingComponent={SVGComponent}
+ *     {...SVGComponentProps}
+ *   />
+ * ```
+ */
 function VisXZoom({
   constrain,
   disablesScrolling = true,
@@ -232,24 +259,45 @@ function VisXZoom({
 }
 
 VisXZoom.propTypes = {
+  /** 
+   * Custom constraints on the SVG transformation matrix.
+   * https://airbnb.io/visx/docs/zoom#Zoom_constrain
+  */
   constrain: PropTypes.func,
+  /** Disable window scrolling for the mouse wheel. */
   disablesScrolling: PropTypes.bool,
+  /** Height in SVG viewport. */
   height: PropTypes.number.isRequired,
+  /** Left coordinate in SVG viewport. */
   left: PropTypes.number,
+  /** True if pan and zoom is enabled in the subject toolbar. */
   move: PropTypes.bool,
+  /** Enable panning. Ignored if zooming is false. */
   panning: PropTypes.bool,
+  /** Set the subject toolbar's onPan callback in the classifier store. */
   setOnPan: PropTypes.func,
+  /** Set the subject toolbar's onZoom callback in the classifier store. */
   setOnZoom: PropTypes.func,
+  /** Top coordinate in SVG viewport. */
   top: PropTypes.number,
+  /** Width in SVG viewport. */
   width: PropTypes.number.isRequired,
+  /** Zoom configuration for the subject or workflow. */
   zoomConfiguration: PropTypes.shape({
+    /** Allowed directions for zoom. */
     direction: PropTypes.oneOf(['both', 'x', 'y']),
+    /** Minimum zoom scale. */
     minZoom: PropTypes.number,
+    /** Maximum zoom scale. */
     maxZoom: PropTypes.number,
+    /** Zoom in scale step. */
     zoomInValue: PropTypes.number,
+    /** Zoom out scale step. */
     zoomOutValue: PropTypes.number
   }),
+  /** Enable zooming. true by default. */
   zooming: PropTypes.bool,
+  /** A React component to zoom. It must render SVG, **not** HTML. */
   zoomingComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -9,6 +9,8 @@ import { useEffect, useRef } from 'react'
 import { useKeyZoom } from '@hooks'
 import ZoomEventLayer from '../ZoomEventLayer'
 
+export const ZOOM_HOT_KEY = 'ctrlKey'
+
 const defaultZoomConfig = {
   direction: 'both',
   minZoom: 1,
@@ -55,7 +57,7 @@ function VisXZoom({
   function onWheel(event) {
     // allow the page to scroll unless scrolling is disabled.
     if (!disablesScrolling) document.body.style.overflow = ''
-    if (disablesScrolling || event.ctrlKey) {
+    if (disablesScrolling || event[ZOOM_HOT_KEY]) {
       // override body overflow to prevent scrolling in Safari.
       document.body.style.overflow = 'hidden'
       event.preventDefault()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -219,7 +219,6 @@ function VisXZoom({
       scaleXMax={zoomConfiguration.maxZoom}
       scaleYMin={zoomConfiguration.minZoom}
       scaleYMax={zoomConfiguration.maxZoom}
-      passive
       top={top}
       width={width}
       wheelDelta={wheelDelta}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
@@ -9,7 +9,7 @@ import mockStore from '@test/mockStore'
 import {
   lightCurveMockData
 } from '../../ScatterPlotViewer/helpers/mockData'
-import VisXZoom from './VisXZoom'
+import VisXZoom, { ZOOM_HOT_KEY } from './VisXZoom'
 import ZoomEventLayer from '../ZoomEventLayer'
 
 describe('Component > VisXZoom', function () {
@@ -393,7 +393,7 @@ describe('Component > VisXZoom', function () {
           clientY: 50,
           deltaY: -1,
           preventDefault: sinon.spy(),
-          shiftKey: true
+          [ZOOM_HOT_KEY]: true
         }
         // these are defaults set in the VisXZoom component
         const baseZoomValue = (eventMock.deltaY < 0) ? 1.2 : 0.8
@@ -468,7 +468,7 @@ describe('Component > VisXZoom', function () {
           clientY: 50,
           deltaY: -1,
           preventDefault: sinon.spy(),
-          shiftKey: true
+          [ZOOM_HOT_KEY]: true
         }
 
         // zooming in first
@@ -481,7 +481,7 @@ describe('Component > VisXZoom', function () {
           clientY: 50,
           deltaY: 10,
           preventDefault: sinon.spy(),
-          shiftKey: true
+          [ZOOM_HOT_KEY]: true
         }
 
         testEvent({ wrapper, type: 'wheel', event: zoomOutEvent, previousTransformMatrix: zoomedInTransformMatrix })
@@ -1049,21 +1049,21 @@ describe('Component > VisXZoom', function () {
           clientY: 50,
           deltaY: 10,
           preventDefault: sinon.spy(),
-          shiftKey: true
+          [ZOOM_HOT_KEY]: true
         })
         wrapper.find(ZoomEventLayer).simulate('wheel', {
           clientX: 50,
           clientY: 50,
           deltaY: 10,
           preventDefault: sinon.spy(),
-          shiftKey: true
+          [ZOOM_HOT_KEY]: true
         })
         wrapper.find(ZoomEventLayer).simulate('wheel', {
           clientX: 50,
           clientY: 50,
           deltaY: 10,
           preventDefault: sinon.spy(),
-          shiftKey: true
+          [ZOOM_HOT_KEY]: true
         })
         const firstZoomedOutTransformMatrix = wrapper.find(StubComponent).props().transformMatrix
         wrapper.find(ZoomEventLayer).simulate('wheel', {
@@ -1071,7 +1071,7 @@ describe('Component > VisXZoom', function () {
           clientY: 50,
           deltaY: 10,
           preventDefault: sinon.spy(),
-          shiftKey: true
+          [ZOOM_HOT_KEY]: true
         })
         const secondZoomedOutTransformMatrix = wrapper.find(StubComponent).props().transformMatrix
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
@@ -392,7 +392,8 @@ describe('Component > VisXZoom', function () {
           clientX: 50,
           clientY: 50,
           deltaY: -1,
-          preventDefault: sinon.spy()
+          preventDefault: sinon.spy(),
+          shiftKey: true
         }
         // these are defaults set in the VisXZoom component
         const baseZoomValue = (eventMock.deltaY < 0) ? 1.2 : 0.8
@@ -420,7 +421,6 @@ describe('Component > VisXZoom', function () {
 
         expect(document.body.style.overflow).to.be.empty()
         wrapper.find(ZoomEventLayer).simulate('pointerenter')
-        expect(document.body.style.overflow).to.equal('hidden')
         wrapper.find(ZoomEventLayer).simulate('pointerleave')
         expect(document.body.style.overflow).to.be.empty()
       })
@@ -467,7 +467,8 @@ describe('Component > VisXZoom', function () {
           clientX: 50,
           clientY: 50,
           deltaY: -1,
-          preventDefault: sinon.spy()
+          preventDefault: sinon.spy(),
+          shiftKey: true
         }
 
         // zooming in first
@@ -479,7 +480,8 @@ describe('Component > VisXZoom', function () {
           clientX: 50,
           clientY: 50,
           deltaY: 10,
-          preventDefault: sinon.spy()
+          preventDefault: sinon.spy(),
+          shiftKey: true
         }
 
         testEvent({ wrapper, type: 'wheel', event: zoomOutEvent, previousTransformMatrix: zoomedInTransformMatrix })
@@ -1046,26 +1048,30 @@ describe('Component > VisXZoom', function () {
           clientX: 50,
           clientY: 50,
           deltaY: 10,
-          preventDefault: sinon.spy()
+          preventDefault: sinon.spy(),
+          shiftKey: true
         })
         wrapper.find(ZoomEventLayer).simulate('wheel', {
           clientX: 50,
           clientY: 50,
           deltaY: 10,
-          preventDefault: sinon.spy()
+          preventDefault: sinon.spy(),
+          shiftKey: true
         })
         wrapper.find(ZoomEventLayer).simulate('wheel', {
           clientX: 50,
           clientY: 50,
           deltaY: 10,
-          preventDefault: sinon.spy()
+          preventDefault: sinon.spy(),
+          shiftKey: true
         })
         const firstZoomedOutTransformMatrix = wrapper.find(StubComponent).props().transformMatrix
         wrapper.find(ZoomEventLayer).simulate('wheel', {
           clientX: 50,
           clientY: 50,
           deltaY: 10,
-          preventDefault: sinon.spy()
+          preventDefault: sinon.spy(),
+          shiftKey: true
         })
         const secondZoomedOutTransformMatrix = wrapper.find(StubComponent).props().transformMatrix
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
@@ -393,7 +393,6 @@ describe('Component > VisXZoom', function () {
           clientY: 50,
           deltaY: -1,
           preventDefault: sinon.spy(),
-          [ZOOM_HOT_KEY]: true
         }
         // these are defaults set in the VisXZoom component
         const baseZoomValue = (eventMock.deltaY < 0) ? 1.2 : 0.8
@@ -419,6 +418,7 @@ describe('Component > VisXZoom', function () {
           </Grommet>
         )
 
+        expect(document.body.style.overflow).to.be.empty()
         wrapper.find(ZoomEventLayer).simulate('pointerenter')
         expect(document.body.style.overflow).to.equal('hidden')
         wrapper.find(ZoomEventLayer).simulate('pointerleave')
@@ -430,6 +430,7 @@ describe('Component > VisXZoom', function () {
           <Grommet theme={zooTheme}>
             <Provider classifierStore={store}>
               <VisXZoom
+                allowsScrolling
                 data={mockData}
                 height={height}
                 width={width}
@@ -443,7 +444,15 @@ describe('Component > VisXZoom', function () {
         const { initialTransformMatrix, transformMatrix } = wrapper.find(StubComponent).props()
         expect(transformMatrix).to.deep.equal(initialTransformMatrix)
 
-        testEvent({ wrapper, type: 'wheel', previousTransformMatrix: initialTransformMatrix })
+        const zoomInEvent = {
+          clientX: 50,
+          clientY: 50,
+          deltaY: -1,
+          preventDefault: sinon.spy(),
+          [ZOOM_HOT_KEY]: true
+        }
+
+        testEvent({ wrapper, type: 'wheel', event: zoomInEvent, previousTransformMatrix: initialTransformMatrix })
       })
 
       it('should scale out the transform matrix on mouse wheel', function () {
@@ -451,6 +460,7 @@ describe('Component > VisXZoom', function () {
           <Grommet theme={zooTheme}>
             <Provider classifierStore={store}>
               <VisXZoom
+                allowsScrolling
                 data={mockData}
                 height={height}
                 width={width}
@@ -1049,21 +1059,18 @@ describe('Component > VisXZoom', function () {
           clientY: 50,
           deltaY: 10,
           preventDefault: sinon.spy(),
-          [ZOOM_HOT_KEY]: true
         })
         wrapper.find(ZoomEventLayer).simulate('wheel', {
           clientX: 50,
           clientY: 50,
           deltaY: 10,
           preventDefault: sinon.spy(),
-          [ZOOM_HOT_KEY]: true
         })
         wrapper.find(ZoomEventLayer).simulate('wheel', {
           clientX: 50,
           clientY: 50,
           deltaY: 10,
           preventDefault: sinon.spy(),
-          [ZOOM_HOT_KEY]: true
         })
         const firstZoomedOutTransformMatrix = wrapper.find(StubComponent).props().transformMatrix
         wrapper.find(ZoomEventLayer).simulate('wheel', {
@@ -1071,7 +1078,6 @@ describe('Component > VisXZoom', function () {
           clientY: 50,
           deltaY: 10,
           preventDefault: sinon.spy(),
-          [ZOOM_HOT_KEY]: true
         })
         const secondZoomedOutTransformMatrix = wrapper.find(StubComponent).props().transformMatrix
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
@@ -419,8 +419,8 @@ describe('Component > VisXZoom', function () {
           </Grommet>
         )
 
-        expect(document.body.style.overflow).to.be.empty()
         wrapper.find(ZoomEventLayer).simulate('pointerenter')
+        expect(document.body.style.overflow).to.equal('hidden')
         wrapper.find(ZoomEventLayer).simulate('pointerleave')
         expect(document.body.style.overflow).to.be.empty()
       })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
@@ -395,7 +395,9 @@ describe('Component > VisXZoom', function () {
           preventDefault: sinon.spy()
         }
         // these are defaults set in the VisXZoom component
-        const zoomValue = (eventMock.deltaY < 0) ? 1.2 : 0.8
+        const baseZoomValue = (eventMock.deltaY < 0) ? 1.2 : 0.8
+        const wheelZoomValue = (eventMock.deltaY < 0) ? 1.1 : 0.9
+        const zoomValue = (type === 'wheel') ? wheelZoomValue : baseZoomValue
         wrapper.find(ZoomEventLayer).simulate(type, eventMock)
         const currentTransformMatrix = wrapper.find(StubComponent).props().transformMatrix
         testTransformations({ currentTransformMatrix, previousTransformMatrix, zoomValue })
@@ -1039,8 +1041,19 @@ describe('Component > VisXZoom', function () {
         const zoomedInTransformMatrix = wrapper.find(StubComponent).props().transformMatrix
         expect(zoomedInTransformMatrix).to.not.deep.equal(initialTransformMatrix)
 
-        // zoom out by mouse wheel
-        // 1 * 1.2 * 1.2 * 0.8 is 1.152 then * 0.8 is 0.9216
+        // zoom out by mouse wheel until we stop at the minimum zoom
+        wrapper.find(ZoomEventLayer).simulate('wheel', {
+          clientX: 50,
+          clientY: 50,
+          deltaY: 10,
+          preventDefault: sinon.spy()
+        })
+        wrapper.find(ZoomEventLayer).simulate('wheel', {
+          clientX: 50,
+          clientY: 50,
+          deltaY: 10,
+          preventDefault: sinon.spy()
+        })
         wrapper.find(ZoomEventLayer).simulate('wheel', {
           clientX: 50,
           clientY: 50,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types'
 import VisXZoom from '../../../SVGComponents/VisXZoom'
 import {
@@ -49,18 +48,21 @@ const defaultZoomConfig = {
 }
 
 function ZoomingScatterPlot({
-  data,
-  invertAxes = defaultInvertAxes,
-  margin = defaultMargin,
-  padding = defaultPadding,
   panning = true,
-  parentHeight,
-  parentWidth,
-  tickDirection = 'outer',
   zoomConfiguration = defaultZoomConfig,
   zooming = true,
-  ...props
+  ...scatterPlotProps
 }) {
+  const {
+    data,
+    invertAxes = defaultInvertAxes,
+    margin = defaultMargin,
+    padding = defaultPadding,
+    parentHeight,
+    parentWidth,
+    tickDirection = 'outer'
+  } = scatterPlotProps
+
   const rangeParameters = {
     invertAxes,
     margin,
@@ -205,47 +207,22 @@ function ZoomingScatterPlot({
   return (
     <VisXZoom
       constrain={constrain}
-      data={data}
       height={height}
-      invertAxes={invertAxes}
       left={leftPosition}
-      margin={margin}
-      padding={padding}
       panning={panning}
-      parentHeight={parentHeight}
-      parentWidth={parentWidth}
-      tickDirection={tickDirection}
       top={topPosition}
       width={width}
-      zoomingComponent={ScatterPlot}
+      zoomingComponent={(zoomProps) => (
+        <ScatterPlot {...zoomProps} {...scatterPlotProps} />
+      )}
       zoomConfiguration={zoomConfiguration}
       zooming={zooming}
-      {...props}
     />
   )
 }
 
 ZoomingScatterPlot.propTypes = {
-  invertAxes: PropTypes.shape({
-    x: PropTypes.bool,
-    y: PropTypes.bool
-  }),
-  margin: PropTypes.shape({
-    bottom: PropTypes.number,
-    left: PropTypes.number,
-    right: PropTypes.number,
-    top: PropTypes.number
-  }),
-  padding: PropTypes.shape({
-    bottom: PropTypes.number,
-    left: PropTypes.number,
-    right: PropTypes.number,
-    top: PropTypes.number
-  }),
   panning: PropTypes.bool,
-  parentHeight: PropTypes.number.isRequired,
-  parentWidth: PropTypes.number.isRequired,
-  tickDirection: PropTypes.oneOf(['inner', 'outer']),
   zoomConfiguration: PropTypes.shape({
     direction: PropTypes.oneOf(['both', 'x', 'y']),
     minZoom: PropTypes.number,
@@ -253,7 +230,8 @@ ZoomingScatterPlot.propTypes = {
     zoomInValue: PropTypes.number,
     zoomOutValue: PropTypes.number
   }),
-  zooming: PropTypes.bool
+  zooming: PropTypes.bool,
+  ...ScatterPlot.propTypes
 }
 
 export default ZoomingScatterPlot

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.js
@@ -10,6 +10,7 @@ import {
 import { PAN_DISTANCE } from '../../helpers/constants'
 import ScatterPlot from '../ScatterPlot'
 
+const DEFAULT_HANDLER = () => true
 
 const DEFAULT_ZOOM = {
   scaleX: 1,
@@ -49,6 +50,8 @@ const defaultZoomConfig = {
 
 function ZoomingScatterPlot({
   panning = true,
+  setOnPan = DEFAULT_HANDLER,
+  setOnZoom = DEFAULT_HANDLER,
   zoomConfiguration = defaultZoomConfig,
   zooming = true,
   ...scatterPlotProps
@@ -212,6 +215,8 @@ function ZoomingScatterPlot({
       panning={panning}
       top={topPosition}
       width={width}
+      setOnPan={setOnPan}
+      setOnZoom={setOnZoom}
       zoomingComponent={(zoomProps) => (
         <ScatterPlot {...zoomProps} {...scatterPlotProps} />
       )}
@@ -223,6 +228,8 @@ function ZoomingScatterPlot({
 
 ZoomingScatterPlot.propTypes = {
   panning: PropTypes.bool,
+  setOnPan: PropTypes.func,
+  setOnZoom: PropTypes.func,
   zoomConfiguration: PropTypes.shape({
     direction: PropTypes.oneOf(['both', 'x', 'y']),
     minZoom: PropTypes.number,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.spec.js
@@ -150,6 +150,7 @@ describe('Component > ZoomingScatterPlot', function() {
         expect(yAxisLabelPreZoomIn).to.not.equal(yAxisLabelPostZoomIn)
         // Zoom out
         fireEvent.wheel(getByTestId('zoom-layer'), zoomOutEventMock)
+        fireEvent.wheel(getByTestId('zoom-layer'), zoomOutEventMock)
         const pointTransformPostZoomOut = container.querySelector('.visx-glyph').getAttribute('transform')
         const xAxisLabelPostZoomOut = container.querySelector('.visx-axis-bottom').querySelector('tspan').innerHTML
         const yAxisLabelPostZoomOut = container.querySelector('.visx-axis-left').querySelector('tspan').innerHTML
@@ -278,6 +279,7 @@ describe('Component > ZoomingScatterPlot', function() {
         expect(xAxisLabelPreZoomIn).to.not.equal(xAxisLabelPostZoomIn)
         expect(yAxisLabelPreZoomIn).to.equal(yAxisLabelPostZoomIn)
         // Zoom out
+        fireEvent.wheel(getByTestId('zoom-layer'), zoomOutEventMock)
         fireEvent.wheel(getByTestId('zoom-layer'), zoomOutEventMock)
         const pointTransformPostZoomOut = container.querySelector('.visx-glyph').getAttribute('transform')
         const xAxisLabelPostZoomOut = container.querySelector('.visx-axis-bottom').querySelector('tspan').innerHTML
@@ -408,6 +410,7 @@ describe('Component > ZoomingScatterPlot', function() {
         expect(xAxisLabelPreZoomIn).to.equal(xAxisLabelPostZoomIn)
         expect(yAxisLabelPreZoomIn).to.not.equal(yAxisLabelPostZoomIn)
         // Zoom out
+        fireEvent.wheel(getByTestId('zoom-layer'), zoomOutEventMock)
         fireEvent.wheel(getByTestId('zoom-layer'), zoomOutEventMock)
         const pointTransformPostZoomOut = container.querySelector('.visx-glyph').getAttribute('transform')
         const xAxisLabelPostZoomOut = container.querySelector('.visx-axis-bottom').querySelector('tspan').innerHTML

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.spec.js
@@ -37,14 +37,16 @@ describe('Component > ZoomingScatterPlot', function() {
     clientX: 50,
     clientY: 50,
     deltaY: -1,
-    preventDefault: sinon.spy()
+    preventDefault: sinon.spy(),
+    shiftKey: true
   }
 
   const zoomOutEventMock = {
     clientX: 50,
     clientY: 50,
     deltaY: 10,
-    preventDefault: sinon.spy()
+    preventDefault: sinon.spy(),
+    shiftKey: true
   }
 
   it('should render without crashing', function() {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.spec.js
@@ -37,16 +37,14 @@ describe('Component > ZoomingScatterPlot', function() {
     clientX: 50,
     clientY: 50,
     deltaY: -1,
-    preventDefault: sinon.spy(),
-    shiftKey: true
+    preventDefault: sinon.spy()
   }
 
   const zoomOutEventMock = {
     clientX: 50,
     clientY: 50,
     deltaY: 10,
-    preventDefault: sinon.spy(),
-    shiftKey: true
+    preventDefault: sinon.spy()
   }
 
   it('should render without crashing', function() {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageCanvas.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageCanvas.js
@@ -23,7 +23,6 @@ function SingleImageCanvas({
   src,
   subject,
   transform, // per VisXZoom
-  transformMatrix // per VisXZoom
 }) {
   const canvasLayer = useRef()
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -42,20 +42,6 @@ function SingleImageViewer({
     enableRotation()
   }, [])
 
-  const singleImageCanvasProps = {
-    enableInteractionLayer,
-    frame,
-    imgRef,
-    invert,
-    move,
-    naturalHeight,
-    naturalWidth,
-    onKeyDown,
-    rotation,
-    src,
-    subject
-  }
-
   return (
     <>
       {zoomControlFn && (
@@ -81,14 +67,29 @@ function SingleImageViewer({
           <VisXZoom
             disablesScrolling={false}
             height={naturalHeight}
+            move={move}
             panning={panning}
             setOnPan={setOnPan}
             setOnZoom={setOnZoom}
             width={naturalWidth}
             zoomConfiguration={DEFAULT_ZOOM_CONFIG}
-            zoomingComponent={SingleImageCanvas}
+            zoomingComponent={(zoomProps) => (
+              <SingleImageCanvas
+                {...zoomProps}
+                enableInteractionLayer={enableInteractionLayer}
+                frame={frame}
+                imgRef={imgRef}
+                invert={invert}
+                move={move}
+                naturalHeight={naturalHeight}
+                naturalWidth={naturalWidth}
+                onKeyDown={onKeyDown}
+                rotation={rotation}
+                src={src}
+                subject={subject}
+              />
+            )}
             zooming={zooming}
-            {...singleImageCanvasProps}
           />
         </svg>
       </Box>
@@ -97,38 +98,18 @@ function SingleImageViewer({
 }
 
 SingleImageViewer.propTypes = {
-  enableInteractionLayer: bool,
   enableRotation: func,
-  frame: number,
-  imgRef: shape({
-    current: shape({
-      naturalHeight: number,
-      naturalWidth: number,
-      src: string
-    })
-  }),
-  invert: bool,
   limitSubjectHeight: bool,
-  move: bool,
-  naturalHeight: number,
-  naturalWidth: number,
-  onKeyDown: func,
   panning: bool,
-  rotation: number,
   setOnPan: func,
   setOnZoom: func,
-  src: string,
-  subject: shape({
-    locations: arrayOf(shape({
-      url: string
-    }))
-  }),
   title: shape({
     id: string,
     text: string
   }),
   zoomControlFn: func,
-  zooming: bool
+  zooming: bool,
+  ...SingleImageCanvas.propTypes
 }
 
 export default SingleImageViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -65,7 +65,7 @@ function SingleImageViewer({
           viewBox={`0 0 ${naturalWidth} ${naturalHeight}`}
         >
           <VisXZoom
-            disablesScrolling={false}
+            allowsScrolling
             height={naturalHeight}
             move={move}
             panning={panning}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -75,7 +75,7 @@ function SingleImageViewer({
           <title id={title.id}>{title.text}</title>
         )}
         <svg
-          style={{ touchAction: 'none' }}
+          style={{ touchAction: 'pinch-zoom' }}
           viewBox={`0 0 ${naturalWidth} ${naturalHeight}`}
         >
           <VisXZoom

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -79,6 +79,7 @@ function SingleImageViewer({
           viewBox={`0 0 ${naturalWidth} ${naturalHeight}`}
         >
           <VisXZoom
+            disablesScrolling={false}
             height={naturalHeight}
             panning={panning}
             setOnPan={setOnPan}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5134,12 +5134,24 @@
   resolved "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.18.tgz"
   integrity sha512-O+qxBlKxPtYM/LyRnK/U5MhVA9kKHj4C2yHsUurDxNO0a8D1PHLz9YmMPh2UXGQE4wtSke03GsLqRsHbUvN9nw==
 
+"@use-gesture/core@10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.3.1.tgz#976c9421e905f0079d49822cfd5c2e56b808fc56"
+  integrity sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==
+
 "@use-gesture/react@^10.0.0-beta.22":
   version "10.2.18"
   resolved "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.18.tgz"
   integrity sha512-MJQ5q/huXIER3st3bsmuWA7lxcdwZd28KJoBPFPNxKFenjF47smaiCCf+dLjUBiTV0DiIYAN4pXK19KxwfnUgg==
   dependencies:
     "@use-gesture/core" "10.2.18"
+
+"@use-gesture/react@~10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@use-gesture/react/-/react-10.3.1.tgz#17a743a894d9bd9a0d1980c618f37f0164469867"
+  integrity sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==
+  dependencies:
+    "@use-gesture/core" "10.3.1"
 
 "@vercel/stega@^0.1.2":
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5129,24 +5129,12 @@
   resolved "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz"
   integrity sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA==
 
-"@use-gesture/core@10.2.18":
-  version "10.2.18"
-  resolved "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.18.tgz"
-  integrity sha512-O+qxBlKxPtYM/LyRnK/U5MhVA9kKHj4C2yHsUurDxNO0a8D1PHLz9YmMPh2UXGQE4wtSke03GsLqRsHbUvN9nw==
-
 "@use-gesture/core@10.3.1":
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.3.1.tgz#976c9421e905f0079d49822cfd5c2e56b808fc56"
   integrity sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==
 
-"@use-gesture/react@^10.0.0-beta.22":
-  version "10.2.18"
-  resolved "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.18.tgz"
-  integrity sha512-MJQ5q/huXIER3st3bsmuWA7lxcdwZd28KJoBPFPNxKFenjF47smaiCCf+dLjUBiTV0DiIYAN4pXK19KxwfnUgg==
-  dependencies:
-    "@use-gesture/core" "10.2.18"
-
-"@use-gesture/react@~10.3.1":
+"@use-gesture/react@^10.0.0-beta.22", "@use-gesture/react@~10.3.1":
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/@use-gesture/react/-/react-10.3.1.tgz#17a743a894d9bd9a0d1980c618f37f0164469867"
   integrity sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==


### PR DESCRIPTION
- In `VisXZoom`, listen for wheel events from the subject components (including the drawing canvas.)
- Explicitly set `passive: false` to allow `event.preventDefault()` in the wheel event listener (to turn off window scrolling.)
- Add the `move` prop so that we can enable/disable wheel zoom according to whether 'pan' is selected in the subject toolbar.
- Tune the wheel zoom parameters for a smoother zooming UX.
- Require the ~~Shift~~ Ctrl key for wheel zoom.
- Add an `allowsScrolling` prop. Disabling window scroll is the default behaviour for JSON data viewers with `VisXZoom`. When `allowsScrolling` is enabled, the mouse wheel scrolls the window by default, and zooms with the ~~Shift~~ Ctrl modifier key.
- a maintenance refactor: upgrade `VisXZoom` to use the [render props pattern](https://react.dev/reference/react/cloneElement#passing-data-with-a-render-prop). This change is more about future code maintainability and modernising the Zooniverse codebase than adding the new functionality here. With the render props pattern, you don't have to add the zooming component's props as extra props to `VisXZoom`, so there's a clear separation between eg. `VisXZoom` props and `SingleImageCanvas` props.

With these changes, you should be able to zoom in and out with the mouse wheel, even if there are marks drawn on top of the subject, and you'll need to use a modifier key to use scrolling zoom with images.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #6746 (but still allows you to drag drawn marks.)
- fixes #6758.

## How to Review
> [!IMPORTANT]
> I definitely recommend explicitly testing this PR in desktop Safari with a laptop trackpad. In Safari 18.3, I found that Safari would still scroll while zooming, where Firefox and Chrome canceled the default page scroll. My solution is to temporarily style the page body with `overflow: hidden` while the trackpad is zooming in Safari.

https://localhost:8080/?env=staging&project=markb-panoptes/test-project-1-mb-fem-lab&workflow=3847

In pan mode, you should be able to use wheel zoom (with the ~~Shift~~ Ctrl key) anywhere on the subject, even on top of drawn marks.


https://github.com/user-attachments/assets/b24dd8a8-69ff-41d0-817c-af8a1ad5c2ff

You can use the Scatter Plot Viewer > X Range Selection story, in the classifier storybook, to check that wheel zoom hasn't changed for Black Hole Hunters.

Try out a portrait subject, from NfN, here:
https://localhost:8080/?env=production&project=cmnbotany%2Fnotes-from-nature-capture-the-collections&workflow=27243



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated
