### PR TITLE
fix(storybook): fix classifier Image Toolbar stories

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.spec.js
@@ -1,7 +1,11 @@
 import { render, screen } from '@testing-library/react'
+import { composeStory } from '@storybook/react'
 import { Provider } from 'mobx-react'
 import mockStore from '@test/mockStore/mockStore.js'
 import ImageToolbar from './ImageToolbar'
+
+import * as storybook from './ImageToolbar.stories.js'
+const { default: Meta, ...stories } = storybook
 
 import {
   DrawingTaskFactory,
@@ -66,6 +70,12 @@ describe('Component > ImageToolbar', function () {
       } else {
         expect(screen.queryByLabelText('ImageToolbar.AnnotateButton.ariaLabel')).to.be.null()
       }
+    })
+  })
+  Object.entries(stories).forEach(([name, story]) => {
+    it(`renders the "${name}" story`, () => {
+      const Story = composeStory(story, Meta)
+      render(<Story />)
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.stories.js
@@ -4,7 +4,7 @@ import asyncStates from '@zooniverse/async-states'
 
 import { SubjectFactory, WorkflowFactory } from '@test/factories'
 import mockStore from '@test/mockStore'
-import { ViewerGrid } from '../Layout/components/NoMaxWidth/NoMaxWidth'
+import { ViewerGrid } from '../Layout/components/shared/StyledContainers'
 import MultiFrameViewer from '../SubjectViewer/components/MultiFrameViewer'
 import SingleImageViewer from '../SubjectViewer/components/SingleImageViewer'
 import SingleTextViewer from '../SubjectViewer/components/SingleTextViewer'


### PR DESCRIPTION
Add smoke tests for the ImageToolbar stories and fix a broken import.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier
## Linked Issue and/or Talk Post
- fixes #6762

## How to Review
Open the Image Toolbar stories in the classifier storybook.

I've added failing smoke tests for those stories, so this PR should be OK to merge once CI tests are passing again.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated
