### PR TITLE
Use SWR mutate to modify icon checked or not-checked

### DIFF
--- a/packages/lib-react-components/src/FavoritesIconButton/FavoritesIconButton.js
+++ b/packages/lib-react-components/src/FavoritesIconButton/FavoritesIconButton.js
@@ -1,6 +1,5 @@
 import { Favorite } from 'grommet-icons'
 import { bool, func } from 'prop-types'
-import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { useTranslation } from '../translations/i18n'
@@ -20,27 +19,20 @@ function FavoritesIconButton({
   disabled = false,
   onClick = DEFAULT_HANDLER
 }) {
-  const [isFavorite, setIsFavorite] = useState(checked)
-
-  useEffect(function updateIsFavorite() {
-    setIsFavorite(checked)
-  }, [checked])
-
   const { t } = useTranslation()
 
-  const label = isFavorite ? 'FavouritesButton.remove' : 'FavouritesButton.add'
+  const label = checked ? 'FavouritesButton.remove' : 'FavouritesButton.add'
 
   function toggleFavorite() {
-    setIsFavorite(!isFavorite)
     onClick()
   }
 
   return (
     <IconActionButton
       a11yTitle={t(label)}
-      aria-checked={isFavorite}
+      aria-checked={checked}
       disabled={disabled}
-      icon={<StyledFavorite $isFavorite={isFavorite} />}
+      icon={<StyledFavorite $isFavorite={checked} />}
       role='checkbox'
       onClick={toggleFavorite}
     />

--- a/packages/lib-react-components/src/hooks/Readme.md
+++ b/packages/lib-react-components/src/hooks/Readme.md
@@ -107,5 +107,5 @@ const query = {
   project_ids: ['1234'],
   owner: 'user_login'
 }
-const { data, error, isLoading } = useUserCollections({ query })
+const { data, error, isLoading, mutate } = useUserCollections({ query })
 ```


### PR DESCRIPTION
## Package
lib-react-components

## Linked Issue and/or Talk Post
Stacks on top of https://github.com/zooniverse/front-end-monorepo/pull/6958. In that PR, `mutate` was considered for an optimistic UI strategy, but the implementation needs adjustment. In order to mutate cache state without a network delay, the function in SWR's `mutate` should not rely on an async response from panoptes. In this PR, I separated the handling of `mutate` from the API calls, which implements an optimistic UI and no need to compensate with a  `useState` / `useEffect` pattern in FavoritesIconButton.

## Describe your changes
- Remove the extra `useState` and `useEffect` from FavoritesIconButton
- Grab `mutate` from `useUserCollections` and use it to return modified `data` in a local, optimistic pattern

## How to Review
- Run app-project locally in dev mode and use https://local.zooniverse.org:3000/projects/markb-panoptes/sltp-test-project-staging/talk/subjects/252639 to favorite and unfavorite the subject

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected