### PR TITLE
build: add "type": "commonjs" to pure CJS libraries

### DIFF
--- a/packages/lib-async-states/package.json
+++ b/packages/lib-async-states/package.json
@@ -9,6 +9,7 @@
   },
   "bugs": "https://github.com/zooniverse/front-end-monorepo/issues",
   "version": "0.1.0",
+  "type": "commonjs",
   "main": "src/async-states.js",
   "scripts": {
     "lint": "zoo-standard src --fix | snazzy",

--- a/packages/lib-grommet-theme/package.json
+++ b/packages/lib-grommet-theme/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
   "version": "3.2.0",
+  "type": "commonjs",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
   "version": "0.5.2",
+  "type": "commonjs",
   "main": "src/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add `type: commonjs` to the package definitions for the three pure CJS libraries:
- `@zooniverse/async-states`
- `@zooniverse/grommet-theme`
- `@zooniverse/panoptes-js`

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-async-states
- lib-grommet-theme
- lib-panoptes-js

## Linked Issue and/or Talk Post
- replaces #6780.
- towards #7036. 

## How to Review
No changes to the build here. `type: commonjs` is the default package type in Node up to 20.18. This makes the type explicit for later Node versions.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
