### PR TITLE
app-project: Add TalkComment component

### DIFF
--- a/packages/app-project/public/locales/en/screens.json
+++ b/packages/app-project/public/locales/en/screens.json
@@ -73,9 +73,10 @@
     }
   },
   "Talk": {
-    "searchPlaceholder": "Search this project for tags, subjects, or @users",
-    "subjectMetadata": "Subject Metadata",
     "featuredCollections": "Featured in these Collections",
-    "relatedSubjects": "Other subjects being discussed:"
+    "goToComment": "Go to comment",
+    "relatedSubjects": "Other subjects being discussed:",
+    "searchPlaceholder": "Search this project for tags, subjects, or @users",
+    "subjectMetadata": "Subject Metadata"
   }
 }

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussion/components/TalkComment/TalkComment.js
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussion/components/TalkComment/TalkComment.js
@@ -1,0 +1,148 @@
+import { Markdownz, ZooniverseLogo } from '@zooniverse/react-components'
+import { Anchor, Box, Text } from 'grommet'
+import { Like, LikeFill, Share } from 'grommet-icons'
+import { useTranslation } from 'next-i18next'
+import styled from 'styled-components'
+
+import Avatar from './components/Avatar'
+
+const StyledCommentCard = styled(Box)`
+  &:hover {
+    box-shadow: 1px 1px 4px 0 rgba(0, 0, 0, 0.25);
+  }
+`
+
+const StyledDisplayName = styled(Text)`
+  letter-spacing: 0.8px;
+`
+
+const StyledDate = styled(Text)`
+  ${StyledCommentCard}:hover &,
+  ${StyledCommentCard}:focus &,
+  ${StyledCommentCard}:focus-within & {
+    display: none;
+  }
+`
+
+const StyledLink = styled(Anchor)`
+  display: none;
+
+  ${StyledCommentCard}:hover &,
+  ${StyledCommentCard}:focus &,
+  ${StyledCommentCard}:focus-within & {
+    display: inline-block;
+  }
+`
+
+const StyledLinkLabel = styled(Text)`
+  font-size: 16px;
+  font-weight: 500;
+  text-transform: uppercase;
+`
+
+function TalkComment({
+  avatar = '',
+  body = '',
+  commentLink = '',
+  date = '',
+  displayName = '',
+  login = '',
+  projectSlug = '',
+  upvotes = 0
+}) {
+  const { t } = useTranslation('screens')
+  
+  const localeDate = new Date(date).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  })
+
+  const LikeIcon = upvotes > 0 ? LikeFill : Like
+
+  return (
+    <StyledCommentCard
+      forwardedAs='li'
+      pad='xsmall'
+      round='xxsmall'
+      tabIndex={0}
+    >
+      <Box
+        justify='between'
+        direction='row'
+      >
+        <Box
+          direction='row'
+          gap='xsmall'
+        >
+          {avatar ?
+            <Avatar
+              src={avatar}
+              alt={`${login} avatar`}
+            />
+            : <ZooniverseLogo id='GroupZooniverseLogo' size='50px' color='#00979d' />}
+          <Box
+            justify='center'
+          >
+            <StyledDisplayName
+              color={{ dark: 'accent-1', light: 'neutral-1' }}
+              size='16px'
+            >
+              {displayName}
+            </StyledDisplayName>
+            {login ?
+              <Text
+                size='xsmall'
+                uppercase={false}
+              >
+                @{login}
+              </Text>
+              : null}
+          </Box>
+        </Box>
+        <Box pad={{ top: 'xsmall' }}>
+          <StyledDate
+            size='xsmall'
+            uppercase={false}
+          >
+            {localeDate}
+          </StyledDate>
+          <StyledLink
+            gap='xsmall'
+            href={commentLink}
+            icon={<Share size='14.667px' />}
+            label={<StyledLinkLabel>{t('Talk.goToComment').toUpperCase()}</StyledLinkLabel>}
+          />
+        </Box>
+      </Box>
+      <Box
+        pad={{ left: '60px', top: 'xsmall'}}
+      >
+        <Markdownz
+          baseURI={''}
+          projectSlug={projectSlug}
+        >
+          {body}
+        </Markdownz>
+      </Box>
+      <Box
+        align='center'
+        direction='row'
+        gap='xxsmall'
+        justify='end'
+      >
+        <LikeIcon
+          color={{ dark: 'accent-1', light: 'neutral-1' }}
+          size='small'
+        />
+        <Text
+          color={{ dark: 'accent-1', light: 'neutral-1' }}
+          size='16px'
+        >
+          {upvotes}
+        </Text>
+      </Box>
+    </StyledCommentCard>
+  )
+}
+
+export default TalkComment

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussion/components/TalkComment/TalkComment.stories.js
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussion/components/TalkComment/TalkComment.stories.js
@@ -1,0 +1,46 @@
+import { Box } from 'grommet'
+
+import TalkComment from './TalkComment'
+
+export default {
+  title: 'Project App / Screens / Subject Talk / Talk Data / TalkComment',
+  component: TalkComment,
+  decorators: [(Story) => (
+    <Box
+      align='center'
+      justify='center'
+      background={{ dark: 'dark-3', light: 'white' }}
+      fill
+      pad='small'
+    >
+      <Box
+        as='ol'
+        fill
+        width={{ max: '600px' }}
+      >
+        <Story />
+      </Box>
+    </Box>
+  )]
+}
+
+export const Default = {
+  args: {
+    avatar: 'https://panoptes-uploads-staging.zooniverse.org/user_avatar/0c51ab10-8c23-47fc-9452-c11852c754a9.jpeg',
+    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.',
+    date: '2025-07-04T20:00:00Z',
+    displayName: 'ZooTester 1',
+    login: 'zootester1',
+    upvotes: 0
+  }
+}
+
+export const WithoutAvatar = {
+  args: {
+    body: 'This is a test comment without an avatar.',
+    date: '2025-07-04T20:00:00Z',
+    displayName: 'ZooTester 2',
+    login: 'zootester2',
+    upvotes: 2
+  }
+}

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussion/components/TalkComment/components/Avatar.js
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussion/components/TalkComment/components/Avatar.js
@@ -1,0 +1,29 @@
+import { Image } from 'grommet'
+import { string } from 'prop-types'
+import styled from 'styled-components'
+
+const StyledAvatar = styled(Image)`
+  width: 50px;
+  height: 50px;
+  object-fit: cover;
+  border-radius: 50%;
+`
+
+function Avatar({
+  src,
+  alt
+}) {
+  return (
+    <StyledAvatar
+      src={src}
+      alt={alt}
+    />
+  )
+}
+
+Avatar.propTypes = {
+  src: string,
+  alt: string
+}
+
+export default Avatar

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussion/components/TalkComment/index.js
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussion/components/TalkComment/index.js
@@ -1,0 +1,1 @@
+export { default } from './TalkComment'


### PR DESCRIPTION
## Package
- app-project

## Describe your changes
- related [Comment Figma design](https://www.figma.com/design/FnwiDKBljICeCDUPtOHH4Q/Subject-Page?node-id=203-6251&m=dev)

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
  - http://localhost:9001/?path=/story/project-app-screens-subject-talk-talk-data-talkcomment--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).