### PR TITLE
Update VV classification export to match the FreehandLine tool

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/README.md
@@ -9,3 +9,24 @@ The volumetric task does not support a required property.
 The volumetric task does not support tags (i.e. insertion, deletion).
 
 The volumetric task is disabled until the subject is loaded.
+
+## VolumetricAnnotation
+
+The volumetric annotation consists of the following structure:
+
+```json
+{
+  "label": "Annotation #1",
+  "threshold": 15,
+  "points": {
+    "active": [{ "x": 1, "y": 1, "z": 1 }],
+    "connected": [[{ "x": 1, "y": 1, "z": 1 }]],
+    "all": [{ "x": 1, "y": 1, "z": 1 }]
+  }
+}
+```
+
+- **threshold**: the value the A* algorithm uses to choose connected points
+- **points.active**: the individual voxel the user clicks
+- **points.connected**: the voxels connected to the index-adjusted active voxel using the threshold value for the a* algorithm
+- **points.all**: collapsed array of all points in active and connected

--- a/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/models/VolumetricAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/models/VolumetricAnnotation.js
@@ -1,17 +1,23 @@
 import { types } from 'mobx-state-tree'
 import Annotation from '../../../models/Annotation'
 
+const CoordinateModel = types.model('CoordinateModel', {
+  x: types.number,
+  y: types.number,
+  z: types.number
+})
+
 const PointsModel = types.model('PointsModel', {
-  active: types.array(types.number),
-  connected: types.array(types.array(types.number), []),
-  all: types.array(types.number),
-});
+  active: types.array(CoordinateModel),
+  connected: types.array(types.array(CoordinateModel), []),
+  all: types.array(CoordinateModel),
+})
 
 const AnnotationModel = types.model('AnnotationModel', {
   label: types.string,
   threshold: types.number,
   points: PointsModel,
-});
+})
 
 const Volumetric = types
   .model('Volumetric', {

--- a/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelAnnotations.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelAnnotations.js
@@ -192,14 +192,25 @@ export const ModelAnnotations = ({ onAnnotation }) => {
     publishCallback: () => {
       if (!onAnnotation) return
 
+      function absToRelative({ point }) {
+        const [ x, y, z ] = annotationModel.config.viewer.getPointCoordinates({ point })
+        return { x, y, z }
+      }
+
       const annotationExport = JSON.parse(JSON.stringify(annotationModel.annotations))
         .filter(a => a.points.active.length > 0)
         .map(a => { 
+          a.points.active = a.points.active.map(point => absToRelative({ point }))
           a.points.all = a.points.all.data
+          a.points.all = a.points.all.map(point => absToRelative({ point }))
+          a.points.connected = a.points.connected.map(pointArray => pointArray.map(point => absToRelative({ point })))
           return a
         })
+      
       onAnnotation(annotationExport)
 
+      // Publish the change for testing
+      annotationModel.publish('publish:annotation', annotationExport)
     },
     export: () => {
       return annotationModel.annotations.map(annotation => {

--- a/packages/lib-subject-viewers/src/VolumetricViewer/tests/ModelAnnotations.spec.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/tests/ModelAnnotations.spec.js
@@ -5,7 +5,8 @@ describe('Component > VolumetricViewer > ModelAnnotations', () => {
   const model = ModelAnnotations({ onAnnotation: () => {} })
   const viewerMock = {
     getPointAnnotationIndex: () => -1,
-    setPointsAnnotationIndex: () => {}
+    setPointsAnnotationIndex: () => {},
+    getPointCoordinates: ({ point }) => [point, point, point]
   }
 
   it('should have initial state', () => {
@@ -239,5 +240,34 @@ describe('Component > VolumetricViewer > ModelAnnotations', () => {
         threshold: ANNOTATION_THRESHOLD
       }
     ])
+  })
+
+  it('should publish data in the correct format', (done) => {
+    const publishListener = (data) => {
+      expect(data).deep.to.equal([
+        {
+          label: 'Annotation 3',
+          points: {
+            active: [{ x: 2, y: 2, z: 2 }],
+            connected: [[]],
+            all: []
+          },
+          threshold: ANNOTATION_THRESHOLD
+        },
+        {
+          label: 'Annotation 4',
+          points: {
+            active: [{ x: 3, y: 3, z: 3 }],
+            connected: [[]],
+            all: []
+          },
+          threshold: ANNOTATION_THRESHOLD
+        }
+      ])
+      done()
+    }
+
+    model.on('publish:annotation', publishListener)
+    model.publishCallback();
   })
 })


### PR DESCRIPTION
## Package
- lib-classifier
- lib-subject-viewer

## Describe your changes
Update the submitted classification that gets uploaded to Panoptes to match the Freehand Line method of having all points formatted as `{ x, y, z }`. 

## How to Review
Load up the classifier locally with a [test volumetric project](https://localhost:8080/?project=kieftrav/volumetric-viewer&env=staging), create a mark, submit classification, and inspect the `console.log()` of the classification export. The  format should be as follows:

```js
{
  points: {
    active: [{ x, y, z}],
    all: [{ x, y, z}],
    connected: [
      [{ x, y, z}],
    ],
  }
}
```

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser