### PR TITLE
Node 20.19+ compatibility: mark some packages as CommonJS

### DIFF
--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -5,6 +5,7 @@
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
   "version": "0.0.1",
   "main": "index.js",
+  "type": "commonjs",
   "scripts": {
     "build": "APP_ENV=${APP_ENV:-development} NODE_ENV=${NODE_ENV:-production} PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
     "dev": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-staging} node server/server.js",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -6,6 +6,7 @@
   "version": "0.0.1",
   "main": "dist/cjs/components/Classifier/index.js",
   "module": "dist/esm/components/Classifier/index.js",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/zooniverse/front-end-monorepo.git",

--- a/packages/lib-content/package.json
+++ b/packages/lib-content/package.json
@@ -6,6 +6,7 @@
   "version": "0.0.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "type": "commonjs",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -6,6 +6,7 @@
   "version": "1.13.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "type": "commonjs",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/lib-subject-viewers/package.json
+++ b/packages/lib-subject-viewers/package.json
@@ -6,6 +6,7 @@
   "version": "0.1.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "type": "commonjs",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/lib-user/package.json
+++ b/packages/lib-user/package.json
@@ -6,6 +6,7 @@
   "version": "0.1.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "type": "commonjs",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",


### PR DESCRIPTION
## PR Overview

This PR should hopefully fix the issue where our FEM tests are failing, by _explicitly_ marking packages as being _CommonJS_ packages (instead of the _new ESM default_ )

Context of the problem:
- We're using Node lts/iron to run our GitHub actions.[^1]
- lts/iron basically means Node 20.whatever [(link)](https://nodejs.org/en/blog/release/v20.9.0)
- _Recently,_[^2] that 20.x specifically meant Node 20.19...
- ...and Node 20.19 has a breaking change that made package ESM-types be default. [(link)](https://nodejs.org/en/blog/release/v20.19.0) (i.e. if "type" was missing in package.json, assume it's "type": "module")
- A lot of our packages didn't specify a type, and ran with the common assumption that it's a CommonJS package.
- As a result, a lot of our automated tests on GitHub went kaput. On local, we may not have noticed this, as we may have had different versions of node running (e.g. I'm running 20.10)

The solution:
- For each package that had its test crashed out, I can see that their package.json was missing an explicit "type" value.
- Solution was to add `"type": "commonjs"` to reinstate the _previous default behaviour_ of "treat this package as CommonJS".
- Credit to Jim for this solution. [(link)](https://github.com/zooniverse/front-end-monorepo/issues/3779#issuecomment-2737370217)

[^1]: Check our [/.github/workflow folder](https://github.com/zooniverse/front-end-monorepo/tree/42b42243a4875926ea6f450a50c8e87ac92a4a26/.github/workflows) various .yml files. For example, our [testing coverage file.](https://github.com/zooniverse/front-end-monorepo/blob/42b42243a4875926ea6f450a50c8e87ac92a4a26/.github/workflows/coverage.yml#L21)
[^2]: March 13 earliest, since that's when 20.19 was released. I'm writing this on 19 Mar.

Notes:
- Not all packages were updated with type=commonJS.
  - app-root explicitly has type=module
  - lib-grommet-theme has no explicit type, but doesn't run any tests, so this doesn't matter.
  - I will just shrug if you ask me about lib-async-states or lib-panoptes-js. 🤷 ~~These have tests and don't have explicit type=commonjs, yet aren't breaking.~~ Oh wait, they don't have **Storybook incorporated into their tests.**  That's the final ingredient in causing the breaking change!
- Longer-long term solution would be to make the packages actually ESM-compatible, but that's a story for another day.

### Status

Ready for review.

Delilah/Mark/Travis, if everything looks good, please go ahead and merge this. We'd also need to revert the short term fix in #6773 , I think.