### PR TITLE
fix(app-root): check user loading state with admin mode

### DIFF
--- a/packages/app-root/src/hooks/useAdminMode.js
+++ b/packages/app-root/src/hooks/useAdminMode.js
@@ -7,17 +7,21 @@ const adminBorderImage = 'repeating-linear-gradient(45deg,#000,#000 25px,#ff0 25
 
 export default function useAdminMode(user) {
   const [adminState, setAdminState] = useState(storedAdminFlag)
-  const adminMode = user?.admin && adminState
+  const userIsLoaded = user !== undefined
+  const userIsLoggedIn = !!user?.id
+  const userIsAdmin = userIsLoggedIn && user?.admin
+  const adminMode = userIsLoaded && userIsAdmin && adminState
 
   useEffect(function onUserChange() {
-    const isAdmin = user?.admin
-    if (isAdmin) {
-      const adminFlag = !!localStorage?.getItem('adminFlag')
-      setAdminState(adminFlag)
-    } else {
-      localStorage?.removeItem('adminFlag')
+    if(userIsLoaded) {
+      if (userIsAdmin) {
+        const adminFlag = !!localStorage?.getItem('adminFlag')
+        setAdminState(adminFlag)
+      } else {
+        localStorage?.removeItem('adminFlag')
+      }
     }
-  }, [user?.admin])
+  }, [userIsAdmin, userIsLoaded])
 
   useEffect(function onAdminChange() {
     if (adminMode) {


### PR DESCRIPTION
Check that the Panoptes user has loaded before checking admin status.

- This ports the changes from #7013 across to the root app, so that the `useAdminMode` hooks are in sync.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package

## Linked Issue and/or Talk Post

## Describe your changes

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).