### PR TITLE
fix(lib-classifier): screen scale calculations for SVG subject images

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -1,9 +1,8 @@
 import cuid from 'cuid'
 import PropTypes from 'prop-types'
-import { useContext, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import styled, { css } from 'styled-components'
 
-import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import { convertEvent } from '@plugins/drawingTools/components/draggable/draggable'
 import DrawingToolMarks from './components/DrawingToolMarks'
 import TranscribedLines from './components/TranscribedLines'
@@ -51,11 +50,7 @@ function InteractionLayer({
   duration
 }) {
   const [creating, setCreating] = useState(false)
-  const svgContext = useContext(SVGContext)
   const canvasRef = useRef(null)
-  if (canvasRef.current !== null) {
-    svgContext.canvas = canvasRef.current
-  }
 
   if (creating && !activeMark) {
     setCreating(false)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -52,8 +52,10 @@ function InteractionLayer({
 }) {
   const [creating, setCreating] = useState(false)
   const svgContext = useContext(SVGContext)
-  const canvasRef = useRef()
-  svgContext.canvas = canvasRef.current
+  const canvasRef = useRef(null)
+  if (canvasRef.current !== null) {
+    svgContext.canvas = canvasRef.current
+  }
 
   if (creating && !activeMark) {
     setCreating(false)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/helpers/isInBounds.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/helpers/isInBounds.js
@@ -5,6 +5,8 @@
  * @returns {boolean} true if the two elements overlap.
  */
 export function isInBounds(markElement, canvas) {
+    if (!canvas) return true
+    if (!markElement) return true
     const object = markElement.getBoundingClientRect()
     const bounds = canvas.getBoundingClientRect()
     const notBeyondLeft = object.left + object.width > bounds.left

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageCanvas.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageCanvas.js
@@ -36,11 +36,11 @@ function SingleImageCanvas({
       >
         <svg>
           <g
-            ref={canvasLayer}
             data-testid='single-image-canvas-visxzoom-transform-group'
             transform={transform}
           >
             <g
+              ref={canvasLayer}
               data-testid='single-image-canvas-rotation-transform-group'
               transform={rotationTransform}
             >

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageCanvas.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageCanvas.js
@@ -34,10 +34,9 @@ function SingleImageCanvas({
           transformMatrix
         }}
       >
-        <svg
-          ref={canvasLayer}
-        >
+        <svg>
           <g
+            ref={canvasLayer}
             data-testid='single-image-canvas-visxzoom-transform-group'
             transform={transform}
           >

--- a/packages/lib-classifier/src/plugins/drawingTools/hooks/useScale.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/hooks/useScale.js
@@ -44,13 +44,15 @@ function getScale(svgContext) {
  * @default 1
  */
 export default function useScale() {
-  const svgContext = useContext(SVGContext)
-  const initialScale = getScale(svgContext)
+  const { canvas, rotate = 0 } = useContext(SVGContext)
+  const initialScale = getScale({ canvas, rotate })
   const [scale, setScale] = useState(initialScale)
 
   setTimeout(() => {
-    const newScale = getScale(svgContext)
-    if (newScale !== scale) setScale(newScale)
+    if (!!canvas) {
+      const newScale = getScale({ canvas, rotate})
+      if (newScale !== scale) setScale(newScale)
+    }
   })
 
   return scale


### PR DESCRIPTION
Update `useScale` to check if the `canvas` DOM node exists before calculating the subject image scale on the screen.

Update `isInBounds` to also catch the case where `svgContext.canvas` is undefined or null.

Fix `canvasRef` in `SingleImageCanvas` so that it reports the correct dimensions for the subject image, in Firefox.

Remove the `canvasRef` hack from `InteractionLayer`, now that `SingleImageCanvas` is fixed.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- fixes #6881

## How to Review
Should be the same as #6882.

You'll want to check that this hasn't regressed #6490, so be sure to check in Firefox, with the subject zoomed in. Remember to test with a rotated image too, to make sure that rotation transforms are still correctly accounted for.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated

