### PR TITLE
Convert Audio tests from Enzyme to RTL

### DIFF
--- a/packages/lib-react-components/src/Media/components/Audio/Audio.spec.js
+++ b/packages/lib-react-components/src/Media/components/Audio/Audio.spec.js
@@ -1,39 +1,38 @@
-import { shallow } from 'enzyme'
+import { render } from '@testing-library/react'
 
 import Audio from './Audio'
 
 const audio = 'https://panoptes-uploads.zooniverse.org/production/subject_location/1c93591f-5d7e-4129-a6da-a65419b88048.mpga'
 
 describe('Audio', function () {
-  it('should render without crashing', function () {
-    const wrapper = shallow(<Audio src={audio} />)
-    expect(wrapper).to.be.ok
-  })
-
   it('should render an audio element', function () {
-    const wrapper = shallow(<Audio src={audio} />)
-    expect(wrapper.find('audio')).to.have.lengthOf(1)
+    render(<Audio src={audio} />)
+    const audioElement = document.querySelector('audio')
+    expect(audioElement).to.exist()
   })
 
   it('should set the aria-title using the alt prop', function () {
     const alt = "City noise"
-    const wrapper = shallow(<Audio alt={alt} src={audio} />)
-    expect(wrapper.find('audio').props()['aria-label']).to.equal(alt)
+    render(<Audio alt={alt} src={audio} />)
+    const audioElement = document.querySelector('audio')
+    expect(audioElement.getAttribute('aria-label')).to.equal(alt)
   })
 
   describe('height and width', function () {
     it('should be set if specified', function () {
-      const wrapper = shallow(<Audio height={200} width={270} src={audio} />)
-      const { maxHeight, maxWidth } = wrapper.props()
-      expect(maxHeight).to.equal(200)
-      expect(maxWidth).to.equal(270)
+      render(<Audio height={200} width={270} src={audio} />)
+      const audioWrapper = document.querySelector('[class*="Audio__StyledBox"]')
+      const computedStyle = window.getComputedStyle(audioWrapper)
+      expect(computedStyle.maxHeight).to.equal('200px')
+      expect(computedStyle.maxWidth).to.equal('270px')
     })
 
     it('should be ignored if not specified', function () {
-      const wrapper = shallow(<Audio src={audio} />)
-      const { maxHeight, maxWidth } = wrapper.props()
-      expect(maxHeight).to.be.undefined()
-      expect(maxWidth).to.be.undefined()
+      render(<Audio src={audio} />)
+      const audioWrapper = document.querySelector('[class*="Audio__StyledBox"]')
+      const computedStyle = window.getComputedStyle(audioWrapper)
+      expect(computedStyle.maxHeight).to.be.empty
+      expect(computedStyle.maxWidth).to.equal('100%')
     })
   })
 })


### PR DESCRIPTION
## Package
- lib-react-components

## Describe your changes
Converted tests from Enzyme to RTL. No changes other than to test file.

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser