### PR TITLE
lib-classifier: Refactor InteractionLayer svgContext canvas definition

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -53,7 +53,10 @@ function InteractionLayer({
   const [creating, setCreating] = useState(false)
   const svgContext = useContext(SVGContext)
   const canvasRef = useRef()
-  svgContext.canvas = canvasRef.current
+  
+  if (canvasRef.current) {
+    svgContext.canvas = canvasRef.current
+  }
 
   if (creating && !activeMark) {
     setCreating(false)


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #6881 

## Describe your changes
- refactor InteractionLayer to define the `svgContext.canvas` (only) if the `canvasRef.current` is defined/truthy
- I think the marks were defined before the canvasRef could be rendered, causing the marks to be rendered off scale, but I'm not entirely sure

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - app-project:
    - ⚠️ production project ⚠️ : https://local.zooniverse.org:3000/projects/aeuk/elephant-id/classify/workflow/24547?demo=true&env=production
  - lib-classifier:
    - staging test project: https://local.zooniverse.org:8080/?project=1779
- What user actions should my reviewer step through to review this PR?
  - draw a mark(s)
  - go to the next step
  - note scale of mark should be consistent
  - go back to previous step
  - note mark should scale and interact as expected
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated