### PR TITLE
VV: fix bug that limits the max number of marks.

### DIFF
--- a/packages/lib-subject-viewers/src/VolumetricViewer/helpers/pointColor.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/helpers/pointColor.js
@@ -24,12 +24,16 @@ export const pointColor = ({
   isThree = false,
   pointValue
 }) => {
+  // To allow infinite marks, we need to use loop through our colors
+  // We have to skip the 0th index for looping because that handles un-annotated points
+  const i = (annotationIndex % (ColorHues.length - 1)) + 1
+  
   // inactive colors are homogenous
   if (isInactive) {
-    return isThree ? ThreeColorsInactive[annotationIndex + 1] : CanvasColorsInactive[annotationIndex + 1]
+    return isThree ? ThreeColorsInactive[i] : CanvasColorsInactive[i]
   } else {
     const ref = isThree ? ThreeColors : CanvasColors
-    return ref[annotationIndex + 1][pointValue]
+    return ref[i][pointValue];
   }
 }
 

--- a/packages/lib-subject-viewers/src/VolumetricViewer/tests/pointColor.spec.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/tests/pointColor.spec.js
@@ -21,7 +21,27 @@ describe('Component > VolumetricViewer > pointColor', () => {
     expect(color).to.equal('hsl(60, 75%, 25%)')
   })
 
-  it('should generate the right black for annotated, three color', () => {
+  it('should generate the right color for annotated, three color', () => {
+    const color = pointColor({ annotationIndex: 1, isThree: true, pointValue: 0 })
+    expect(color).deep.to.equal({
+      isColor: true,
+      r: 0.16068267770835676,
+      g: 0.16068267770835684,
+      b: 0.005155668396761914
+    })
+  })
+
+  it('should generate the right color for annotated, three color, overloaded index', () => {
+    const color = pointColor({ annotationIndex: 13, isThree: true, pointValue: 0 })
+    expect(color).deep.to.equal({
+      isColor: true,
+      r: 0.16068267770835676,
+      g: 0.16068267770835684,
+      b: 0.005155668396761914
+    })
+  })
+
+  it('should generate the right color for annotated, three color, overloaded index', () => {
     const color = pointColor({ annotationIndex: 1, isThree: true, pointValue: 0 })
     expect(color).deep.to.equal({
       isColor: true,


### PR DESCRIPTION
## Package
- lib-subject-viewers

## Describe your changes
Fix color looping bug wherein creating a new mark with an annotationIndex greater than the number of colors generated should loop to the 1st color instead of erroring.

## How to Review
Load up the `lib-subject-viewers` storybook on production and this branch. Use "shift+click" to create at least 12 different marks on the 4x4x4 Story (any story works, this is the simplest example). This will fail in production and start re-looping through the colors. 

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated