### PR TITLE
Add Classifier build to Storybook deploy pipeline

### DIFF
--- a/.github/workflows/deploy_storybook.yml
+++ b/.github/workflows/deploy_storybook.yml
@@ -21,6 +21,7 @@ jobs:
       - run: yarn install --production=false --frozen-lockfile
       - run: yarn workspace @zooniverse/react-components build:es6
       - run: yarn workspace @zooniverse/subject-viewers build:es6
+      - run: yarn workspace @zooniverse/classifier build:es6
       - name: Deploy to GH Pages
         run: yarn deploy-storybook -- --ci
         env:


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Describe your changes
Inspired by today's deploy build [failing](https://github.com/zooniverse/front-end-monorepo/actions/runs/16198155248). After investigation of a nondescript error `failure to build fe-project`, I remembered something like this happened when I first created the `lib-subject-viewers` package and added it to our deploy process. 

The solution ended up needing to build the `lib-classifier` as part of the yaml file. I believe this has to do with the fixed `VolumetricViewer.stories.js` that was part of this week's deploy and its asynchronous import of `lib-subject-viewers`... i.e. Storybook can't build+deploy properly without its underlying packages building the importable dependencies (i.e `fe-project` depends upon `lib-classifier`). 

Working deploy process is [here](https://github.com/zooniverse/front-end-monorepo/actions/runs/16203268180), which was built off of this branch.