### PR TITLE
lib-classifier: Refactor SingleImageViewer for limitSubjectHeight

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -1,12 +1,20 @@
 import { Box } from 'grommet'
 import { arrayOf, bool, func, number, shape, string } from 'prop-types'
 import { useEffect } from 'react'
+import styled, { css } from 'styled-components'
 
 import ZoomControlButton from '../ZoomControlButton'
 
 import VisXZoom from '../SVGComponents/VisXZoom'
 
 import SingleImageCanvas from './SingleImageCanvas'
+
+const StyledSVG = styled.svg`
+  background-color: ${props => props.theme.global.colors['light-4']};
+  touch-action: pinch-zoom;
+  max-width: ${props => props.$maxWidth};
+  ${props => props.$maxHeight && css`max-height: ${props.$maxHeight};`}
+`
 
 const DEFAULT_HANDLER = () => true
 const DEFAULT_ZOOM_CONFIG = {
@@ -24,6 +32,7 @@ function SingleImageViewer({
   frame = 0,
   imgRef,
   invert = false,
+  limitSubjectHeight = false,
   move = false,
   naturalHeight,
   naturalWidth,
@@ -56,6 +65,9 @@ function SingleImageViewer({
     subject
   }
 
+  const maxHeight = limitSubjectHeight ? `min(${naturalHeight}px, 90vh)` : null
+  const maxWidth = limitSubjectHeight ? `${naturalWidth}px` : '100%'
+
   return (
     <>
       {zoomControlFn && (
@@ -67,15 +79,15 @@ function SingleImageViewer({
       <Box
         align='flex-end'
         animation='fadeIn'
-        background='light-4'
         overflow='hidden'
         width='100%'
       >
         {title?.id && title?.text && (
           <title id={title.id}>{title.text}</title>
         )}
-        <svg
-          style={{ touchAction: 'none' }}
+        <StyledSVG
+          $maxHeight={maxHeight}
+          $maxWidth={maxWidth}
           viewBox={`0 0 ${naturalWidth} ${naturalHeight}`}
         >
           <VisXZoom
@@ -89,7 +101,7 @@ function SingleImageViewer({
             zooming={zooming}
             {...singleImageCanvasProps}
           />
-        </svg>
+        </StyledSVG>
       </Box>
     </>
   )


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- https://frontend.preview.zooniverse.org/projects/ssilverberg/disk-detective/classify/workflow/22260 is not limiting subject height as expected

## Describe your changes
- update single image components (Box, svg) to adjust per `limitSubjectHeight`
- previously the PlaceholderSVG wrapped and constrained width and height per `limitSubjectHeight`, then in #6390 the PlaceholderSVG was refactored to _not_ be the parent of the single image viewer and the new parent components were not updated to constrain width and height per `limitSubjectHeight` either

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
