### PR TITLE
Caesar Reduction Fetch not respecting ToolIndex

### DIFF
--- a/packages/lib-classifier/src/hooks/useMachineLearntReductions.js
+++ b/packages/lib-classifier/src/hooks/useMachineLearntReductions.js
@@ -37,8 +37,8 @@ export default function useMachineLearntReductions() {
         newMark.id = newMark.markId;
         delete newMark.markId;
 
-        const task = step?.tasks[0]	// we only get access to one task at a time in a step
-        task?.activeTool.createMark(newMark)
+        // we only get access to one task at a time in a step
+        step?.tasks[0].tools[newMark.toolIndex]?.createMark(newMark)
       })
     }
 


### PR DESCRIPTION
## Package
- [ ] lib-classifier

## Describe your changes
Make it so that when we add a mark we do it to the right tool

## How to Review
Load up the `lib-classifier` and view this project: https://local.zooniverse.org:8080/?project=22358&env=production

When you load up that project outside of this branch, all of the boxes should be green (i.e. they don't respect toolIndex). Load it up in this branch and you'll see mostly yellow/red/blue boxes instead.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated