### PR TITLE
lib-classifier: Refactor SingleImageViewer and VisXZoom back to component props

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -64,6 +64,7 @@ function VisXZoom({
   zoomConfiguration = defaultZoomConfig,
   zoomingComponent,
   zooming = false,
+  ...props
 }) {
   const { onKeyZoom } = useKeyZoom()
   const zoomRef = useRef(null)
@@ -233,6 +234,7 @@ function VisXZoom({
               initialTransformMatrix={_zoom.initialTransformMatrix}
               transformMatrix={_zoom.transformMatrix}
               transform={_zoom.toString()}
+              {...props}
             >
               <ZoomEventLayer
                 focusable

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -233,6 +233,7 @@ function VisXZoom({
               initialTransformMatrix={_zoom.initialTransformMatrix}
               transformMatrix={_zoom.transformMatrix}
               transform={_zoom.toString()}
+              move={move}
               {...props}
             >
               <ZoomEventLayer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -44,9 +44,8 @@ const DEFAULT_HANDLER = () => true
  *     }}
  *     setOnPan={setOnPan}
  *     setOnZoom={setOnZoom}
- *     zoomingComponent={(zoomProps) => (
- *       <SVGComponent {...zoomProps} {...SVGComponentProps} />
- *     )}
+ *     zoomingComponent={SVGComponent}
+ *     ...props
  *   />
  * ```
  */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.js
@@ -217,11 +217,10 @@ function ZoomingScatterPlot({
       width={width}
       setOnPan={setOnPan}
       setOnZoom={setOnZoom}
-      zoomingComponent={(zoomProps) => (
-        <ScatterPlot {...zoomProps} {...scatterPlotProps} />
-      )}
+      zoomingComponent={ScatterPlot}
       zoomConfiguration={zoomConfiguration}
       zooming={zooming}
+      {...scatterPlotProps}
     />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -56,7 +56,6 @@ function SingleImageViewer({
     frame,
     imgRef,
     invert,
-    move,
     naturalHeight,
     naturalWidth,
     onKeyDown,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -51,6 +51,20 @@ function SingleImageViewer({
     enableRotation()
   }, [])
 
+  const singleImageCanvasProps = {
+    enableInteractionLayer,
+    frame,
+    imgRef,
+    invert,
+    move,
+    naturalHeight,
+    naturalWidth,
+    onKeyDown,
+    rotation,
+    src,
+    subject
+  }
+
   const maxHeight = limitSubjectHeight ? `min(${naturalHeight}px, 90vh)` : null
   const maxWidth = limitSubjectHeight ? `${naturalWidth}px` : '100%'
 
@@ -86,23 +100,9 @@ function SingleImageViewer({
             setOnZoom={setOnZoom}
             width={naturalWidth}
             zoomConfiguration={DEFAULT_ZOOM_CONFIG}
-            zoomingComponent={(zoomProps) => (
-              <SingleImageCanvas
-                {...zoomProps}
-                enableInteractionLayer={enableInteractionLayer}
-                frame={frame}
-                imgRef={imgRef}
-                invert={invert}
-                move={move}
-                naturalHeight={naturalHeight}
-                naturalWidth={naturalWidth}
-                onKeyDown={onKeyDown}
-                rotation={rotation}
-                src={src}
-                subject={subject}
-              />
-            )}
+            zoomingComponent={SingleImageCanvas}
             zooming={zooming}
+            {...singleImageCanvasProps}
           />
         </StyledSVG>
       </Box>


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #6778 

## Describe your changes
- reverts refactor to use the render props pattern in SingleImageViewer and VisXZoom per #6757 back to component props
- the render props pattern is preferable to the component props pattern, so further investigation and refactoring is warranted, but for now, these changes fix a bug where the drawing mark subtask was opening when toggling between annotate and move modes

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - staging/testing
    - lib-classifier: https://local.zooniverse.org:8080/?project=1693&workflow=3838
    - app-project: https://local.zooniverse.org:3000/projects/markb-panoptes/test-project-1-mb-fem-lab/classify/workflow/3838?env=staging&demo=true
  - ⚠️  production ⚠️ 
    - app-project: https://local.zooniverse.org:3000/projects/printmigrationnetwork/print/classify/workflow/20199/subject-set/111070/subject/84319351?demo=true
- What user actions should my reviewer step through to review this PR?
  - create a (in test project point) mark, answer subtask, close subtask
  - toggle to pan/zoom aka move mode
  - note subtask doesn't re-open
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? yes, the refactor to render props is preferable, should work, further investigation and refactor necessary accordingly

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
