### PR TITLE
Create an All Projects page for user groups

### DIFF
--- a/packages/app-root/src/app/groups/[groupId]/projects/GroupAllProjectsContainer.js
+++ b/packages/app-root/src/app/groups/[groupId]/projects/GroupAllProjectsContainer.js
@@ -1,0 +1,31 @@
+'use client'
+
+import { Loader } from '@zooniverse/react-components'
+import { Contributors, GroupAllProjects } from '@zooniverse/user'
+import { useContext } from 'react'
+import { Box } from 'grommet'
+
+import { PanoptesAuthContext } from '../../../../contexts'
+
+function GroupAllProjectsContainer({ groupId, joinToken }) {
+  const { adminMode, isLoading, user } = useContext(PanoptesAuthContext)
+
+  return (
+    <>
+      {isLoading ? (
+        <Box as='main' height='100vh' align='center' justify='center'>
+          <Loader />
+        </Box>
+      ) : (
+        <GroupAllProjects
+          adminMode={adminMode}
+          authUser={user}
+          groupId={groupId}
+          joinToken={joinToken}
+        />
+      )}
+    </>
+  )
+}
+
+export default GroupAllProjectsContainer

--- a/packages/app-root/src/app/groups/[groupId]/projects/page.js
+++ b/packages/app-root/src/app/groups/[groupId]/projects/page.js
@@ -1,0 +1,15 @@
+import GroupAllProjectsContainer from './GroupAllProjectsContainer.js'
+
+export const metadata = {
+  title: 'Group All Projects',
+  description: 'Zooniverse group all projects page'
+}
+
+export default function GroupAllProjectsPage({ params, searchParams }) {
+  return (
+    <GroupAllProjectsContainer
+      groupId={params.groupId}
+      joinToken={searchParams.join_token}
+    />
+  )
+}

