### PR TITLE
Use async-states v0.1.0 in all packages

### DIFF
--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@sentry/nextjs": "~8.54.0",
     "@sindresorhus/string-hash": "~1.2.0",
-    "@zooniverse/async-states": "~0.0.1",
+    "@zooniverse/async-states": "~0.1.0",
     "@zooniverse/classifier": "^0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",

--- a/packages/app-root/package.json
+++ b/packages/app-root/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@next/bundle-analyzer": "~14.2.26",
     "@next/third-parties": "~14.2.26",
-    "@zooniverse/async-states": "~0.0.1",
+    "@zooniverse/async-states": "~0.1.0",
     "@zooniverse/content": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -38,7 +38,7 @@
     "@visx/scale": "~3.12.0",
     "@visx/shape": "~3.12.0",
     "@visx/zoom": "~3.12.0",
-    "@zooniverse/async-states": "~0.0.1",
+    "@zooniverse/async-states": "~0.1.0",
     "@zooniverse/subject-viewers": "0.1.0",
     "cuid": "~3.0.0",
     "d3": "~6.7.0",

--- a/packages/lib-subject-viewers/package.json
+++ b/packages/lib-subject-viewers/package.json
@@ -40,7 +40,7 @@
     "three": "^0.177.0"
   },
   "peerDependencies": {
-    "@zooniverse/async-states": "~0.0.1",
+    "@zooniverse/async-states": "~0.1.0",
     "@zooniverse/grommet-theme": "3.x.x",
     "@zooniverse/react-components": "~1.14.0",
     "grommet": "2.x.x",

--- a/packages/lib-user/package.json
+++ b/packages/lib-user/package.json
@@ -29,7 +29,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@zooniverse/async-states": "~0.0.1",
+    "@zooniverse/async-states": "~0.1.0",
     "@zooniverse/panoptes-js": "~0.5.0",
     "dayjs": "~1.11.11",
     "i18next": "~24.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10182,16 +10182,6 @@ form-data@^4.0.0:
     es-set-tostringtag "^2.1.0"
     mime-types "^2.1.12"
 
-formidable@^2.1.2:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.1.5.tgz#dd7ef4d55c164afaf9b6eb472bfd04b02d66d2dd"
-  integrity sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==
-  dependencies:
-    "@paralleldrive/cuid2" "^2.2.2"
-    dezalgo "^1.0.4"
-    once "^1.4.0"
-    qs "^6.11.0"
-
 formidable@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-3.5.4.tgz#ac9a593b951e829b3298f21aa9a2243932f32ed9"
@@ -17147,7 +17137,7 @@ stylis@4.3.2:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.2.tgz#8f76b70777dd53eb669c6f58c997bf0a9972e444"
   integrity sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==
 
-superagent@^10.2.0, superagent@~10.2.1:
+superagent@^10.2.0, superagent@^8.0.8, superagent@~10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-10.2.1.tgz#3e39038fff125cbd1584fa4b384db2994bbffdcb"
   integrity sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==
@@ -17161,22 +17151,6 @@ superagent@^10.2.0, superagent@~10.2.1:
     methods "^1.1.2"
     mime "2.6.0"
     qs "^6.11.0"
-
-superagent@^8.0.8:
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-8.1.2.tgz#03cb7da3ec8b32472c9d20f6c2a57c7f3765f30b"
-  integrity sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==
-  dependencies:
-    component-emitter "^1.3.0"
-    cookiejar "^2.1.4"
-    debug "^4.3.4"
-    fast-safe-stringify "^2.1.1"
-    form-data "^4.0.0"
-    formidable "^2.1.2"
-    methods "^1.1.2"
-    mime "2.6.0"
-    qs "^6.11.0"
-    semver "^7.3.8"
 
 supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"


### PR DESCRIPTION
## Package
Several, but most importantly lib-classifier

## Bug Description
- I published a new version of `@zooniverse/async-states` today (v0.1.0) after converting its tests to Vitest
- While Mark and I were manually testing frontend.preview for deployment, I noticed that the subject queue wasn’t advancing after a completed classification.
- Advancing the next subject listens for `asyncStates.posting`. This is the only code in FEM (and probably all of Zooniverse) that looks for the value `.posting`.
- Turns out, since I did not tell FEM’s packages to bump to `@zooniverse/async-states` v0.1.0, they were still using v0.0.1, which should have been fine, but [v0.0.1](https://www.npmjs.com/package/@zooniverse/async-states/v/0.0.1) doesn’t have `.posting`. It has only four: `initialized, loading, success, error` 🤦🏼‍♀️ The extra two states `.posting` and `.putting` were added to FEM’s code 6 (!) years ago, yet that code was never published as a new version of `@zooniverse/async-states`.

## Describe your changes
- Use async-states v0.1.0 in all package.json files

## How to Review
- Bootstrap this branch locally and run app-project or lib-classifier. The subject queue should advance after completing a classification. Example project: https://local.zooniverse.org:3000/projects/goplayoutside3/fem-test-project/classify/workflow/28231?env=production&demo=true

# Checklist

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed