### PR TITLE
fix(classifier): add z-index to QuickTalk

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -16,6 +16,7 @@ const FixedBox = styled(Box)`
   right: 2.5em;
   max-width: 80vw;
   max-height: 80vh;
+  z-index: 10;
 `
 
 const ButtonContainer = styled(Box)`


### PR DESCRIPTION
Add `z-index: 10;` to `QuickTalk`, so that it is stacked above other content on the page.

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- fixes #6973.

## How to Review
On a workflow with Quick Talk, the Talk dialog should now appear above Recent Classifications subjects, not behind them. See #6973 for details (and screenshots of this change in Firefox and Chrome.)

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
