### PR TITLE
fix(a11y): single image viewer title

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.spec.js
@@ -11,7 +11,7 @@ describe('Component > Layouts > Centered', function () {
     // Mock the loading state transition
     Default.store.subjectViewer.onSubjectReady()
     
-    await waitFor(() => expect(screen.getByLabelText('Subject 1')).exists()) // img aria-label from SVGImage
+    await waitFor(() => expect(screen.getByTitle('Subject 1')).exists()) // subject viewer title
     await waitFor(() => expect(screen.getByText(mockTasks.init.strings.question)).exists()) // task question paragraph
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
@@ -12,7 +12,7 @@ describe('Component > Layouts > MaxWidth', function () {
     // Mock the loading state transition
     Default.store.subjectViewer.onSubjectReady()
 
-    await waitFor(() => expect(screen.getByLabelText('Subject 1')).exists()) // img aria-label from SVGImage
+    await waitFor(() => expect(screen.getByTitle('Subject 1')).exists()) // subject viewer title
     await waitFor(() => expect(screen.getByText(mockTasks.init.strings.question)).exists()) // task question paragraph
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.spec.js
@@ -10,7 +10,7 @@ describe('Component > Layouts > NoMaxWidth', function () {
     // Mock the loading state transition
     Default.store.subjectViewer.onSubjectReady()
 
-    await waitFor(() => expect(screen.getByLabelText('Subject 1')).exists()) // img aria-label from SVGImage
+    await waitFor(() => expect(screen.getByTitle('Subject 1')).exists()) // subject viewer title
     await waitFor(() => expect(screen.getByText(mockTasks.init.strings.question)).exists()) // task question paragraph
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -57,6 +57,10 @@ function SubjectViewer({
             onError={onError}
             onReady={onSubjectReady}
             subject={subject}
+            title={{
+              id: 'subject-title',
+              text: `Subject ${subject.id}`
+            }}
             viewerConfiguration={subject?.viewerConfiguration}
           />
         )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -57,13 +57,14 @@ function SingleImageViewer({
         overflow='hidden'
         width='100%'
       >
-        {title?.id && title?.text && (
-          <title id={title.id}>{title.text}</title>
-        )}
         <svg
           style={{ touchAction: 'pinch-zoom' }}
           viewBox={`0 0 ${naturalWidth} ${naturalHeight}`}
+          aria-labelledby={title?.id}
         >
+          {title?.id && title?.text && (
+            <title id={title.id}>{title.text}</title>
+          )}
           <VisXZoom
             allowsScrolling
             height={naturalHeight}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 
 const SUBJECT_IMAGE_URL = 'https://panoptes-uploads.zooniverse.org/production/subject_location/11f98201-1c3f-44d5-965b-e00373daeb18.jpeg'
 
-import Meta, { Default, Error, Loading, PanAndZoom } from './SingleImageViewer.stories'
+import Meta, { subject, Default, Error, Loading, PanAndZoom } from './SingleImageViewer.stories'
 
 describe('Component > SingleImageViewer', function () {
   describe('with a successful subject location request', function () {
@@ -18,7 +18,7 @@ describe('Component > SingleImageViewer', function () {
     describe('with title', function () {
       it('should render the title', function () {
         render(<DefaultStory />)
-        const title = screen.getByText('Subject 1234')
+        const title = screen.getByTitle(`Subject ${subject.id}`)
         expect(title).to.exist()
       })
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
@@ -9,7 +9,7 @@ import { SubjectFactory, WorkflowFactory } from '@test/factories'
 
 import SingleImageViewerContainer from './SingleImageViewerContainer'
 
-const subject = SubjectFactory.build({
+export const subject = SubjectFactory.build({
   locations: [{ 'image/jpeg': 'https://panoptes-uploads.zooniverse.org/production/subject_location/11f98201-1c3f-44d5-965b-e00373daeb18.jpeg' }]
 })
 
@@ -37,8 +37,8 @@ export function Default() {
         <SingleImageViewerContainer
           loadingState={asyncStates.success}
           title={{
-            id: '1234',
-            text: 'Subject 1234'
+            id: 'subject-title',
+            text: `Subject ${subject.id}`
           }}
         />
       </Box>


### PR DESCRIPTION
- Fix the `SingleImageViewer` title, which was being rendered outside the SVG.
- Fix the tests to catch missing titles.
- Add a default title for single image subjects.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## How to Review
Single image subjects should now be properly labelled in the accessibility tree. You should be able to check their accessible name in the storybook, with either Chrome or Firefox.

<img width="697" alt="The accessibility properties panel in Chrome dev tools, showing the properties of the root SVG element for a single image subject, including its accessible name." src="https://github.com/user-attachments/assets/d0685db7-b97d-4648-9110-1a0a88f45ef7" />


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated
