### PR TITLE
refactor(lib-classifier): clean up LineControls matrix calculations

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageCanvas.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageCanvas.js
@@ -20,6 +20,7 @@ function SingleImageCanvas({
   src,
   subject,
   transform, // per VisXZoom
+  transformMatrix,
 }) {
   const canvasLayer = useRef()
 
@@ -29,7 +30,8 @@ function SingleImageCanvas({
       <SVGContext.Provider
         value={{
           canvas: canvasLayer.current,
-          rotate: rotation
+          rotate: rotation,
+          transformMatrix
         }}
       >
         <svg

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
@@ -5,7 +5,6 @@ import { Tooltip } from '@zooniverse/react-components'
 import SVGContext from '../../../shared/SVGContext'
 import { useTranslation } from '@translations/i18n'
 import { Pan, Radial, Redo, Trash, Undo, Checkmark, Close } from 'grommet-icons'
-import useScale from '../../../hooks/useScale'
 
 const StyledGroup = styled.g`
   cursor: pointer;
@@ -28,21 +27,20 @@ const LineControls = forwardRef(function LineControls({
 },
   ref
 ) {
-  const scale = useScale()
   let [activePosition, setActivePosition] = useState('tl')
   let [showDeleteButtons, setShowDeleteButtons] = useState(false)
   const { t } = useTranslation('plugins')
+
+  const { canvas, rotate, transformMatrix = DEFAULT_TRANSFORM_MATRIX } = useContext(SVGContext)
+  const { scaleX, scaleY, translateX, translateY } = transformMatrix
 
   const FILL_COLOR = theme.dark ? '#333333' : '#ffffff'
   const STROKE_COLOR = theme.dark ? '#ffffff' : '#000000'
   const DELETE_CANCEL_COLOR = '#E45950'
   const DELETE_CONFIRM_COLOR = '#1ED359'
-  const STROKE_WIDTH = 0.5 / scale
-  const OUTER_RADIUS = 40 / scale
-  const INNER_RADIUS = 20 / scale
-
-  const { canvas, rotate, transformMatrix = DEFAULT_TRANSFORM_MATRIX } = useContext(SVGContext)
-  const { scaleX, scaleY, translateX, translateY } = transformMatrix
+  const STROKE_WIDTH = 0.5 / scaleX
+  const OUTER_RADIUS = 40 / scaleX
+  const INNER_RADIUS = 20 / scaleX
 
   const { width, height } = canvas.getBBox()
   const xLeft = (LINE_CONTROL_INSET - translateX) / scaleX
@@ -87,9 +85,9 @@ const LineControls = forwardRef(function LineControls({
       action: deleteMarkCancel,
       icon: {
         type: Close,
-        size: (16 / scale),
-        x: p.x - (27 / scale),
-        y: p.y - (8 / scale),
+        size: (16 / scaleX),
+        x: p.x - (27 / scaleX),
+        y: p.y - (8 / scaleY),
         color: DELETE_CANCEL_COLOR
       },
       path: `M ${p.x} ${p.y + OUTER_RADIUS}
@@ -102,9 +100,9 @@ const LineControls = forwardRef(function LineControls({
       action: deleteMarkConfirm,
       icon: {
         type: Checkmark,
-        size: (18 / scale),
-        x: p.x + (12 / scale),
-        y: p.y - (10 / scale),
+        size: (18 / scaleX),
+        x: p.x + (12 / scaleX),
+        y: p.y - (10 / scaleY),
         color: DELETE_CONFIRM_COLOR
       },
       path: `M ${p.x} ${p.y + OUTER_RADIUS}
@@ -119,9 +117,9 @@ const LineControls = forwardRef(function LineControls({
       action: undo,
       icon: {
         type: Undo,
-        size: (10 / scale),
-        x: p.x - (27 / scale),
-        y: p.y - (27 / scale),
+        size: (10 / scaleX),
+        x: p.x - (27 / scaleX),
+        y: p.y - (27 / scaleY),
         color: STROKE_COLOR
       },
       path: `M ${p.x - OUTER_RADIUS} ${p.y}
@@ -135,9 +133,9 @@ const LineControls = forwardRef(function LineControls({
       action: mark.redo,
       icon: {
         type: Redo,
-        size: (10 / scale),
-        x: p.x + (17 / scale),
-        y: p.y - (27 / scale),
+        size: (10 / scaleX),
+        x: p.x + (17 / scaleX),
+        y: p.y - (27 / scaleY),
         color: STROKE_COLOR
       },
       path: `M ${p.x + OUTER_RADIUS} ${p.y}
@@ -151,9 +149,9 @@ const LineControls = forwardRef(function LineControls({
       action: mark.close,
       icon: {
         type: Radial,
-        size: (10 / scale),
-        x: p.x - (27 / scale),
-        y: p.y + (17 / scale),
+        size: (10 / scaleX),
+        x: p.x - (27 / scaleX),
+        y: p.y + (17 / scaleY),
         color: STROKE_COLOR
       },
       path: `M ${p.x - OUTER_RADIUS} ${p.y}
@@ -167,9 +165,9 @@ const LineControls = forwardRef(function LineControls({
       action: deleteMark,
       icon: {
         type: Trash,
-        size: (10 / scale),
-        x: p.x + (17 / scale),
-        y: p.y + (17 / scale),
+        size: (10 / scaleX),
+        x: p.x + (17 / scaleX),
+        y: p.y + (17 / scaleY),
         color: STROKE_COLOR
       },
       path: `M ${p.x + OUTER_RADIUS} ${p.y}
@@ -185,9 +183,9 @@ const LineControls = forwardRef(function LineControls({
       },
       icon: {
         type: Pan,
-        size: (20 / scale),
-        x: p.x - (10 / scale),
-        y: p.y - (10 / scale),
+        size: (20 / scaleX),
+        x: p.x - (10 / scaleX),
+        y: p.y - (10 / scaleY),
         color: STROKE_COLOR
       },
       path: `M ${p.x - INNER_RADIUS} ${p.y}

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
@@ -11,6 +11,15 @@ const StyledGroup = styled.g`
   cursor: pointer;
   pointer-events: all !important;
 `
+const DEFAULT_TRANSFORM_MATRIX = {
+  scaleX: 1,
+  scaleY: 1,
+  skewX: 0,
+  skewY: 0,
+  translateX: 0,
+  translateY: 0
+}
+const LINE_CONTROL_INSET = 70
 
 const LineControls = forwardRef(function LineControls({
   mark,
@@ -32,21 +41,17 @@ const LineControls = forwardRef(function LineControls({
   const OUTER_RADIUS = 40 / scale
   const INNER_RADIUS = 20 / scale
 
-  const { canvas, rotate } = useContext(SVGContext)
-
-  // Get the transformation that's been applied to a parent element
-  const canvasSVG = canvas.closest('svg')
-  const matrix = canvasSVG.firstChild.getCTM()
-  const { a: hScale, d: vScale, e: hTranslate, f: vTranslate } = matrix
-  const LINE_CONTROL_INSET = 70;
+  const { canvas, rotate, transformMatrix = DEFAULT_TRANSFORM_MATRIX } = useContext(SVGContext)
+  const { scaleX, scaleY, translateX, translateY } = transformMatrix
 
   const { width, height } = canvas.getBBox()
-  const x = (LINE_CONTROL_INSET - hTranslate) / hScale
-  const y = (LINE_CONTROL_INSET - vTranslate) / vScale
+  const xLeft = (LINE_CONTROL_INSET - translateX) / scaleX
+  const xRight = (width - translateX - LINE_CONTROL_INSET) / scaleX
+  const y = (LINE_CONTROL_INSET - translateY) / scaleY
 
   const p = (activePosition === 'tl')
-    ? { x, y }
-    : { x: x + ((width - (LINE_CONTROL_INSET * 2)) / hScale), y }
+    ? { x: xLeft, y }
+    : { x: xRight, y }
 
   function onEnterOrSpace(ev, func) {
     if (ev.keyCode === 13 || ev.keyCode === 32) {

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
@@ -35,7 +35,7 @@ const LineControls = forwardRef(function LineControls({
   const { canvas, rotate } = useContext(SVGContext)
 
   // Get the transformation that's been applied to a parent element
-  const { matrix } = canvas.parentElement.parentElement.transform.baseVal.consolidate()
+  const matrix = canvas.parentElement.parentElement.getCTM()
   const { a: hScale, d: vScale, e: hTranslate, f: vTranslate } = matrix
   const LINE_CONTROL_INSET = 70;
 

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
@@ -35,7 +35,8 @@ const LineControls = forwardRef(function LineControls({
   const { canvas, rotate } = useContext(SVGContext)
 
   // Get the transformation that's been applied to a parent element
-  const matrix = canvas.parentElement.parentElement.getCTM()
+  const canvasSVG = canvas.closest('svg')
+  const matrix = canvasSVG.firstChild.getCTM()
   const { a: hScale, d: vScale, e: hTranslate, f: vTranslate } = matrix
   const LINE_CONTROL_INSET = 70;
 

--- a/packages/lib-classifier/src/plugins/drawingTools/shared/SVGContext.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/shared/SVGContext.js
@@ -1,39 +1,42 @@
 import { createContext } from 'react'
 
+const DEFAULT_TRANSFORM_MATRIX = {
+  scaleX: 1,
+  scaleY: 1,
+  skewX: 0,
+  skewY: 0,
+  translateX: 0,
+  translateY: 0
+}
 /**
  * Canvas context for drawing tools.
  */
 const SVGContext = createContext({
-    /**
-     * The drawing canvas node from the DOM.
-     * @type {SVGGraphicsElement}
-     * @default null
-     */
-    canvas: null,
-    /**
-     * The SVG viewbox for the current subject.
-     * @type {string}
-     * @default ''
-     */
-    viewBox: '',
-    /**
-     * The rotation of the canvas.
-     * @type {number}
-     * @default 0
-     */
-    rotate: 0,
-    /**
-     * The width of the canvas.
-     * @type {number}
-     * @default 0
-     */
-    width: 0,
-    /**
-     * The height of the canvas.
-     * @type {number}
-     * @default 0
-     */
-    height: 0
+  /**
+   * The drawing canvas node from the DOM.
+   * @type {SVGGraphicsElement}
+   * @default null
+   */
+  canvas: null,
+  /**
+   * The rotation of the canvas.
+   * @type {number}
+   * @default 0
+   */
+  rotate: 0,
+  /**
+   * The transformation matrix of the canvas.
+   * @typedef {Object} TransformMatrix
+   * @property {number} scaleX - The scale factor in the X direction.
+   * @property {number} scaleY - The scale factor in the Y direction.
+   * @property {number} skewX - The skew factor in the X direction.
+   * @property {number} skewY - The skew factor in the Y direction.
+   * @property {number} translateX - The translation in the X direction.
+   * @property {number} translateY - The translation in the Y direction.
+   * @type {TransformMatrix}
+   * @default
+   */
+  transformMatrix: DEFAULT_TRANSFORM_MATRIX,
 })
 
 export default SVGContext


### PR DESCRIPTION
Add the `VisXZoom` transform matrix to `SVGContext`, so that we can use it directly in `LineControls` and avoid the controls jumping when the DOM changes.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier/plugins/drawingTools

## Linked Issue and/or Talk Post
- follow-up to #6811. 
- fixes #6818.

## How to Review
Same as #6811. You should notice little or no flickering of the line controls when panning and zooming on this branch.

https://github.com/user-attachments/assets/43c2d917-d310-48c6-bbcf-c759a36c6750



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
