### PR TITLE
Update the VV annotation to only send active and connected points.

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/README.md
@@ -20,8 +20,7 @@ The volumetric annotation consists of the following structure:
   "threshold": 15,
   "points": {
     "active": [{ "x": 1, "y": 1, "z": 1 }],
-    "connected": [[{ "x": 1, "y": 1, "z": 1 }]],
-    "all": [{ "x": 1, "y": 1, "z": 1 }]
+    "connected": [[{ "x": 1, "y": 1, "z": 1 }]]
   }
 }
 ```
@@ -29,4 +28,3 @@ The volumetric annotation consists of the following structure:
 - **threshold**: the value the A* algorithm uses to choose connected points
 - **points.active**: the individual voxel the user clicks
 - **points.connected**: the voxels connected to the index-adjusted active voxel using the threshold value for the a* algorithm
-- **points.all**: collapsed array of all points in active and connected

--- a/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/models/VolumetricAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/models/VolumetricAnnotation.js
@@ -9,8 +9,7 @@ const CoordinateModel = types.model('CoordinateModel', {
 
 const PointsModel = types.model('PointsModel', {
   active: types.array(CoordinateModel),
-  connected: types.array(types.array(CoordinateModel), []),
-  all: types.array(CoordinateModel),
+  connected: types.array(types.array(CoordinateModel), [])
 })
 
 const AnnotationModel = types.model('AnnotationModel', {

--- a/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/models/VolumetricTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/volumetric/models/VolumetricTask.spec.js
@@ -24,8 +24,7 @@ describe("Model > VolumetricTask", function () {
     threshold: 15,
     points: {
       active: [],
-      connected: [],
-      all: []
+      connected: []
     }
   }]
 

--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/Plane.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/Plane.js
@@ -106,7 +106,7 @@ export const Plane = ({
   viewer
 }) => {
   const [hideCoor, setHideCoor] = useState()
-  const [expanded, setExpanded] = useState()
+  const [expanded, setExpanded] = useState(false)
   const [currentFrameIndex, setCurrentFrameIndex] = useState(0)
   const canvasRef = useRef(null)
   const containerRef = useRef(null)

--- a/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelAnnotations.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelAnnotations.js
@@ -201,9 +201,8 @@ export const ModelAnnotations = ({ onAnnotation }) => {
         .filter(a => a.points.active.length > 0)
         .map(a => { 
           a.points.active = a.points.active.map(point => absToRelative({ point }))
-          a.points.all = a.points.all.data
-          a.points.all = a.points.all.map(point => absToRelative({ point }))
           a.points.connected = a.points.connected.map(pointArray => pointArray.map(point => absToRelative({ point })))
+          delete a.points.all;
           return a
         })
       

--- a/packages/lib-subject-viewers/src/VolumetricViewer/tests/ModelAnnotations.spec.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/tests/ModelAnnotations.spec.js
@@ -249,8 +249,7 @@ describe('Component > VolumetricViewer > ModelAnnotations', () => {
           label: 'Annotation 3',
           points: {
             active: [{ x: 2, y: 2, z: 2 }],
-            connected: [[]],
-            all: []
+            connected: [[]]
           },
           threshold: ANNOTATION_THRESHOLD
         },
@@ -258,8 +257,7 @@ describe('Component > VolumetricViewer > ModelAnnotations', () => {
           label: 'Annotation 4',
           points: {
             active: [{ x: 3, y: 3, z: 3 }],
-            connected: [[]],
-            all: []
+            connected: [[]]
           },
           threshold: ANNOTATION_THRESHOLD
         }


### PR DESCRIPTION
## Describe your changes
Update the annotation export so that it only has the `connected` and `active` points and removes `all`. Follow on from #6802 

## How to Review
Load up the classifier locally with a [test volumetric project](https://localhost:8080/?project=kieftrav/volumetric-viewer&env=staging), create a mark, submit classification, and inspect the `console.log()` of the classification export. The  format should be as follows:

```js
{
  points: {
    active: [{ x, y, z}],
    connected: [
      [{ x, y, z}],
    ],
  }
}
```

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser