### PR TITLE
Fix issue with mobile scrolling for tutorial popup on safari.

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
@@ -1,12 +1,16 @@
 import { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
 import { ResponsiveContext } from 'grommet'
 import { Modal } from '@zooniverse/react-components'
-import asyncStates from '@zooniverse/async-states'
 import { useTranslation } from '@translations/i18n'
-
 import { withStores } from '@helpers'
 import SlideTutorial from '../SlideTutorial'
+
+const StyledModal = styled(Modal)`
+  max-height: 80vh;
+`
 
 function storeMapper (classifierStore) {
   const {
@@ -45,7 +49,7 @@ function ModalTutorial ({
 
   if (tutorial) {
     return (
-      <Modal
+      <StyledModal
         {...props}
         active={active}
         closeFn={onClose}
@@ -56,7 +60,7 @@ function ModalTutorial ({
           pad='none'
           width={width}
         />
-      </Modal>
+      </StyledModal>
     )
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -1,11 +1,15 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Box, Button, Heading, Paragraph } from 'grommet'
+import { Box, Button, Paragraph } from 'grommet'
 import { Markdownz, Media } from '@zooniverse/react-components'
 import { useTranslation } from '@translations/i18n'
 
 import StepNavigation from '@shared/StepNavigation'
+
+const StyledBox = styled(Box)`
+  max-height: 80vh;
+`
 
 const StyledMarkdownWrapper = styled(Box)`
   > h1, h2 {
@@ -48,7 +52,6 @@ function SlideTutorial({
   const { t } = useTranslation('components')
   const { medium, step } = stepWithMedium(stepIndex)
   const isThereMedia = medium?.src
-  const isFirstStep = stepIndex === 0
   const isLastStep = stepIndex === steps.length - 1
 
   if (!step) {
@@ -60,7 +63,7 @@ function SlideTutorial({
   }
 
   return (
-    <Box
+    <StyledBox
       className={className}
       height={height}
       justify='between'
@@ -95,7 +98,7 @@ function SlideTutorial({
           margin={{ top: 'medium' }}
           primary
         />}
-    </Box>
+    </StyledBox>
   )
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -7,10 +7,6 @@ import { useTranslation } from '@translations/i18n'
 
 import StepNavigation from '@shared/StepNavigation'
 
-const StyledBox = styled(Box)`
-  max-height: 80vh;
-`
-
 const StyledMarkdownWrapper = styled(Box)`
   > h1, h2 {
     font-size: 26px;
@@ -63,7 +59,7 @@ function SlideTutorial({
   }
 
   return (
-    <StyledBox
+    <Box
       className={className}
       height={height}
       justify='between'
@@ -98,7 +94,7 @@ function SlideTutorial({
           margin={{ top: 'medium' }}
           primary
         />}
-    </StyledBox>
+    </Box>
   )
 }
 


### PR DESCRIPTION
## Package
- [ ] lib-classifier

## Linked Issue and/or Talk Post
https://github.com/zooniverse/front-end-monorepo/issues/6093

## Describe your changes
Added a `max-height: 80vh;` to the tutorial containing div. This leaves the tutorial unaffected on desktop while accommodating the mobile experience. I tried to use the new unit of 'dvh' but that did not work for mobile safari on my device. The downside (which I consider negligible to the existing non-functionality) is that on other mobile browsers there is extra/dead space below the tutorial navigation.

## How to Review
Load up `app-project` locally, find your computer's local IP address in the WiFi settings, and then load up the Woodpecker Cavity Cam project main page on your iOS device. From there, you can select a workflow and view the changes to the tutorial (helps testing in a private tab). 

Example URL (please update with your machine's IP address): https://192.168.0.41:3000/projects/elwest/woodpecker-cavity-cam?env=production

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._