### PR TITLE
lib-react-components: Edit IconActionButton aria-checked styling and ImageIconButton disabled attributtes

### DIFF
--- a/packages/lib-react-components/src/IconActionButton/IconActionButton.js
+++ b/packages/lib-react-components/src/IconActionButton/IconActionButton.js
@@ -63,7 +63,8 @@ const StyledButton = styled(GrommetButton)`
   }
 
   &:active:not(:disabled),
-  &[aria-pressed='true'] {
+  &[aria-pressed='true'],
+  &[aria-checked='true'] {
     background-color: ${props => props.theme.global.colors['neutral-1']};
 
     > svg {

--- a/packages/lib-react-components/src/IconActionButton/IconActionButton.stories.js
+++ b/packages/lib-react-components/src/IconActionButton/IconActionButton.stories.js
@@ -40,7 +40,7 @@ export const Active = {
   }
 }
 
-export const CloseButton = {
+export const CustomIconButton = {
   args: {
     a11yTitle: 'Close',
     icon: <CloseIcon />

--- a/packages/lib-react-components/src/ImageIconButton/ImageIconButton.js
+++ b/packages/lib-react-components/src/ImageIconButton/ImageIconButton.js
@@ -17,8 +17,8 @@ function ImageIconButton({
       disabled={disabled}
       href={disabled ? undefined : href}
       icon={<Image />}
-      rel='noopener noreferrer'
-      target='_blank'
+      rel={disabled ? undefined : 'noopener noreferrer'}
+      target={disabled ? undefined : '_blank'}
       {...props}
     />
   )


### PR DESCRIPTION
## Package
- lib-react-components

## Describe your changes
- if ImageIconButton is disabled, do not define `rel` or `target` per https://github.com/zooniverse/front-end-monorepo/pull/6963#pullrequestreview-3024751542
- add `IconActionButton` aria-checked styling for `role='checkbox'` like with `InvertIconButton`

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
  - http://localhost:6007/?path=/story/components-imageiconbutton--disabled
  - http://localhost:6007/?path=/story/components-inverticonbutton--checked
- Are there plans for follow up PR’s to further fix this bug or develop this feature?
  - see linked GitHub project

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated