### PR TITLE
lib-classifier: Refactor ImageToolbar buttons Annotate and Move per active step annotate task

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.js
@@ -8,6 +8,7 @@ const DEFAULT_HANDLER = () => {}
 
 function AnnotateButton({
   active = false,
+  disabled = false,
   onClick = DEFAULT_HANDLER
 }) {
   const { t } = useTranslation('components')
@@ -16,6 +17,7 @@ function AnnotateButton({
       active={active}
       aria-pressed={active.toString()}
       a11yTitle={t('ImageToolbar.AnnotateButton.ariaLabel')}
+      disabled={disabled}
       icon={<EditIcon />}
       onClick={onClick}
     />
@@ -24,6 +26,7 @@ function AnnotateButton({
 
 AnnotateButton.propTypes = {
   active: PropTypes.bool,
+  disabled: PropTypes.bool,
   onClick: PropTypes.func
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.spec.js
@@ -5,13 +5,25 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import zooTheme from '@zooniverse/grommet-theme'
 
+import { DrawingTaskFactory, WorkflowFactory } from '@test/factories'
 import mockStore from '@test/mockStore'
 
 import AnnotateButtonContainer from './AnnotateButtonContainer'
 
 describe('Component > AnnotateButton', function () {
-  function withStore (store) {
-    return function Wrapper ({ children }) {
+  const workflow = WorkflowFactory.build()
+  const drawingTask = DrawingTaskFactory.build({
+    instruction: 'Draw a point',
+    taskKey: 'T1',
+    tools: [{
+      type: 'point'
+    }],
+    type: 'drawing'
+  })
+  workflow.tasks = [drawingTask]
+
+  function withStore(store) {
+    return function Wrapper({ children }) {
       return (
         <Grommet theme={zooTheme}>
           <Provider classifierStore={store}>
@@ -23,7 +35,7 @@ describe('Component > AnnotateButton', function () {
   }
   
   it('should have an accessible name', function () {
-    const store = mockStore()
+    const store = mockStore({ workflow })
     
     render(
       <AnnotateButtonContainer />, {
@@ -37,7 +49,7 @@ describe('Component > AnnotateButton', function () {
   it('should change the subject viewer annotate and move states when clicked', async function () {
     const user = userEvent.setup({ delay: null })
 
-    const store = mockStore()
+    const store = mockStore({ workflow })
     store.subjectViewer.enableMove()
 
     expect(store.subjectViewer.annotate).to.be.false()
@@ -57,6 +69,31 @@ describe('Component > AnnotateButton', function () {
     expect(store.subjectViewer.annotate).to.be.true()
     expect(store.subjectViewer.move).to.be.false()
     expect (store.subjectViewer.interactionMode).to.equal('annotate')
+  })
 
+  describe('when disabled', function () {
+    it('should not show as pressed and not change the subject viewer annotate and move states', async function () {
+      const user = userEvent.setup({ delay: null })
+
+      const store = mockStore() // mockStore default workflow does not include an annotate task
+      store.subjectViewer.enableMove()
+
+      expect(store.subjectViewer.annotate).to.be.false()
+      expect(store.subjectViewer.move).to.be.true()
+
+      render(
+        <AnnotateButtonContainer />, {
+          wrapper: withStore(store)
+        }
+      )
+
+      const button = screen.getByRole('button', { name: 'ImageToolbar.AnnotateButton.ariaLabel' })
+      expect(button).to.have.attribute('aria-pressed', 'false')
+      await user.click(button)
+      expect(button).to.have.attribute('aria-pressed', 'false')
+
+      expect(store.subjectViewer.annotate).to.be.false()
+      expect(store.subjectViewer.move).to.be.true()
+    })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.stories.js
@@ -1,27 +1,31 @@
-import { Box } from 'grommet'
 import AnnotateButton from './AnnotateButton'
-
-const args = {
-  active: false
-}
+import { ComponentDecorator } from '../shared/ComponentDecorator'
 
 export default {
   title: 'Image Toolbar / AnnotateButton',
   component: AnnotateButton,
+  decorators: [ComponentDecorator],
   argTypes: {
+    active: {
+      control: 'boolean',
+      value: false
+    },
+    disabled: {
+      control: 'boolean',
+      value: false
+    },
     onClick: {
       action: 'clicked'
     }
   },
-  args
 }
 
-export function Default({ active, onClick }) {
+export function Default({ active, disabled, onClick }) {
   return (
-    <Box width='72px'>
-      <Box pad='12px'>
-        <AnnotateButton active={active} onClick={onClick} />
-      </Box>
-    </Box>
+    <AnnotateButton
+      active={active}
+      disabled={disabled}
+      onClick={onClick}
+    />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButtonContainer.js
@@ -5,12 +5,21 @@ import { useStores } from '@hooks'
 import AnnotateButton from './AnnotateButton'
 
 function storeMapper(classifierStore) {
-  const { annotate, enableAnnotate, separateFramesView } =
-    classifierStore.subjectViewer
+  const {
+    subjectViewer: {
+      annotate,
+      enableAnnotate,
+      separateFramesView
+    },
+    workflowSteps: {
+      hasActiveAnnotateTask
+    }
+  } = classifierStore
 
   return {
     annotate,
     enableAnnotate,
+    hasActiveAnnotateTask,
     separateFramesView
   }
 }
@@ -22,12 +31,14 @@ function AnnotateButtonContainer({
   const {
     annotate,
     enableAnnotate,
+    hasActiveAnnotateTask,
     separateFramesView
   } = useStores(storeMapper)
 
   return (
     <AnnotateButton
       active={separateFramesView ? separateFrameAnnotate : annotate}
+      disabled={!hasActiveAnnotateTask}
       onClick={
         separateFramesView ? separateFrameEnableAnnotate : enableAnnotate
       }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButtonContainer.js
@@ -6,15 +6,11 @@ import AnnotateButton from './AnnotateButton'
 
 function storeMapper(classifierStore) {
   const {
-    subjectViewer: {
-      annotate,
-      enableAnnotate,
-      separateFramesView
-    },
-    workflowSteps: {
-      hasActiveAnnotateTask
-    }
-  } = classifierStore
+    annotate,
+    enableAnnotate,
+    hasActiveAnnotateTask,
+    separateFramesView
+  } = classifierStore.subjectViewer
 
   return {
     annotate,

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -25,14 +25,6 @@ const StyledButton = styled(GrommetButton)`
     margin-bottom: clamp(8px, 20%, 10px);
     // similar to padding of Image Toolbar
   }
-  
-  &[aria-pressed='true'] {
-    background-color: ${props => props.theme.global.colors.brand};
-
-    > svg {
-      fill: white;
-    }
-  }
 
   &:disabled {
     cursor: not-allowed;
@@ -59,6 +51,22 @@ const StyledButton = styled(GrommetButton)`
 
       > path {
         fill: ${props => (props.theme.dark ? 'black' : 'white')};
+      }
+    }
+  }
+
+  &[aria-pressed='true'] {
+    background-color: ${props => props.theme.global.colors.brand};
+
+    > svg {
+      fill: white;
+    }
+
+    &:not(:hover) {
+      background-color: ${props => props.theme.global.colors.brand};
+      
+      > svg {
+        fill: white;
       }
     }
   }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -38,8 +38,8 @@ const StyledButton = styled(GrommetButton)`
     cursor: not-allowed;
   }
 
-  &:hover:not(:disabled):not([aria-pressed='true']),
-  &:focus:not(:disabled):not([aria-pressed='true']) {
+  &:hover:not(:disabled),
+  &:focus:not(:disabled) {
     ${props =>
       props.theme.dark
         ? css`

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -38,8 +38,8 @@ const StyledButton = styled(GrommetButton)`
     cursor: not-allowed;
   }
 
-  &:hover:not(:disabled),
-  &:focus:not(:disabled) {
+  &:hover:not(:disabled):not([aria-pressed='true']),
+  &:focus:not(:disabled):not([aria-pressed='true']) {
     ${props =>
       props.theme.dark
         ? css`

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -31,7 +31,7 @@ const StyledButton = styled(GrommetButton)`
   }
 
   &:hover:not(:disabled),
-  &:focus:not(:disabled) {
+  &:focus-visible:not(:disabled) {
     ${props =>
       props.theme.dark
         ? css`

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButton.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButton.stories.js
@@ -1,26 +1,31 @@
-import { Box } from 'grommet'
 import FullscreenButton from './FullscreenButton'
-
-const args = {
-  active: false,
-  disabled: false
-}
+import { ComponentDecorator } from '../shared/ComponentDecorator'
 
 export default {
   title: 'Image Toolbar / FullscreenButton',
   component: FullscreenButton,
+  decorators: [ComponentDecorator],
   argTypes: {
+    active: {
+      control: 'boolean',
+      value: false
+    },
+    disabled: {
+      control: 'boolean',
+      value: false
+    },
     onClick: {
       action: 'clicked'
     }
-  },
-  args
+  }
 }
 
 export function Default({ active, disabled, onClick }) {
   return (
-    <Box width='72px' pad='12px'>
-      <FullscreenButton active={active} disabled={disabled} onClick={onClick} />
-    </Box>
+    <FullscreenButton
+      active={active}
+      disabled={disabled}
+      onClick={onClick}
+    />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/InvertButton/InvertButton.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/InvertButton/InvertButton.stories.js
@@ -1,31 +1,31 @@
-import { Box } from 'grommet'
-
 import InvertButton from './InvertButton'
-
-const args = {
-  active: false,
-  disabled: false,
-}
+import { ComponentDecorator } from '../shared/ComponentDecorator'
 
 export default {
   title: 'Image Toolbar / InvertButton',
   component: InvertButton,
+  decorators: [ComponentDecorator],
   argTypes: {
+    active: {
+      control: 'boolean',
+      value: false
+    },
+    disabled: {
+      control: 'boolean',
+      value: false
+    },
     onClick: {
       action: 'clicked'
     }
-  },
-  args
+  }
 }
 
 export function Default({ active, disabled, onClick }) {
   return (
-    <Box width='72px' pad='12px'>
-      <InvertButton
-        active={active}
-        disabled={disabled}
-        onClick={onClick}
-      />
-    </Box>
+    <InvertButton
+      active={active}
+      disabled={disabled}
+      onClick={onClick}
+    />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.stories.js
@@ -1,30 +1,31 @@
-import { Box } from 'grommet'
 import MoveButton from './MoveButton'
-
-const args = {
-  active: false,
-  disabled: false,
-}
+import { ComponentDecorator } from '../shared/ComponentDecorator'
 
 export default {
   title: 'Image Toolbar / MoveButton',
   component: MoveButton,
+  decorators: [ComponentDecorator],
   argTypes: {
+    active: {
+      control: 'boolean',
+      value: false
+    },
+    disabled: {
+      control: 'boolean',
+      value: false
+    },
     onClick: {
       action: 'clicked'
     }
-  },
-  args
+  }
 }
 
 export function Default({ active, disabled, onClick }) {
   return (
-    <Box width='72px' pad='12px'>
-      <MoveButton
-        active={active}
-        disabled={disabled}
-        onClick={onClick}
-      />
-    </Box>
+    <MoveButton
+      active={active}
+      disabled={disabled}
+      onClick={onClick}
+    />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButton.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButton.stories.js
@@ -1,25 +1,26 @@
-import { Box } from 'grommet'
 import ResetButton from './ResetButton'
-
-const args = {
-  disabled: false
-}
+import { ComponentDecorator } from '../shared/ComponentDecorator'
 
 export default {
   title: 'Image Toolbar / ResetButton',
   component: ResetButton,
+  decorators: [ComponentDecorator],
   argTypes: {
+    disabled: {
+      control: 'boolean',
+      value: false
+    },
     onClick: {
       action: 'clicked'
     }
-  },
-  args
+  }
 }
 
 export function Default({ disabled, onClick }) {
   return (
-    <Box width='72px' pad='12px'>
-      <ResetButton disabled={disabled} onClick={onClick} />
-    </Box>
+    <ResetButton
+      disabled={disabled}
+      onClick={onClick}
+    />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.stories.js
@@ -1,25 +1,26 @@
-import { Box } from 'grommet'
 import RotateButton from './RotateButton'
-
-const args = {
-  disabled: false
-}
+import { ComponentDecorator } from '../shared/ComponentDecorator'
 
 export default {
   title: 'Image Toolbar / RotateButton',
   component: RotateButton,
+  decorators: [ComponentDecorator],
   argTypes: {
+    disabled: {
+      control: 'boolean',
+      value: false
+    },
     onClick: {
       action: 'clicked'
     }
-  },
-  args
+  }
 }
 
 export function Default({ disabled, onClick }) {
   return (
-    <Box width='72px' pad='12px'>
-      <RotateButton disabled={disabled} onClick={onClick} />
-    </Box>
+    <RotateButton
+      disabled={disabled}
+      onClick={onClick}
+    />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.stories.js
@@ -1,25 +1,26 @@
-import { Box } from 'grommet'
 import ZoomInButton from './ZoomInButton'
-
-const args = {
-  disabled: false
-}
+import { ComponentDecorator } from '../shared/ComponentDecorator'
 
 export default {
   title: 'Image Toolbar / ZoomInButton',
   component: ZoomInButton,
+  decorators: [ComponentDecorator],
   argTypes: {
+    disabled: {
+      control: 'boolean',
+      value: false
+    },
     onClick: {
       action: 'clicked'
     }
-  },
-  args
+  }
 }
 
 export function Default({ disabled, onClick }) {
   return (
-    <Box width='72px' pad='12px'>
-      <ZoomInButton disabled={disabled} onClick={onClick} />
-    </Box>
+    <ZoomInButton
+      disabled={disabled}
+      onClick={onClick}
+    />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.stories.js
@@ -1,25 +1,26 @@
-import { Box } from 'grommet'
 import ZoomOutButton from './ZoomOutButton'
-
-const args = {
-  disabled: false
-}
+import { ComponentDecorator } from '../shared/ComponentDecorator'
 
 export default {
   title: 'Image Toolbar / ZoomOutButton',
   component: ZoomOutButton,
+  decorators: [ComponentDecorator],
   argTypes: {
+    disabled: {
+      control: 'boolean',
+      value: false
+    },
     onClick: {
       action: 'clicked'
     }
-  },
-  args
+  }
 }
 
 export function Default({ disabled, onClick }) {
   return (
-    <Box width='72px' pad='12px'>
-      <ZoomOutButton disabled={disabled} onClick={onClick} />
-    </Box>
+    <ZoomOutButton
+      disabled={disabled}
+      onClick={onClick}
+    />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/shared/ComponentDecorator.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/shared/ComponentDecorator.js
@@ -1,0 +1,13 @@
+import { Box } from 'grommet'
+
+export function ComponentDecorator(Story) {
+  return (
+    <Box
+      margin={{ left: '250px' }}
+      pad='12px'
+      width='72px'
+    >
+      <Story />
+    </Box>
+  )
+}

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -183,7 +183,7 @@ const SubjectViewer = types
           self.enableMove()
         }
 
-        self.showAnnotate = canAnnotate
+        self.showAnnotate = canAnnotate 
       },
 
       setFlipbookSpeed (speed) {

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -182,8 +182,6 @@ const SubjectViewer = types
         } else {
           self.enableMove()
         }
-
-        self.showAnnotate = canAnnotate 
       },
 
       setFlipbookSpeed (speed) {

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -49,6 +49,10 @@ const SubjectViewer = types
       return false
     },
 
+    get hasActiveAnnotateTask () {
+      return getRoot(self)?.workflowSteps.hasActiveAnnotateTask
+    },
+
     get hasAnnotateTask () {
       return getRoot(self)?.workflowSteps.hasAnnotateTask
     },
@@ -75,8 +79,8 @@ const SubjectViewer = types
       afterAttach () {
         function _syncAnnotateVisibility() {
           // Make sure the right button is active in the ImageToolbar
-          self.setAnnotateVisibility(self.hasAnnotateTask)
-          if (self.hasAnnotateTask) {
+          self.setAnnotateVisibility(self.hasActiveAnnotateTask)
+          if (self.hasActiveAnnotateTask) {
             self.enableAnnotate()
           } else {
             self.enableMove()

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -1,4 +1,4 @@
-import { autorun, toJS } from 'mobx'
+import { autorun } from 'mobx'
 import {
   addDisposer,
   applySnapshot,
@@ -75,7 +75,17 @@ const WorkflowStepStore = types
       return activeInteractionTask || {}
     },
 
-    // Needs to check all steps, not just the active one
+    // check only active step tasks for annotate task
+    get hasActiveAnnotateTask () {
+      for (const task of self.activeStepTasks) {
+        if (task.type === 'drawing' || task.type === 'transcription' || task.type === 'dataVisAnnotation' || task.type === 'subjectGroupComparison') {
+          return true
+        }
+      }
+      return false
+    },
+
+    // check all steps, not just the active one, for annotate task
     get hasAnnotateTask () {
       for (const key in self.workflow?.tasks) {
         const task = self.workflow.tasks[key]

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
@@ -1,5 +1,3 @@
-import RootStore from '../RootStore'
-
 import WorkflowStepStore from './WorkflowStepStore'
 import {
   DrawingTaskFactory,


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #6779 
- iteration on #5994 

## Describe your changes
- add a disabled state to Annotate button
- refactor WorkflowStepStore with `hasActiveAnnotateTask` for annotate task in active step
- refactor SubjectViewerStore to enable annotate or move per `hasActiveAnnotateTask`
- refactor ImageToolbar Button pressed (not) hover styling, see https://github.com/zooniverse/front-end-monorepo/issues/6779#issuecomment-2768686700

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - lib-classifier:
    - staging test project: https://local.zooniverse.org:8080/?project=335
    - ⚠️ production project ⚠️ : https://local.zooniverse.org:8080/?project=22977&env=production&workflow=25770
  - app-project:
    - staging test project: https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats/classify/workflow/693?env=staging
    - ⚠️ production project ⚠️ : https://local.zooniverse.org:3000/projects/zookeeper/elephant-id-ey/classify/workflow/25770?env=production&demo=true
- What user actions should my reviewer step through to review this PR?
  - load workflow with annotate task in subsequent step
  - note initial step without annotate task subject viewer is in move mode and annotate button is disabled
  - note that in step with annotate task subject viewer is in annotate mode and annotate button is enabled
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected