### PR TITLE
Tutorial: fix navigation breaking when too many steps

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/shared/StepNavigation/StepNavigation.js
+++ b/packages/lib-classifier/src/components/Classifier/components/shared/StepNavigation/StepNavigation.js
@@ -18,6 +18,7 @@ const StyledButton = styled(Button)`
 
 const StyledRadioButtonGroup = styled(RadioButtonGroup)`
   position: relative;
+  overflow: auto;
 
   > label {
     > span {

--- a/packages/lib-classifier/src/components/Classifier/components/shared/StepNavigation/StepNavigation.js
+++ b/packages/lib-classifier/src/components/Classifier/components/shared/StepNavigation/StepNavigation.js
@@ -16,9 +16,11 @@ const StyledButton = styled(Button)`
   }
 `
 
+// flex-wrap + gap are used to ensure if the Tutorial has too many steps, the 
 const StyledRadioButtonGroup = styled(RadioButtonGroup)`
   position: relative;
-  overflow: auto;
+  flex-wrap: wrap;
+  gap: 20px 0;
 
   > label {
     > span {


### PR DESCRIPTION
## PR Overview

Package: lib-classifier
Closes #6798 

This PR provides a _rudimentary fix_ for the Tutorial system's StepNavigation, to prevent the Tutorial UI from completely breaking when a tutorial has too many steps.

Before this patch:

<img width="470" alt="Image" src="https://github.com/user-attachments/assets/26083123-dad7-45f2-85cb-1abeee6c5ccd" />

After this patch:

<img width="468" alt="Image" src="https://github.com/user-attachments/assets/832dd95f-7c6a-401a-b4a4-a2e0eddf2945" />

<details>
<summary>(Previous solution:)</summary>

<img width="470" alt="Image" src="https://github.com/user-attachments/assets/0bc10925-d09b-4d88-8ec7-17d985ddb598" />

This solution was replaced [after this comment.](https://github.com/zooniverse/front-end-monorepo/pull/6799#issuecomment-2758633484)
</details>

### Status

Ready for review.