### PR TITLE
lib-classifier, lib-user: Add class to components for react-rnd to ignore drag actions

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
@@ -84,7 +84,7 @@ function SubTaskPopup({
   })
 
   const rndProps = {
-    cancel: '.subtaskpopup-element-that-ignores-drag-actions',
+    cancel: '.element-that-ignores-drag-actions',
     minHeight,
     minWidth,
     onDragStop,
@@ -107,7 +107,7 @@ function SubTaskPopup({
         titleColor=''
       >
         <Box 
-          className='subtaskpopup-element-that-ignores-drag-actions'
+          className='element-that-ignores-drag-actions'
           gap='small'
         >
           <form onSubmit={close}>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.js
@@ -50,6 +50,7 @@ export default function ConsensusPopup ({
       position='top-left'
       plain
       rndProps={{
+        cancel: '.element-that-ignores-drag-actions',
         default: position,
         maxHeight: 350,
         minHeight: MIN_POPUP_HEIGHT,
@@ -61,7 +62,9 @@ export default function ConsensusPopup ({
       <Paragraph>
         {t('SubjectViewer.InteractionLayer.TranscribedLines.ConsensusPopup.explanation', { count: line.textOptions.length })}
       </Paragraph>
-      <StyledBox>
+      <StyledBox
+        className='element-that-ignores-drag-actions'
+      >
         {line.consensusText &&
           <Paragraph>
             {line.consensusText}

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
@@ -34,7 +34,7 @@ function ModalHeading ({ background = 'brand', color = 'neutral-6', className = 
         </StyledHeading>}
       {closeFn &&
         <CloseButton
-          className='subtaskpopup-element-that-ignores-drag-actions'
+          className='element-that-ignores-drag-actions'
           closeFn={closeFn}
           color={color}
         />

--- a/packages/lib-user/src/components/shared/MainContent/MainContent.js
+++ b/packages/lib-user/src/components/shared/MainContent/MainContent.js
@@ -126,26 +126,29 @@ function MainContent({
         active={showCalendar}
         closeFn={handleCalendarClose}
         position='top'
+        rndProps={{ cancel: '.element-that-ignores-drag-actions' }}
         title={t('MainContent.calendarTitle')}
       >
-        <Calendar
-          bounds={[
-            sourceCreatedAtDate,
-            todayUTC
-          ]}
-          date={[customDateRange]}
-          onSelect={handleCalendarChange}
-          range='array'
-        />
-        <Box
-          direction='row'
-          justify='end'
-          margin={{ top: 'small' }}
-        >
-          <StyledCalendarButton
-            label={t('MainContent.calendarBtn')}
-            onClick={handleCalendarSave}
+        <Box className='element-that-ignores-drag-actions'>
+          <Calendar
+            bounds={[
+              sourceCreatedAtDate,
+              todayUTC
+            ]}
+            date={[customDateRange]}
+            onSelect={handleCalendarChange}
+            range='array'
           />
+          <Box
+            direction='row'
+            justify='end'
+            margin={{ top: 'small' }}
+          >
+            <StyledCalendarButton
+              label={t('MainContent.calendarBtn')}
+              onClick={handleCalendarSave}
+            />
+          </Box>
         </Box>
       </MovableModal>
       <ContentBox

--- a/packages/lib-user/src/components/shared/MainContent/MainContent.js
+++ b/packages/lib-user/src/components/shared/MainContent/MainContent.js
@@ -1,4 +1,4 @@
-import { Loader, MovableModal, SpacedText } from '@zooniverse/react-components'
+import { Loader, Modal, MovableModal, SpacedText } from '@zooniverse/react-components'
 import { Anchor, Box, Calendar, ResponsiveContext, Text } from 'grommet'
 import { arrayOf, bool, func, number, shape, string } from 'prop-types'
 import { useCallback, useContext, useEffect, useState } from 'react'
@@ -66,6 +66,8 @@ function MainContent({
   }, [selectedDateRange])
 
   const size = useContext(ResponsiveContext)
+  
+  const CalendarModal = size === 'small' ? Modal : MovableModal
 
   const hoursSpent = convertStatsSecondsToHours(stats?.time_spent)
 
@@ -122,35 +124,49 @@ function MainContent({
 
   return (
     <>
-      <MovableModal
+      <CalendarModal
         active={showCalendar}
         closeFn={handleCalendarClose}
+        pad='none'
         position='top'
         rndProps={{ cancel: '.element-that-ignores-drag-actions' }}
         title={t('MainContent.calendarTitle')}
       >
-        <Box className='element-that-ignores-drag-actions'>
-          <Calendar
-            bounds={[
-              sourceCreatedAtDate,
-              todayUTC
-            ]}
-            date={[customDateRange]}
-            onSelect={handleCalendarChange}
-            range='array'
-          />
-          <Box
-            direction='row'
-            justify='end'
-            margin={{ top: 'small' }}
-          >
-            <StyledCalendarButton
-              label={t('MainContent.calendarBtn')}
-              onClick={handleCalendarSave}
+        <Box
+          align='center'
+          className='element-that-ignores-drag-actions'
+          fill
+          pad={{
+            bottom: 'medium',
+            horizontal: size === 'small' ? 'none' : 'medium',
+            top: 'small'
+          }}
+        >
+          <Box>
+            <Calendar
+              bounds={[
+                sourceCreatedAtDate,
+                todayUTC
+              ]}
+              date={[customDateRange]}
+              onSelect={handleCalendarChange}
+              range='array'
             />
+            <Box
+              direction='row'
+              fill
+              justify='end'
+              margin={{ top: 'small' }}
+              pad={{ horizontal: size === 'small' ? 'small' : 'none' }}
+            >
+              <StyledCalendarButton
+                label={t('MainContent.calendarBtn')}
+                onClick={handleCalendarSave}
+              />
+            </Box>
           </Box>
         </Box>
-      </MovableModal>
+      </CalendarModal>
       <ContentBox
         direction='column'
         gap='medium'


### PR DESCRIPTION
## Package
- lib-react-components
- lib-classifier
- lib-user

## Linked Issue and/or Talk Post
- closes #6418 
- closes #6797 

## Describe your changes
- refactor modal close button classname to something more generic
- add a classname so that [react-rnd cancels touch/drag events](https://github.com/bokuweb/react-rnd?tab=readme-ov-file#cancel-string) to:
  - consensus line popup
  - stats calendar modal

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - lib-classifier
    - staging transcription project: https://local.zooniverse.org:3000/projects/blicksam/transcription-task-testing/classify/workflow/13898?env=production&demo=true
  - lib-user
    - staging public user group: https://local.zooniverse.org:3000/groups/1326989?start_date=2025-02-04
- What user actions should my reviewer step through to review this PR?
  - on a small screen, close the modal and use touch events within the modal
- Which storybook stories should be reviewed?
  - lib-classifier
    - http://localhost:6006/?path=/story/drawing-tools-transcribedlines-consensuspopup--default
  - lib-user
    - http://localhost:6008/?path=/story/components-shared-maincontent--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected