### PR TITLE
Implement ARIA recommendation for the Accordion pattern for the VV Planes view

### DIFF
--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/Plane.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/Plane.js
@@ -234,7 +234,7 @@ export const Plane = ({
     <StyledBox className={`plane-container plane-container-${dimension} ${expanded ? 'expanded' : 'collapsed'} no-select`} ref={containerRef}>
       <button
         aria-controls={`section-${planeId}`}
-        aria-expanded={expanded}
+        aria-expanded={expanded.toString()}
         aria-label={`Toggle ${viewer.dimensions[dimension]} Plane Visibility`}
         className={`plane-title ${expanded ? 'expanded' : 'collapsed'}`}
         id={`accordion-${planeId}`}

--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/Plane.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/Plane.js
@@ -4,7 +4,7 @@ import { number, object } from 'prop-types'
 import { pointColor } from './../helpers/pointColor.js'
 import { Slider } from './Slider'
 import styled, { css } from 'styled-components'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 
 const BACKGROUND_COLOR = '#000'
 const CANVAS_WIDTH = 330
@@ -19,6 +19,10 @@ const StyledBox = styled(Box)`
   border-radius: 16px;
   margin-bottom: 20px;
   width: 390px;
+
+  button {
+    border: none;
+  }
 
   &.expanded {
     border-bottom-right-radius: 0px;
@@ -106,6 +110,7 @@ export const Plane = ({
   const [currentFrameIndex, setCurrentFrameIndex] = useState(0)
   const canvasRef = useRef(null)
   const containerRef = useRef(null)
+  const planeId = useId();
 
   // Offscreen Canvas for fast rendering
   const frameCanvas = document.createElement('canvas')
@@ -227,18 +232,31 @@ export const Plane = ({
 
   return (
     <StyledBox className={`plane-container plane-container-${dimension} ${expanded ? 'expanded' : 'collapsed'} no-select`} ref={containerRef}>
-      <Box className={`plane-title ${expanded ? 'expanded' : 'collapsed'}`}>
+      <button
+        aria-controls={`section-${planeId}`}
+        aria-expanded={expanded}
+        aria-label={`Toggle ${viewer.dimensions[dimension]} Plane Visibility`}
+        className={`plane-title ${expanded ? 'expanded' : 'collapsed'}`}
+        id={`accordion-${planeId}`}
+        onClick={toggleContentVisibility}
+        type="button"
+      >
         <Box className='plane-title-dimension'>{viewer.getDimensionLabel({ dimension })}</Box>
         <Box className={`plane-title-frame`}>{hideCoor ? '' : currentFrameIndex}</Box>
-        <Box className='plane-title-label' onClick={toggleContentVisibility}>
+        <Box className='plane-title-label'>
           {expanded ? 'Collapse' : 'Expand'}
         </Box>
-        <div className='plane-title-toggle' onClick={toggleContentVisibility}>
+        <div className='plane-title-toggle'>
           {expanded ? <FormUp /> : <FormDown />}
         </div>
-      </Box>
+      </button>
       {expanded &&
-        <Box className='plane-content'>
+        <Box 
+          aria-labelledby={`accordion-${planeId}`}
+          className='plane-content'
+          id={`section-${planeId}`}
+          role="region"
+        >
           <Slider
             dimension={dimension}
             viewer={viewer}


### PR DESCRIPTION
## Package
- lib-subject-viewers

## Describe your changes
Implement the [ARIA Accordion Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/) for the Plane View of the Volumetric Viewer

## How to Review
- Running Storybook locally with the Volumetric Viewer, click anywhere on the header to expand/collapse the planar view. - Using the keyboard, test that the three required keyboard interactions work as expected from the ARIA Accordion Pattern page (enter, space, tab, shift+tab). 
- The whole header should be highlighted when its element is focused through keyboard navigation. 

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser