### PR TITLE
lib-user: Refactor lists with a11y name, tabindex, and scroll-snap

### DIFF
--- a/packages/lib-user/src/components/Contributors/components/ContributorsList/ContributorsList.js
+++ b/packages/lib-user/src/components/Contributors/components/ContributorsList/ContributorsList.js
@@ -47,6 +47,7 @@ function ContributorsList({
               login={contributor.login}
             />
             <Box
+              a11yTitle={t('Contributors.ContributorsList.projectStats', {name: contributor.display_name })}
               as='ol'
               direction='row'
               fill='horizontal'

--- a/packages/lib-user/src/components/Contributors/components/ContributorsList/ContributorsList.js
+++ b/packages/lib-user/src/components/Contributors/components/ContributorsList/ContributorsList.js
@@ -1,11 +1,22 @@
 import { Box } from 'grommet'
 import { arrayOf, number, shape, string } from 'prop-types'
+import styled from 'styled-components'
 import { useTranslation } from '../../../../translations/i18n.js'
 
 import { convertStatsSecondsToHours } from '@utils'
 
 import MemberStats from '../MemberStats'
 import ProjectStats from '../ProjectStats'
+
+const StyledBox = styled(Box)`
+  box-shadow: inset -10px 0px 10px -10px rgba(0, 0, 0, 0.25);
+  list-style: none;
+  scroll-snap-type: x mandatory;
+
+  li {
+    scroll-snap-align: center;
+  }
+`
 
 function ContributorsList({
   contributors = [],
@@ -46,17 +57,13 @@ function ContributorsList({
               hours={totalHoursSpent}
               login={contributor.login}
             />
-            <Box
+            <StyledBox
               a11yTitle={t('Contributors.ContributorsList.projectStats', {name: contributor.display_name })}
-              as='ol'
+              forwardedAs='ol'
               direction='row'
               fill='horizontal'
               overflow={{ horizontal: 'auto' }}
               pad='none'
-              style={{
-                boxShadow: 'inset -10px 0px 10px -10px rgba(0, 0, 0, 0.25)',
-                listStyle: 'none'
-              }}
               tabIndex={0}
             >
               {contributor.project_contributions.map(statsProject => {
@@ -73,7 +80,7 @@ function ContributorsList({
                   />
                 )
               })}
-            </Box>
+            </StyledBox>
           </Box>
         )
       })}

--- a/packages/lib-user/src/components/Contributors/components/ContributorsList/ContributorsList.js
+++ b/packages/lib-user/src/components/Contributors/components/ContributorsList/ContributorsList.js
@@ -56,6 +56,7 @@ function ContributorsList({
                 boxShadow: 'inset -10px 0px 10px -10px rgba(0, 0, 0, 0.25)',
                 listStyle: 'none'
               }}
+              tabIndex={0}
             >
               {contributor.project_contributions.map(statsProject => {
                 const project = projects.find(project => project.id === statsProject.project_id.toString())

--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
@@ -15,7 +15,11 @@ export default function RecentProjects({
   const size = useContext(ResponsiveContext)
 
   return (
-    <ContentBox title={t('UserHome.RecentProjects.title')} screenSize={size}>
+    <ContentBox
+      title={t('UserHome.RecentProjects.title')}
+      titleId='recent-projects'
+      screenSize={size}
+    >
       {isLoading && (
         <Box fill justify='center' align='center'>
           <Loader />
@@ -45,6 +49,7 @@ export default function RecentProjects({
       {!isLoading &&
         projectPreferences?.length ? (
           <Box
+            aria-labelledby='recent-projects'
             as='ul'
             direction='row'
             gap='small'

--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
@@ -51,6 +51,7 @@ export default function RecentProjects({
             pad={{ horizontal: 'xxsmall', bottom: 'xsmall', top: 'xxsmall' }}
             overflow={{ horizontal: 'auto' }}
             style={{ listStyle: 'none' }}
+            tabIndex={0}
             margin='0'
           >
             {projectPreferences.map(preference => (

--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
@@ -1,10 +1,20 @@
 import { Anchor, Box, ResponsiveContext, Text } from 'grommet'
 import { arrayOf, bool, shape, string } from 'prop-types'
 import { useContext } from 'react'
+import styled from 'styled-components'
 import { Loader, ProjectCard, SpacedText } from '@zooniverse/react-components'
 import { useTranslation, Trans } from '../../../../translations/i18n.js'
 
 import { ContentBox } from '@components/shared'
+
+const StyledBox = styled(Box)`
+  list-style: none;
+  scroll-snap-type: x mandatory;
+
+  li {
+    scroll-snap-align: center;
+  }
+`
 
 export default function RecentProjects({
   isLoading = false,
@@ -48,14 +58,13 @@ export default function RecentProjects({
       )}
       {!isLoading &&
         projectPreferences?.length ? (
-          <Box
+          <StyledBox
             aria-labelledby='recent-projects'
-            as='ul'
+            forwardedAs='ul'
             direction='row'
             gap='small'
             pad={{ horizontal: 'xxsmall', bottom: 'xsmall', top: 'xxsmall' }}
             overflow={{ horizontal: 'auto' }}
-            style={{ listStyle: 'none' }}
             tabIndex={0}
             margin='0'
           >
@@ -70,7 +79,7 @@ export default function RecentProjects({
                 />
               </li>
             ))}
-          </Box>
+          </StyledBox>
         ) : null}
     </ContentBox>
   )

--- a/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
@@ -1,11 +1,21 @@
 import { Anchor, Box, ResponsiveContext, Text } from 'grommet'
 import { arrayOf, bool, shape, string } from 'prop-types'
 import { useContext } from 'react'
+import styled from 'styled-components'
 import { Loader, SpacedText } from '@zooniverse/react-components'
 import { useTranslation, Trans } from '../../../../translations/i18n.js'
 
 import { ContentBox } from '@components/shared'
 import SubjectCard from '../SubjectCard/SubjectCard.js'
+
+const StyledBox = styled(Box)`
+  list-style: none;
+  scroll-snap-type: x mandatory;
+
+  li {
+    scroll-snap-align: center;
+  }
+`
 
 function RecentSubjects({
   isLoading = false,
@@ -51,14 +61,13 @@ function RecentSubjects({
       )}
       {!isLoading && recents?.length
         ? (
-          <Box
+          <StyledBox
             aria-labelledby='recent-subjects'
-            as='ul'
+            forwardedAs='ul'
             direction='row'
             gap='small'
             pad={{ horizontal: 'xxsmall', bottom: 'xsmall', top: 'xxsmall' }}
             overflow={{ horizontal: 'auto' }}
-            style={{ listStyle: 'none' }}
             tabIndex={0}
             margin='0'
           >
@@ -77,7 +86,7 @@ function RecentSubjects({
                 </li>
               )
             })}
-          </Box>
+          </StyledBox>
         ) : null}
     </ContentBox>
   )

--- a/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
@@ -54,6 +54,7 @@ function RecentSubjects({
             pad={{ horizontal: 'xxsmall', bottom: 'xsmall', top: 'xxsmall' }}
             overflow={{ horizontal: 'auto' }}
             style={{ listStyle: 'none' }}
+            tabIndex={0}
             margin='0'
           >
             {recents.map(recent => {

--- a/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
@@ -16,7 +16,11 @@ function RecentSubjects({
   const size = useContext(ResponsiveContext)
 
   return (
-    <ContentBox title='Recent Classifications' screenSize={size}>
+    <ContentBox
+      title='Recent Classifications'
+      titleId='recent-subjects'
+      screenSize={size}
+    >
       {isLoading && (
         <Box fill justify='center' align='center'>
           <Loader />
@@ -48,6 +52,7 @@ function RecentSubjects({
       {!isLoading && recents?.length
         ? (
           <Box
+            aria-labelledby='recent-subjects'
             as='ul'
             direction='row'
             gap='small'

--- a/packages/lib-user/src/components/shared/ContentBox/ContentBox.js
+++ b/packages/lib-user/src/components/shared/ContentBox/ContentBox.js
@@ -10,6 +10,7 @@ function ContentBox({
   linkLabel = undefined,
   linkProps = undefined,
   title = undefined,
+  titleId = undefined,
   toolTip = undefined,
   ...rest
 }) {
@@ -51,7 +52,7 @@ function ContentBox({
         >
 
           {title ? (
-            <ContentHeading>
+            <ContentHeading id={titleId}>
               {title}
               {toolTip ? toolTip : null}
             </ContentHeading>
@@ -76,6 +77,7 @@ ContentBox.propTypes = {
   linkProps: object,
   screenSize: string,
   title: string,
+  titleId: string,
   toolTip: node
 }
 

--- a/packages/lib-user/src/components/shared/ContentBox/components/ContentHeading.js
+++ b/packages/lib-user/src/components/shared/ContentBox/components/ContentHeading.js
@@ -1,6 +1,6 @@
 import { SpacedText } from '@zooniverse/react-components'
 import { Heading } from 'grommet'
-import { node } from 'prop-types'
+import { node, string } from 'prop-types'
 import styled from 'styled-components'
 
 const StyledHeading = styled(Heading)`
@@ -9,10 +9,12 @@ const StyledHeading = styled(Heading)`
 `
 
 function ContentHeading({
-  children
+  children,
+  id
 }) {
   return (
     <StyledHeading
+      id={id}
       level={2}
       margin='0'
     >
@@ -32,6 +34,7 @@ function ContentHeading({
 
 ContentHeading.propTypes = {
   children: node.isRequired,
+  id: string
 }
 
 export default ContentHeading

--- a/packages/lib-user/src/components/shared/TopProjects/TopProjects.js
+++ b/packages/lib-user/src/components/shared/TopProjects/TopProjects.js
@@ -21,6 +21,11 @@ const StyledRowList = styled(Box)`
   list-style: none;
   margin-block-end: 0;
   margin-block-start: 0;
+  scroll-snap-type: x mandatory;
+  
+  li {
+    scroll-snap-align: center;
+  }
 `
 
 function CardsGrid({ children }) {

--- a/packages/lib-user/src/components/shared/TopProjects/TopProjects.js
+++ b/packages/lib-user/src/components/shared/TopProjects/TopProjects.js
@@ -58,6 +58,7 @@ function CardsRow({ children }) {
         horizontal: 'xxsmall',
         top: 'xxsmall'
       }}
+      tabIndex={0}
     >
       {children}
     </StyledRowList>

--- a/packages/lib-user/src/translations/en.json
+++ b/packages/lib-user/src/translations/en.json
@@ -24,7 +24,8 @@
   "Contributors": {
     "ContributorsList": {
       "a11y": "{{name}} member stats",
-      "privateProject": "Private Project {{index}}"
+      "privateProject": "Private Project {{index}}",
+      "projectStats": "{{name}} project stats"
     },
     "ProjectStats": {
       "a11y": "{{project}} member stats"


### PR DESCRIPTION
## Package
- lib-user

## Linked Issue and/or Talk Post
- closes #6380 
- closes #6316 

## Describe your changes
- add `tabIndex={0}` to horizontally scrollable lists
- add a11y name, with `aria-labelledby` or `a11yTitle`, to lists
- add scroll-snap styling to lists

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - user's homepage:
    - lib-user: https://local.zooniverse.org:8080/
    - app-root: https://local.zooniverse.org:3000/
- What user actions should my reviewer step through to review this PR?
  - tab to list, use arrow keys to scroll left/right
  - note scrolling snaps so list item is centered
- Which storybook stories should be reviewed?
  - RecentProjects: http://localhost:6008/?path=/story/components-userhome-recentprojects--default
  - RecentSubjects: http://localhost:6008/?path=/story/components-userhome-recentsubjects--default
  - Contributors member's list of projects: http://localhost:6008/?path=/story/components-contributors-contributorslist--default
  - TopProjects: http://localhost:6008/?path=/story/components-shared-topprojects--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).