### PR TITLE
ProjectLink: fix Bluesky external links

### DIFF
--- a/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/helpers/formatUrlObject/formatUrlObject.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/helpers/formatUrlObject/formatUrlObject.js
@@ -34,6 +34,7 @@ function formatUrlObject(obj, t) {
   if (obj.site && obj.site.includes('bsky.app')) {
     formattedObject.IconComponent = BlueSkyIcon
     formattedObject.type = t('ConnectWithProject.ProjectLink.types.bluesky')
+    formattedObject.url = `https://bsky.app/profile/${obj.path}`
   }
 
   if (obj.site && obj.site.includes('facebook')) {


### PR DESCRIPTION
## PR Overview

Closes: #6907 
Related: zooniverse/Panoptes-Front-End#7313
Package: app-project

This PR fixes an issue where Bluesky links were going to the wrong URLs, i.e. the Bluesky links should go to bsky.app/PROFILE/accountname, not bsky.app/accountname

Changes made:
- formatUrlObject now _dynamically constructs_ Bluesky links, instead of relying on the pre-built URL in projectResource.urls[x].url

### Testing

- Edit a test project _on PFE PR 7313_ , e.g. https://pr-7313.pfe-preview.zooniverse.org/lab/1982?env=staging
- Go to Project Details, Social Links section.
- Add/edit a Bluesky external link, e.g. add the zooniverse.bsky.social account
- Also check that the SocialLinkEditor editor visually makes sense by showing the subpath.
- Add/edit a non-Bluesky external link, e.g. add therealzooniverse account to the Facebook link.
- View the project home page on **FEM app-project**, e.g. https://local.zooniverse.org:3000/projects/darkeshard/example-1982?env=staging
- Ensure that the Bluesky link opens to the correct webpage
- Ensure that the non-Bluesky link opens to the correct webpage.

### Dev Notes

So, some details on the changes. Let's say we have Project1234:

```
project1234Resource = {
  ...
  urls: [
    { url: "https://bsky.app/example", path: "example", site: "bsky.app/", label: "" }
  ]
}
``` 

Instead of using project1234Resource.urls[0].url to create the external project link (which is the default behaviour), the formatUrlObject() now purposely reconstructs it into the correct https://bsky.app/profile/example

This is done EVEN THOUGH zooniverse/Panoptes-Front-End#7313 now corrects the project resource's URLs (i.e. moving forward, all Bluesky links will be like project1234Resource.urls[0].url = "https://bsky.app/profile/example"), because that "correction" can only occur _when a project owner re-updates the Bluesky links after PFE PR 7313 is merged & deployed._

### Status

Ready for review. Low priority.