### PR TITLE
lib-subject-viewers: Fix VolumetricViewer exports

### DIFF
--- a/packages/lib-subject-viewers/src/VolumetricViewer/VolumetricFull/index.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/VolumetricFull/index.js
@@ -1,1 +1,1 @@
-export { default as VolumetricFull } from './VolumetricFull'
+export { default } from './VolumetricFull'

--- a/packages/lib-subject-viewers/src/VolumetricViewer/VolumetricPreview/index.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/VolumetricPreview/index.js
@@ -1,1 +1,1 @@
-export { default as VolumetricPreview } from './VolumetricPreview'
+export { default } from './VolumetricPreview'

--- a/packages/lib-subject-viewers/src/VolumetricViewer/VolumetricView/index.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/VolumetricView/index.js
@@ -1,1 +1,1 @@
-export { default as VolumetricView } from './VolumetricView'
+export { default } from './VolumetricView'


### PR DESCRIPTION
## Package
lib-subject-viewers

## Describe your changes
- Fix the export statements that were broken by https://github.com/zooniverse/front-end-monorepo/pull/7021

## How to Review
- lib-react-component's Story for Volumetric Media should render: http://localhost:6007/?path=/story/components-media--volumetric-media
- app-project run locally should load Mind Mapper: https://local.zooniverse.org:3000/projects/cmcbrain/mind-mapper/classify/workflow/28858?env=production

# Checklist

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out