### PR TITLE
lib-classifier: Fix survey task question answer label translation

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
@@ -32,7 +32,7 @@ export default function Questions({
         const question = questions.get(questionId) || { answers: {}, answersOrder: [] }
         const inputType = question.multiple ? 'checkbox' : 'radio'
         const options = question.answersOrder.map(answerId => ({
-          label: question.answers.get(answerId).label,
+          label: strings.get(`questions.${questionId}.answers.${answerId}.label`),
           value: answerId
         }))
 


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- see this Slack thread
- ⚠️ production workflow ⚠️ : https://www.zooniverse.org/projects/fr/crea-mont-blanc/wild-mont-blanc/classify/workflow/7551
- click linked workflow, click Marmotte, note question answers are **_NOT_** translated

## Describe your changes
- get translated question answer label from translations strings

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - ⚠️ production workflow ⚠️ : https://local.zooniverse.org:3000/projects/fr/crea-mont-blanc/wild-mont-blanc/classify/workflow/7551?env=production&demo=true
- What user actions should my reviewer step through to review this PR?
  - click linked workflow, click Marmotte, note question answers are translated
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated