### PR TITLE
lib-classifier: Refactor VisXZoom onFirstScroll and hasScrolledRef per initial CTRL + scroll event

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -98,12 +98,13 @@ function VisXZoom({
       return throttledWheelHandler(event)
     }
 
-    /* If subject viewer allows scrolling, 
+    /* If subject viewer allows scrolling,
+    and user is not zooming with hot key, 
     check for first scroll event (hasScrolledRef is false), then
     set hasScrolledRef to true and
     call onFirstScroll callback.
     */
-    if (allowsScrolling && !hasScrolledRef.current) {
+    if (allowsScrolling && !event[ZOOM_HOT_KEY] && !hasScrolledRef.current) {
       hasScrolledRef.current = true
       onFirstScroll()
     }
@@ -122,6 +123,9 @@ function VisXZoom({
         // Prevent the page from jumping when the scrollbar is removed.
         document.body.style.paddingRight = `${scrollbarWidth}px`
       }
+
+      /* the user is zooming with the hot key, so set hasScrolledRef to true */
+      hasScrolledRef.current = true
 
       /* event.preventDefault() will throw a warning in the browser
       for passive events. To avoid that, use addEventListener with 


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #6821 

## Describe your changes
- check if user is using CTRL + scroll and if they are, then don't call `onFirstScroll` callback to show CTRL + scroll message
- if user's first scroll is with CTRL + scroll, then set `hasScrolledRef` to `true` to prevent CTRL + scroll message from showing on subsequent scrolls

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - any with an image, like https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats/classify/workflow/693
- What user actions should my reviewer step through to review this PR?
  1. put classifier in pan/zoom mode
  2. press CTRL + zoom
  3. note **no** "Use CTRL + zoom..." message shows
  4. zoom without CTRL
  5. also note **no** "Use CTRL + zoom..." message shows
- Which storybook stories should be reviewed?
  - http://localhost:6006/?path=/story/subject-viewers-singleimageviewer--pan-and-zoom
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated