### PR TITLE
fix(classifier): infinite zoom bug

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
@@ -22,6 +22,7 @@ function ZoomInButton ({
       disabled={disabled}
       icon={<ZoomInIcon />}
       onClick={onClick}
+      onContextMenu={onClick}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
     />

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -38,6 +38,8 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
   function onPointerUp(event) {
     const { currentTarget, pointerId } = event
     currentTarget.releasePointerCapture(pointerId)
+    clearInterval(timer)
+    setTimer('')
   }
 
   return (

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -23,6 +23,7 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
   const zoomCallback = separateFrameZoomIn || zoomIn
 
   function onClick() {
+    // Stop the zoom callback
     clearInterval(timer)
     zoomCallback()
   }
@@ -30,6 +31,7 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
   function onPointerDown(event) {
     const { currentTarget, pointerId } = event
     clearInterval(timer)
+    // Start the zoom callback running every 100ms
     const newTimer = setInterval(zoomCallback, 100)
     setTimer(newTimer)
     currentTarget.setPointerCapture(pointerId)
@@ -38,6 +40,7 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
   function onPointerUp(event) {
     const { currentTarget, pointerId } = event
     currentTarget.releasePointerCapture(pointerId)
+    // Stop the zoom callback
     clearInterval(timer)
     setTimer('')
   }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
@@ -22,6 +22,7 @@ function ZoomOutButton({
       disabled={disabled}
       icon={<ZoomOutIcon />}
       onClick={onClick}
+      onContextMenu={onClick}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
     />

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -38,6 +38,8 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
   function onPointerUp(event) {
     const { currentTarget, pointerId } = event
     currentTarget.releasePointerCapture(pointerId)
+    clearInterval(timer)
+    setTimer('')
   }
 
   return (

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -23,6 +23,7 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
   const zoomCallback = separateFrameZoomOut || zoomOut
 
   function onClick() {
+    // stop the zoom callback
     clearInterval(timer)
     zoomCallback()
   }
@@ -30,6 +31,7 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
   function onPointerDown(event) {
     const { currentTarget, pointerId } = event
     clearInterval(timer)
+    // start the zoom callback running every 100s
     const newTimer = setInterval(zoomCallback, 100)
     setTimer(newTimer)
     currentTarget.setPointerCapture(pointerId)
@@ -38,6 +40,7 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
   function onPointerUp(event) {
     const { currentTarget, pointerId } = event
     currentTarget.releasePointerCapture(pointerId)
+    // stop the zoom callback
     clearInterval(timer)
     setTimer('')
   }


### PR DESCRIPTION
Fix a bug where zoom in/out becomes stuck at either maximum or minimum zoom after `pointerup` by remembering to clear the current timer when the pointer is released.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #6921.
- reverts a change from #5050.
- Talk: [infinite zoom in FEM still happens](https://www.zooniverse.org/talk/17/3683475?comment=6051429&page=1).

## How to Review

Zoom in or out, but release the pointer while off the pressed button. This fires the `pointerup` handler, but not the `click` handler.

https://github.com/user-attachments/assets/0b9b159e-b80a-4ace-a75e-de04b1302017



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

