### PR TITLE
lib-user: Refactor horizontal lists scroll-snap-align to start

### DIFF
--- a/packages/lib-user/src/components/Contributors/components/ContributorsList/ContributorsList.js
+++ b/packages/lib-user/src/components/Contributors/components/ContributorsList/ContributorsList.js
@@ -14,7 +14,7 @@ const StyledBox = styled(Box)`
   scroll-snap-type: x mandatory;
 
   li {
-    scroll-snap-align: center;
+    scroll-snap-align: start;
   }
 `
 

--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
@@ -12,7 +12,7 @@ const StyledBox = styled(Box)`
   scroll-snap-type: x mandatory;
 
   li {
-    scroll-snap-align: center;
+    scroll-snap-align: start;
   }
 `
 

--- a/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
@@ -13,7 +13,7 @@ const StyledBox = styled(Box)`
   scroll-snap-type: x mandatory;
 
   li {
-    scroll-snap-align: center;
+    scroll-snap-align: start;
   }
 `
 

--- a/packages/lib-user/src/components/shared/TopProjects/TopProjects.js
+++ b/packages/lib-user/src/components/shared/TopProjects/TopProjects.js
@@ -24,7 +24,7 @@ const StyledRowList = styled(Box)`
   scroll-snap-type: x mandatory;
   
   li {
-    scroll-snap-align: center;
+    scroll-snap-align: start;
   }
 `
 


### PR DESCRIPTION
## Package
- lib-user

## Linked Issue and/or Talk Post
- closes #6847 

## Describe your changes
- edits `scroll-snap-align` from `center` to `start`, this keeps the left-most card completely visible as a user scrolls
- there might be a case for `center` (keep center-most card center aligned within parent container) or `end` (keep right-most card visible), but after the discussion in the linked issue and testing locally - I think `start` is the preferable option, or my non-technical take is that it is the option that "looks most correct" compared to the other options, especially visually within the larger layout/page whose other horizontal lists will be initially showing the left-most card fully

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - user's homepage:
    - lib-user: https://local.zooniverse.org:8080/
    - app-root: https://local.zooniverse.org:3000/
- What user actions should my reviewer step through to review this PR?
  - tab to list, use arrow keys to scroll left/right
  - note scrolling snaps so list item is centered
- Which storybook stories should be reviewed?
  - RecentProjects: http://localhost:6008/?path=/story/components-userhome-recentprojects--default
  - RecentSubjects: http://localhost:6008/?path=/story/components-userhome-recentsubjects--default
  - Contributors member's list of projects: http://localhost:6008/?path=/story/components-contributors-contributorslist--default
  - TopProjects: http://localhost:6008/?path=/story/components-shared-topprojects--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected