### PR TITLE
SGV 1: Submit subject.subjectIds when submitting a classification for a subjectGroup

### DIFF
--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -1,7 +1,7 @@
 import asyncStates from '@zooniverse/async-states'
 import cuid from 'cuid'
 import { snakeCase } from 'lodash'
-import { flow, getRoot, getSnapshot, isValidReference, tryReference, types } from 'mobx-state-tree'
+import { flow, getRoot, getSnapshot, getType, isValidReference, tryReference, types } from 'mobx-state-tree'
 
 import Classification, { ClassificationMetadata } from './Classification'
 import ResourceStore from './ResourceStore'
@@ -137,8 +137,7 @@ const ClassificationStore = types
         classificationToSubmit.metadata = convertedMetadata
 
         // SubjectGroup wants to submit all subject.subjectIds for analytics & retirement rules
-        const workflow = tryReference(() => getRoot(self).workflows.active)
-        if (workflow.configuration.subject_viewer === 'subjectGroup') {
+        if (getType(subject).name === 'SubjectGroup') {
           const links = {...classificationToSubmit.links}
           links.subjects = [...classificationToSubmit.links.subjects, ...subject.subjectIds.toJSON()]
           classificationToSubmit.links = links

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -126,14 +126,23 @@ const ClassificationStore = types
         classification.metadata.update(metadata)
 
         classification.completed = true
+
         // Convert from observables
-        let classificationToSubmit = classification.toSnapshot()
+        const classificationToSubmit = classification.toSnapshot()
 
         const convertedMetadata = {}
         Object.entries(classificationToSubmit.metadata).forEach(([key, value]) => {
           convertedMetadata[snakeCase(key)] = value
         })
         classificationToSubmit.metadata = convertedMetadata
+
+        // SubjectGroup wants to submit all subject.subjectIds for analytics & retirement rules
+        const workflow = tryReference(() => getRoot(self).workflows.active)
+        if (workflow.configuration.subject_viewer === 'subjectGroup') {
+          const links = {...classificationToSubmit.links}
+          links.subjects = [...classificationToSubmit.links.subjects, ...subject.subjectIds.toJSON()]
+          classificationToSubmit.links = links
+        }
 
         /*
           Subject.alreadySeen is a computed value, so copy it across to a copy of the subject snapshot.

--- a/packages/lib-classifier/src/store/subjects/SubjectGroup/README.md
+++ b/packages/lib-classifier/src/store/subjects/SubjectGroup/README.md
@@ -12,3 +12,9 @@ Subjects for the SubjectGroupViewer are a special case; a "Group Subject" is a r
   - `subject.metadata.#subject_group_id` is a number indicating the unique ID of this Subject Group, which is distinct from `subject.id`. Honestly, don't worry about this for now.
 - Subject Groups are STRONGLY ASSOCIATED with the Subject Group Viewer. Please see `src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md` for more details.
 - Subject Groups are STRONGLY ASSSOCIATED with the Subject Group Comparison Task. Please see `src/plugins/tasks/SubjectGroupComparisonTask/README.md` for more details.
+
+## 2025-09-22: New Classifier behaviour:
+When a classification for a Subject Group is submitted, (1) all the IDs of the group's constituent Subjects, AND (2) the ID of the Subject Group itself, will be submitted in the `classification.links.subjects` data.
+- `classification.links.subjects` is an array of Subject IDs, recorded as strings. The array will contain n + 1 entries, where n is the number of real/constituent subjects in the subject group.
+- Example: Subject Group 1000 consists of constituent Subjects [9, 5, 2, 4]. The classification will be submitted with `myClassification.links.subjects = ["2", "4", "5", "9", "1000"]`
+- 🐨 Note that the subject IDs in the classification links are sorted in ascending order, regardless of the order of real Subjects.


### PR DESCRIPTION
## Package
- [ ] lib-classifier

## Linked Issue and/or Talk Post
- Milestone [#31](https://github.com/zooniverse/front-end-monorepo/milestone/31)
- Closes Issue #6903 
- Related PR's: [#6979](https://github.com/zooniverse/front-end-monorepo/pull/6979), [#7357](https://github.com/zooniverse/Panoptes-Front-End/pull/7357), and [#7050](https://github.com/zooniverse/front-end-monorepo/pull/7050)

## Describe your changes
Does a check before submitting the Classification JSON to see if the active workflow's `subject_viewer` is a `subjectGroup`, and if so, adds all the `subject.subjectIds` to the `classification.links.subjects` array.

## How to Review
Load up the lib-classifier locally and open [this project](https://localhost:8080/?project=darkeshard%2Fsurvos-testing-2020-subject-group-viewer&workflow=3412) to have a test SubjectGroup workflow. Click the Done button to submit a classification, inspect both the "Completed classification" object and the POST'ed classification object to see that the `classifications.links.subjects` is 26 items long (25 individual subjects + 1 group subject).

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)