### PR TITLE
lib-classifier: Use a Grid for subject viewer container in CenteredLayout

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { Box } from 'grommet'
+import { Box, Grid } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
 import FeedbackModal from '@components/Classifier/components/Feedback'
@@ -36,8 +36,13 @@ const ContainerBox = styled(Box)`
   }
 `
 
-const ViewBox = styled(Box)`
-  flex-direction: row;
+// Similar to the shared ViewerGrid component, but 'auto' columns
+// allows for always 3rem-width toolbar and adapts to limited-height subjects
+const ViewerGrid = styled(Grid)`
+  grid-area: viewer;
+  grid-template-columns: auto;
+  grid-template-rows: auto;
+  grid-template-areas: 'subject toolbar';
 `
 
 const StyledImageToolbarContainer = styled.div`
@@ -74,7 +79,7 @@ export default function CenteredLayout({
   return (
     <Relative>
       <ContainerBox hasSurveyTask={hasSurveyTask}>
-        <ViewBox forwardedAs='section'>
+        <ViewerGrid forwardedAs='section'>
           <StyledSubjectContainer hasSurveyTask={hasSurveyTask}>
             <Banners />
             <SubjectViewer />
@@ -85,7 +90,7 @@ export default function CenteredLayout({
               <StyledImageToolbar />
             </StyledImageToolbarContainer>
           )}
-        </ViewBox>
+        </ViewerGrid>
         <StickyTaskArea hasSurveyTask={hasSurveyTask}>
           <TaskArea />
           {separateFramesView && <FieldGuide />}

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.stories.js
@@ -53,7 +53,7 @@ tasksEntries.forEach(([taskKey, task]) => {
 const workflowSnapshot = WorkflowFactory.build({
   configuration: {
     invert_subject: true,
-    limit_subject_height: true
+    limit_subject_height: true // required for this layout to be applied
   },
   first_task: 'init',
   strings: taskStrings,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -1,13 +1,15 @@
 import { Box } from 'grommet'
 import { bool, func, shape, string } from 'prop-types'
-import { useEffect, useState, useRef } from 'react'
-import styled, { css } from 'styled-components'
+import { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { useTranslation } from '@translations/i18n'
 
 import ZoomControlButton from '../ZoomControlButton'
 import ZoomHelperOverlay from './components/ZoomHelperOverlay'
 import VisXZoom from '../SVGComponents/VisXZoom'
 import SingleImageCanvas from './SingleImageCanvas'
 
+// For positioning ZoomHelperOverlay on top of StyledSVG (the subject)
 const Relative = styled(Box)`
   position: relative;
 `
@@ -16,7 +18,7 @@ const StyledSVG = styled.svg`
   background-color: ${props => props.theme.global.colors['light-4']};
   touch-action: pinch-zoom;
   max-width: ${props => props.$maxWidth};
-  ${props => props.$maxHeight && css`max-height: ${props.$maxHeight};`}
+  max-height: ${props => props.$maxHeight};
 `
 
 const DEFAULT_HANDLER = () => true
@@ -51,6 +53,7 @@ function SingleImageViewer({
   zoomControlFn = null,
   zooming = true
 }) {
+  const { t } = useTranslation('components')
   const [showZoomHelper, setShowZoomHelper] = useState(false)
   const [fadingOut, setFadingOut] = useState(false)
 
@@ -62,12 +65,12 @@ function SingleImageViewer({
   function handleFirstScroll() {
     if (allowsScrolling && zooming) {
       setShowZoomHelper(true)
-      
+
       // Set fading out after 3 seconds
       setTimeout(() => {
         setFadingOut(true)
       }, 3000)
-      
+
       // Hide completely after animation completes (300ms animation)
       setTimeout(() => {
         setShowZoomHelper(false)
@@ -76,6 +79,7 @@ function SingleImageViewer({
     }
   }
 
+  // For CenteredLayout dimensions
   const maxHeight = limitSubjectHeight ? `min(${naturalHeight}px, 90vh)` : null
   const maxWidth = limitSubjectHeight ? `${naturalWidth}px` : '100%'
 
@@ -101,7 +105,7 @@ function SingleImageViewer({
           viewBox={`0 0 ${naturalWidth} ${naturalHeight}`}
         >
           {allowsScrolling && (
-            <desc id='scrolling-info'>In pan mode, use CTRL + scroll to zoom.</desc>
+            <desc id='scrolling-info'>{t('SubjectViewer.zoomHelp')}</desc>
           )}
           {title?.id && title?.text && (
             <title id={title.id}>{title.text}</title>


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6061

## Describe your changes
- Use a Grid for the subject viewer layout instead of a flexbox

## How to Review
- There are screenshots of Squirrel Mapper in the linked Issue, but Active Asteroids and Daily Minor Planet are good projects to test too
- [x] Run app-project and compare Active Asteroids [locally](https://local.zooniverse.org:3000/projects/orionnau/active-asteroids/classify/workflow/17169?env=production&demo=true) to [production](https://www.zooniverse.org/projects/orionnau/active-asteroids/classify/workflow/17169) on a screen size smaller and larger than 768px (the breakpoint when it stacks vertically).
- [x] The horizontal layout should be unchanged, but the vertically stacked layout should allow the subject image to increase to either its intrinsic dimensions or limited to 90vh
- [ ] You may want to toggle limit-subject-height for your test [Survey Task Project](https://frontend.preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project?env=staging), too

# Checklist

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated