### PR TITLE
Fix bug where the VV planar view wouldn't show an annotation if the histogram had removed its underlying color's voxel

### DIFF
--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/Plane.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/Plane.js
@@ -169,10 +169,10 @@ export const Plane = ({
   }
 
   function drawPoint ({ context, point, x, y }) {
-    // Draw points that are not in threshold same color as background
-    if (viewer.isPointInThreshold({ point })) {
-      const annotationIndex = viewer.getPointAnnotationIndex({ point })
+    const annotationIndex = viewer.getPointAnnotationIndex({ point })
 
+    // Draw points that are not in threshold same color as background
+    if (viewer.isPointInThreshold({ point }) || annotationIndex !== -1) {
       // isInactive makes all inactive marks less visible 
       const isInactive = (annotationIndex === -1)
         ? false


### PR DESCRIPTION
## Package
- lib-subject-viewers

## Describe your changes
When the Histogram controls are narrowed, all marks should remain visible regardless of if the underlying color has been removed from the histogram in the Plane view

## How to Review
Load up the Volumetric Viewer in the `lib-subject-viewer` Storybook. Annotate any voxel and then use the sliders for the histogram to hide voxels that are too dark / too light. It's possible to slide one slider all the way over to the other slider, making only marks visible (good for testing purposes). Before this change, marks would disappear in the Plane view.

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser