### PR TITLE
lib-content: Fix aria-label in Sidebar in OurTeam and Publications

### DIFF
--- a/packages/lib-content/src/screens/About/About.js
+++ b/packages/lib-content/src/screens/About/About.js
@@ -102,7 +102,7 @@ function AboutPage() {
           <Box as='aside' align='center'>
             <StickySidebar
               activeSection={activeSection}
-              ariaLabel={t('AboutPage.sideBarLabel')}
+              ariaLabel={t('AboutPage.sidebarLabel')}
               sections={sidebarSections}
               setActiveSection={setActiveSection}
             />

--- a/packages/lib-content/src/screens/OurTeam/OurTeam.js
+++ b/packages/lib-content/src/screens/OurTeam/OurTeam.js
@@ -44,7 +44,7 @@ function OurTeam({ teamData = [], sections = [] }) {
           <Box as='aside' align='center'>
             <StickySidebar
               activeSection={activeSection}
-              ariaLabel={t('OurTeam.sideBarLabel')}
+              ariaLabel={t('OurTeam.sidebarLabel')}
               sections={sections}
               setActiveSection={setActiveSection}
             />

--- a/packages/lib-content/src/screens/OurTeam/OurTeam.spec.js
+++ b/packages/lib-content/src/screens/OurTeam/OurTeam.spec.js
@@ -34,7 +34,7 @@ describe('Component > Our Team', function () {
   })
 
   it('should have a nav with label', function () {
-    const sideBar = screen.getByText('Institution')
+    const sideBar = screen.getByText('Institution') // This is the DropdownNav in jsdom
     expect(sideBar).to.be.ok()
   })
 

--- a/packages/lib-content/src/screens/Publications/Publications.js
+++ b/packages/lib-content/src/screens/Publications/Publications.js
@@ -67,7 +67,7 @@ function Publications({ publicationsData = [], sections = [] }) {
           <Box as='aside' align='center'>
             <StickySidebar
               activeSection={activeSection}
-              ariaLabel={t('Publications.sideBarLabel')}
+              ariaLabel={t('Publications.sidebarLabel')}
               sections={sections}
               setActiveSection={setActiveSection}
             />

--- a/packages/lib-content/src/screens/Publications/Publications.spec.js
+++ b/packages/lib-content/src/screens/Publications/Publications.spec.js
@@ -37,7 +37,7 @@ describe('Component > Publications Page', function () {
   })
 
   it('should have sidebar nav label', function () {
-    const sideBar = screen.getByText('Discipline')
+    const sideBar = screen.getByText('Discipline')  // This is the DropdownNav in jsdom
     expect(sideBar).to.be.ok()
   })
 


### PR DESCRIPTION
## Package
lib-content

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6053


## How to Review
Run app-root locally and visit
- https://local.zooniverse.org:3000/about/publications
- https://local.zooniverse.org:3000/about/teams

The sidebar aria-label should be translated correctly.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook