### PR TITLE
fix(app-project): check admin mode after user loads

### DIFF
--- a/packages/app-project/src/hooks/useAdminMode.js
+++ b/packages/app-project/src/hooks/useAdminMode.js
@@ -7,17 +7,20 @@ const localStorage = isBrowser ? window.localStorage : null
 export default function useAdminMode() {
   const { store } = useContext(MobXProviderContext)
   const [adminState, setAdminState] = useState(false)
-  const adminMode = store?.user.isAdmin && adminState
+  const userIsAdmin = store?.user.isAdmin
+  const userIsLoaded = store?.user.isLoaded
+  const adminMode = userIsLoaded && userIsAdmin && adminState
 
   useEffect(function onUserChange() {
-    const isAdmin = store?.user.isAdmin
-    if (isAdmin) {
-      const adminFlag = !!localStorage?.getItem('adminFlag')
-      setAdminState(adminFlag)
-    } else {
-      localStorage?.removeItem('adminFlag')
+    if (userIsLoaded) {
+      if (userIsAdmin) {
+        const adminFlag = !!localStorage?.getItem('adminFlag')
+        setAdminState(adminFlag)
+      } else {
+        localStorage?.removeItem('adminFlag')
+      }
     }
-  }, [store?.user.isAdmin])
+  }, [userIsAdmin, userIsLoaded])
 
   function toggleAdmin() {
     let newAdminState = !adminState

--- a/packages/app-project/src/shared/components/StandardLayout/StandardLayout.spec.jsx
+++ b/packages/app-project/src/shared/components/StandardLayout/StandardLayout.spec.jsx
@@ -1,3 +1,4 @@
+import asyncStates from '@zooniverse/async-states'
 import zooTheme from '@zooniverse/grommet-theme'
 import { within } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
@@ -182,47 +183,96 @@ describe('Component > StandardLayout', function () {
   })
 
   describe('in admin mode', function () {
-    before(function () {
-      const snapshot = {
-        project: {
-          configuration: {
-            languages: ['en']
+    describe('when the user is loading', function () {
+      before(function () {
+        const snapshot = {
+          project: {
+            configuration: {
+              languages: ['en']
+            },
+            slug: 'Foo/Bar',
+            strings: {
+              display_name: 'Foobar'
+            },
+            links: {
+              active_workflows: ['1']
+            }
           },
-          slug: 'Foo/Bar',
-          strings: {
-            display_name: 'Foobar'
-          },
-          links: {
-            active_workflows: ['1']
+          user: {
+            loadingState: asyncStates.loading
           }
-        },
-        user: {
-          id: '1',
-          admin: true,
-          login: 'zooVolunteer'
         }
-      }
-      window.localStorage.setItem('adminFlag', true)
-      render(<StandardLayout />, { wrapper: withStore(snapshot)})
-      projectPage = screen.getByTestId('project-page')
-      zooHeader = screen.getByRole('banner')
-      zooFooter = screen.getByRole('contentinfo')
-      adminToggle = within(zooFooter).getByRole('checkbox', { name: 'Admin Mode' })
+        window.localStorage.setItem('adminFlag', true)
+        render(<StandardLayout />, { wrapper: withStore(snapshot)})
+        projectPage = screen.getByTestId('project-page')
+        zooHeader = screen.getByRole('banner')
+        zooFooter = screen.getByRole('contentinfo')
+        adminToggle = within(zooFooter).queryByRole('checkbox', { name: 'Admin Mode' })
+      })
+
+      after(function () {
+        window.localStorage.removeItem('adminFlag')
+      })
+
+      it('should not have a striped border', function () {
+        expect(projectPage).toBeDefined()
+        const borderImage = window.getComputedStyle(projectPage)['border-image']
+        expect(borderImage).to.equal('')
+      })
+
+      it('should not show the admin toggle in the footer', function () {
+        expect(adminToggle).toBeNull()
+      })
+
+      it('should preserve the stored adminFlag', function () {
+        expect(window.localStorage.getItem('adminFlag')).to.equal('true')
+      })
     })
 
-    after(function () {
-      window.localStorage.removeItem('adminFlag')
-    })
+    describe('when the user has loaded', function () {
+      before(function () {
+        const snapshot = {
+          project: {
+            configuration: {
+              languages: ['en']
+            },
+            slug: 'Foo/Bar',
+            strings: {
+              display_name: 'Foobar'
+            },
+            links: {
+              active_workflows: ['1']
+            }
+          },
+          user: {
+            id: '1',
+            admin: true,
+            login: 'zooVolunteer',
+            loadingState: asyncStates.success
+          }
+        }
+        window.localStorage.setItem('adminFlag', true)
+        render(<StandardLayout />, { wrapper: withStore(snapshot)})
+        projectPage = screen.getByTestId('project-page')
+        zooHeader = screen.getByRole('banner')
+        zooFooter = screen.getByRole('contentinfo')
+        adminToggle = within(zooFooter).getByRole('checkbox', { name: 'Admin Mode' })
+      })
 
-    it('should have a striped border', function () {
-      expect(projectPage).toBeDefined()
-      const borderImage = window.getComputedStyle(projectPage)['border-image']
-      expect(borderImage).to.equal(adminBorderImage)
-    })
+      after(function () {
+        window.localStorage.removeItem('adminFlag')
+      })
 
-    it('should show the admin toggle in the footer', function () {
-      expect(adminToggle).toBeDefined()
-      expect(adminToggle.checked).to.equal(true)
+      it('should have a striped border', function () {
+        expect(projectPage).toBeDefined()
+        const borderImage = window.getComputedStyle(projectPage)['border-image']
+        expect(borderImage).to.equal(adminBorderImage)
+      })
+
+      it('should show the admin toggle in the footer', function () {
+        expect(adminToggle).toBeDefined()
+        expect(adminToggle.checked).to.equal(true)
+      })
     })
   })
 

--- a/packages/app-project/stores/User/User.js
+++ b/packages/app-project/stores/User/User.js
@@ -28,7 +28,11 @@ const User = types
     },
 
     get isAdmin() {
-      return self.admin
+      return self.isLoggedIn && self.admin
+    },
+
+    get isLoaded() {
+      return self.loadingState === asyncStates.success
     },
 
     get isLoggedIn () {


### PR DESCRIPTION
Wait until after the current user has authenticated before checking admin mode. Fixes a bug where the stored `adminFlag` could be deleted while you are logging in.

- [x] add a failing test that expects admin mode to persist across page loads.
- [x] update the `User` model and `useAdminMode` hook to pass the new test.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## Linked Issue and/or Talk Post
- fixes #7004.

## How to Review
When you enter a page with `adminFlag` already set in local storage, `useAdminMode` should now wait for authentication API requests to complete before checking whether you are authorised to use admin mode. Admin mode should be preserved, even if you open a project page in a new tab (with no stored user.) 

There's now a test case to check that `adminFlag` remains set in local storage while the current user loads. To test this by hand, turn on admin mode in an open tab, then open a project page in a new tab 

https://github.com/user-attachments/assets/62b73ecf-bfb4-40ee-ada3-1808b910a7a6



On the main branch, opening an admin mode project in a new tab will turn off admin mode (#7004.)


https://github.com/user-attachments/assets/f900c902-5b17-4af5-93e6-4d0673b74fd1



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