--- a/packages/lib-user/dev/components/App/App.js
+++ b/packages/lib-user/dev/components/App/App.js
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 import {
   Certificate,
   Contributors,
+  GroupAllProjects,
   GroupStats,
   MyGroups,
   UserHome,
@@ -147,6 +148,13 @@ function App({
           groupId={groupId}
           joinToken={joinToken}
         />
+      )
+    } else if (subpaths[1] === 'projects') {
+      content = (
+        <GroupAllProjects
+          authUser={user}
+          groupId={groupId}
+          joinToken={joinToken}/>
       )
     } else {
       content = (

--- a/packages/lib-user/src/components/GroupAllProjects/GroupAllProjects.js
+++ b/packages/lib-user/src/components/GroupAllProjects/GroupAllProjects.js
@@ -1,27 +1,14 @@
-import { useTranslation } from '../../translations/i18n.js'
 import { arrayOf, bool, shape, string } from 'prop-types'
-import { Loader, ProjectCard } from '@zooniverse/react-components'
-import { Box, ResponsiveContext, Text } from 'grommet'
-import { useContext } from 'react'
-import styled from 'styled-components'
+import { useTranslation } from '../../translations/i18n.js'
 
 import { usePanoptesProjects, useStats } from '@hooks'
-import { ContentBox, HeaderLink, Layout } from '@components/shared'
+import { AllProjects, ContentBox, HeaderLink, Layout } from '@components/shared'
 
 const STATS_ENDPOINT = '/classifications/user_groups'
 
-const StyledBox = styled(Box)`
-  list-style: none;
-  margin-block-start: 0;
-  padding-inline-start: 0;
-`
-
 // props are passed from GroupContainer via cloneElement
-function GroupAllProjects({ adminMode, authUser, group, membership }) {
+function GroupAllProjects({ authUser, group }) {
   const { t } = useTranslation()
-
-  const size = useContext(ResponsiveContext)
-  const cardSize = size
 
   // fetch all projects stats; date range is all time
   const {
@@ -82,33 +69,8 @@ function GroupAllProjects({ adminMode, authUser, group, membership }) {
         />
       }
     >
-      <ContentBox title='All Projects'>
-        {loading ? (
-          <Box fill align='center' justify='center'>
-            <Loader />
-          </Box>
-        ) : topProjects?.length === 0 ? (
-          <Text>No projects found for this group</Text>
-        ) : error ? (
-          <Text>There was an error fetching project stats for this group</Text>
-        ) : (
-          <StyledBox forwardedAs='ul' direction='row' wrap gap='10px'>
-            {topProjects.map(topProject => {
-              return (
-                <li key={topProject?.id}>
-                  <ProjectCard
-                    badge={topProject?.count}
-                    description={topProject?.description}
-                    displayName={topProject?.display_name}
-                    href={`https://www.zooniverse.org/projects/${topProject?.slug}`}
-                    imageSrc={topProject?.avatar_src}
-                    size={cardSize}
-                  />
-                </li>
-              )
-            })}
-          </StyledBox>
-        )}
+      <ContentBox title='All Projects' pad='49px'>
+        <AllProjects error={error} loading={loading} projects={topProjects} />
       </ContentBox>
     </Layout>
   )

--- a/packages/lib-user/src/components/GroupAllProjects/GroupAllProjects.js
+++ b/packages/lib-user/src/components/GroupAllProjects/GroupAllProjects.js
@@ -1,0 +1,132 @@
+import { useTranslation } from '../../translations/i18n.js'
+import { arrayOf, bool, shape, string } from 'prop-types'
+import { Loader, ProjectCard } from '@zooniverse/react-components'
+import { Box, ResponsiveContext, Text } from 'grommet'
+import { useContext } from 'react'
+import styled from 'styled-components'
+
+import { usePanoptesProjects, useStats } from '@hooks'
+import { ContentBox, HeaderLink, Layout } from '@components/shared'
+
+const STATS_ENDPOINT = '/classifications/user_groups'
+
+const StyledBox = styled(Box)`
+  list-style: none;
+  margin-block-start: 0;
+  padding-inline-start: 0;
+`
+
+// props are passed from GroupContainer via cloneElement
+function GroupAllProjects({ adminMode, authUser, group, membership }) {
+  const { t } = useTranslation()
+
+  const size = useContext(ResponsiveContext)
+  const cardSize = size
+
+  // fetch all projects stats; date range is all time
+  const {
+    data: allProjectsStats,
+    error: statsError,
+    isLoading: statsLoading
+  } = useStats({
+    authUserId: authUser?.id,
+    endpoint: STATS_ENDPOINT,
+    sourceId: group?.id
+  })
+
+  // fetch project data from panoptes
+  const projectIds = allProjectsStats?.project_contributions?.map(
+    project => project.project_id
+  )
+  const projectsQuery = {
+    cards: true,
+    id: projectIds?.join(','),
+    page_size: 100
+  }
+  const {
+    data: projects,
+    error: projectsError,
+    isLoading: projectsLoading
+  } = usePanoptesProjects(projectsQuery)
+
+  // order by top projects
+  let topProjects = []
+  const topProjectContributions = allProjectsStats?.project_contributions?.sort(
+    (a, b) => b.count - a.count
+  )
+
+  if (topProjectContributions?.length > 0) {
+    topProjects = topProjectContributions
+      ?.map(projectContribution => {
+        const projectData = projects?.find(
+          project => project.id === projectContribution.project_id.toString()
+        )
+        return {
+          count: projectContribution.count,
+          ...projectData
+        }
+      })
+      .filter(project => project?.id)
+  }
+
+  const error = statsError || projectsError
+  const loading = statsLoading || projectsLoading
+
+  return (
+    <Layout
+      primaryHeaderItem={
+        <HeaderLink
+          href={`/groups/${group.id}`}
+          label={t('common.back')}
+          primaryItem={true}
+        />
+      }
+    >
+      <ContentBox title='All Projects'>
+        {loading ? (
+          <Box fill align='center' justify='center'>
+            <Loader />
+          </Box>
+        ) : topProjects?.length === 0 ? (
+          <Text>No projects found for this group</Text>
+        ) : error ? (
+          <Text>There was an error fetching project stats for this group</Text>
+        ) : (
+          <StyledBox forwardedAs='ul' direction='row' wrap gap='10px'>
+            {topProjects.map(topProject => {
+              return (
+                <li key={topProject?.id}>
+                  <ProjectCard
+                    badge={topProject?.count}
+                    description={topProject?.description}
+                    displayName={topProject?.display_name}
+                    href={`https://www.zooniverse.org/projects/${topProject?.slug}`}
+                    imageSrc={topProject?.avatar_src}
+                    size={cardSize}
+                  />
+                </li>
+              )
+            })}
+          </StyledBox>
+        )}
+      </ContentBox>
+    </Layout>
+  )
+}
+
+GroupAllProjects.propTypes = {
+  adminMode: bool,
+  authUser: shape({
+    id: string
+  }),
+  group: shape({
+    display_name: string,
+    id: string
+  }),
+  membership: shape({
+    id: string,
+    roles: arrayOf(string)
+  })
+}
+
+export default GroupAllProjects

--- a/packages/lib-user/src/components/GroupAllProjects/GroupAllProjects.js
+++ b/packages/lib-user/src/components/GroupAllProjects/GroupAllProjects.js
@@ -69,7 +69,7 @@ function GroupAllProjects({ authUser, group }) {
         />
       }
     >
-      <ContentBox title='All Projects' pad='49px'>
+      <ContentBox title='All Projects' pad='45px'>
         <AllProjects error={error} loading={loading} projects={topProjects} />
       </ContentBox>
     </Layout>

--- a/packages/lib-user/src/components/GroupAllProjects/GroupAllProjectsContainer.js
+++ b/packages/lib-user/src/components/GroupAllProjects/GroupAllProjectsContainer.js
@@ -1,0 +1,35 @@
+'use client'
+
+import { bool, shape, string } from 'prop-types'
+
+import { GroupContainer } from '@components/shared'
+import GroupAllProjects from './GroupAllProjects.js'
+
+function GroupAllProjectsContainer({
+  adminMode,
+  authUser,
+  groupId,
+  joinToken
+}) {
+  return (
+    <GroupContainer
+      adminMode={adminMode}
+      authUser={authUser}
+      groupId={groupId}
+      joinToken={joinToken}
+    >
+      <GroupAllProjects />
+    </GroupContainer>
+  )
+}
+
+GroupAllProjectsContainer.propTypes = {
+  adminMode: bool,
+  authUser: shape({
+    id: string
+  }),
+  groupId: string,
+  joinToken: string
+}
+
+export default GroupAllProjectsContainer

--- a/packages/lib-user/src/components/GroupAllProjects/index.js
+++ b/packages/lib-user/src/components/GroupAllProjects/index.js
@@ -1,0 +1,1 @@
+export { default } from './GroupAllProjectsContainer.js'

--- a/packages/lib-user/src/components/index.js
+++ b/packages/lib-user/src/components/index.js
@@ -1,5 +1,6 @@
 export { default as Certificate } from './Certificate'
 export { default as Contributors } from './Contributors'
+export { default as GroupAllProjects } from './GroupAllProjects'
 export { default as GroupStats } from './GroupStats'
 export { default as MyGroups } from './MyGroups'
 export { default as UserHome } from './UserHome'

--- a/packages/lib-user/src/components/shared/AllProjects/AllProjects.js
+++ b/packages/lib-user/src/components/shared/AllProjects/AllProjects.js
@@ -31,7 +31,7 @@ function AllProjects({ error, loading, projects }) {
           <Text>{t('AllProjects.error')}</Text>
         </Box>
       ) : (
-        <StyledBox forwardedAs='ul' direction='row' wrap>
+        <StyledBox forwardedAs='ul' direction='row' wrap justify='center'>
           {projects.map(project => {
             return (
               <li key={project?.id}>

--- a/packages/lib-user/src/components/shared/AllProjects/AllProjects.js
+++ b/packages/lib-user/src/components/shared/AllProjects/AllProjects.js
@@ -1,0 +1,73 @@
+import { Box, Text } from 'grommet'
+import styled from 'styled-components'
+import { arrayOf, bool, number, shape, string } from 'prop-types'
+import ProjectCard from '@zooniverse/react-components/ProjectCard'
+import Loader from '@zooniverse/react-components/Loader'
+import { useTranslation } from '../../../translations/i18n.js'
+
+const StyledBox = styled(Box)`
+  list-style: none;
+  margin-block-start: 0;
+  padding-inline-start: 0;
+  column-gap: 20px;
+  row-gap: 20px;
+`
+
+function AllProjects({ error, loading, projects }) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      {loading ? (
+        <Box fill align='center' justify='center'>
+          <Loader />
+        </Box>
+      ) : projects?.length === 0 ? (
+        <Box fill align='center' pad='medium'>
+          <Text>{t('AllProjects.noProjects')}</Text>
+        </Box>
+      ) : error ? (
+        <Box fill align='center' pad='medium'>
+          <Text>{t('AllProjects.error')}</Text>
+        </Box>
+      ) : (
+        <StyledBox forwardedAs='ul' direction='row' wrap>
+          {projects.map(project => {
+            return (
+              <li key={project?.id}>
+                <ProjectCard
+                  badge={project?.count}
+                  description={project?.description}
+                  displayName={project?.display_name}
+                  href={`https://www.zooniverse.org/projects/${project?.slug}`}
+                  imageSrc={project?.avatar_src}
+                  size='large'
+                />
+              </li>
+            )
+          })}
+        </StyledBox>
+      )}
+    </>
+  )
+}
+
+AllProjects.propTypes = {
+  error: shape({
+    message: string,
+    status: number
+  }),
+  loading: bool,
+  projects: arrayOf(
+    shape({
+      avatar_src: string,
+      count: number,
+      description: string,
+      display_name: string,
+      id: string,
+      slug: string
+    })
+  )
+}
+
+export default AllProjects

--- a/packages/lib-user/src/components/shared/AllProjects/AllProjects.stories.js
+++ b/packages/lib-user/src/components/shared/AllProjects/AllProjects.stories.js
@@ -1,0 +1,39 @@
+import { PROJECTS } from '../../../../test/mocks/panoptes'
+
+import AllProjects from './AllProjects.js'
+
+export default {
+  title: 'Components/shared/AllProjects',
+  component: AllProjects
+}
+
+export const Default = {
+  args: {
+    error: null,
+    loading: false,
+    projects: PROJECTS
+  }
+}
+
+export const Loading =  {
+  args: {
+    error: null,
+    loading: true,
+    projects: PROJECTS
+  }
+}
+
+export const Error =  {
+  args: {
+    error: { message: `Couldn't fetch projects`, status: 500 },
+    loading: false,
+    projects: PROJECTS
+  }
+}
+export const NoProjects = {
+  args: {
+    error: null,
+    loading: false,
+    projects: []
+  }
+}

--- a/packages/lib-user/src/components/shared/AllProjects/index.js
+++ b/packages/lib-user/src/components/shared/AllProjects/index.js
@@ -1,0 +1,1 @@
+export { default } from './AllProjects.js'

--- a/packages/lib-user/src/components/shared/index.js
+++ b/packages/lib-user/src/components/shared/index.js
@@ -1,3 +1,4 @@
+export { default as AllProjects } from './AllProjects'
 export { default as Avatar } from './Avatar'
 export { default as BarChart } from './BarChart'
 export { default as ContentBox } from './ContentBox'

--- a/packages/lib-user/src/index.js
+++ b/packages/lib-user/src/index.js
@@ -1,5 +1,6 @@
 // components
 export { default as Certificate } from './components/Certificate'
+export { default as GroupAllProjects } from './components/GroupAllProjects'
 export { default as GroupStats } from './components/GroupStats'
 export { default as MyGroups } from './components/MyGroups'
 export { default as Contributors } from './components/Contributors'

--- a/packages/lib-user/src/translations/en.json
+++ b/packages/lib-user/src/translations/en.json
@@ -7,6 +7,10 @@
     "hours": "Hours",
     "projects": "Projects"
   },
+  "AllProjects": {
+    "error": "There was an error",
+    "noProjects": "No projects found"
+  },
   "BarChart": {
     "a11y": "Bar chart of {{typeLabel}} by {{countLabel}} from {{startDate}} to {{endDate}}",
     "day": "Day",


### PR DESCRIPTION
## Package
app-root
lib-user

## Linked Issue and/or Talk Post
Toward: https://github.com/zooniverse/front-end-monorepo/issues/6690
[Figma](https://www.figma.com/design/qbqbmR3t5XV6eKcpuRj7mG/Group-Stats?node-id=412-9650)

## Describe your changes

This is one of multiple PRs needed to create the All Projects pages for individual users and user groups. There will be other PRs branched from this one to handle All Projects from UserHome and UserStats. In this PR:
- Created a simple shared AllProjects component. It simply displays an array of `projects` with ProjectCard.
- Created a route for https://www.zooniverse.org/groups/[groupId]/projects
- Created a page component in lib-user called GroupAllProjects using the existing containers for other group pages, common hooks, layout, etc.

## How to Review
- There will eventually be a link in the Top Projects section of a group page, but I intentionally did not include it in this PR because we want to deploy all of the "All Projects" pages at once
- View any group's `/projects` page by adding it to the end of the url, such as this group (not a public group, but Mark you are in it): https://local.zooniverse.org:3000/groups/2620016/projects?env=production
- Project cards are sorted in order of most classifications ==> least classifications. Group contributions cannot be sorted in any other order.
- See the various UI states for AllProjects in storybook: http://localhost:6008/?path=/story/components-shared-allprojects


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)