### PR TITLE
RotateRectangle: new resize behaviour

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
@@ -102,15 +102,13 @@ function RotateRectangle({
         <DragHandle
           x={x_left}
           y={y_top}
-          dragMove={(e, d) =>
-            onHandleDrag({
-              x_left: x_left + rotateXY(d, angle).x,
-              x_right: x_right - rotateXY(d, angle).x,
-              y_top: y_top + rotateXY(d, angle).y,
-              y_bottom: y_bottom - rotateXY(d, angle).y,
-              angle: angle
+          dragMove={(e, d) => {
+            mark.resizeByCorner({
+              dx: d.x,
+              dy: d.y,
+              corner: 'top left'
             })
-          }
+          }}
         />
       )}
 
@@ -119,28 +117,26 @@ function RotateRectangle({
         <DragHandle
           x={x_right}
           y={y_top}
-          dragMove={(e, d) =>
-            onHandleDrag({
-              x_left: x_left - rotateXY(d, angle).x,
-              x_right: x_right + rotateXY(d, angle).x,
-              y_top: y_top + rotateXY(d, angle).y,
-              y_bottom: y_bottom - rotateXY(d, angle).y,
-              angle: angle
+          dragMove={(e, d) => {
+            mark.resizeByCorner({
+              dx: d.x,
+              dy: d.y,
+              corner: 'top right'
             })
-          }
+          }}
         />
       )}
 
       {/* Original Bottom Right corner */}
       {active && (
         <DragHandle
-          fill='red'
           x={x_right}
           y={y_bottom}
           dragMove={(e, d) => {
             mark.resizeByCorner({
               dx: d.x,
-              dy: d.y
+              dy: d.y,
+              corner: 'bottom right'
             })
           }}
         />
@@ -151,15 +147,13 @@ function RotateRectangle({
         <DragHandle
           x={x_left}
           y={y_bottom}
-          dragMove={(e, d) =>
-            onHandleDrag({
-              x_left: x_left + rotateXY(d, angle).x,
-              x_right: x_right - rotateXY(d, angle).x,
-              y_top: y_top - rotateXY(d, angle).y,
-              y_bottom: y_bottom + rotateXY(d, angle).y,
-              angle: angle
+          dragMove={(e, d) => {
+            mark.resizeByCorner({
+              dx: d.x,
+              dy: d.y,
+              corner: 'bottom left'
             })
-          }
+          }}
         />
       )}
     </g>

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
@@ -23,31 +23,13 @@ function RotateRectangle({
   const xRotationHandle = x_center + width / 2 + BUFFER
 
   function onHandleDrag(coords) {
-    mark.setCoordinates(coords)
+    mark.resizeByCorner(coords)
   }
 
   function onRotateDrag(e) {
     const angle = mark.getAngle(x_center, y_center, e.x, e.y)
     mark.setCoordinates({ x_left, x_right, y_top, y_bottom, angle })
   }
-
-  function rotateXY({ x, y }, angleInDegrees) {
-    const theta = angleInDegrees * (Math.PI / 180)
-    const xTheta = x * Math.cos(theta) + y * Math.sin(theta)
-    const yTheta = -(x * Math.sin(theta)) + y * Math.cos(theta)
-    return { x: xTheta, y: yTheta }
-  }
-
-  // Resizing behaviour:
-  // Given a rectangle with corners ABCD and origin/centre O...
-  //   A-------B
-  //   |   O   |
-  //   D-------C
-  // ...when we resize the rectangle by dragging one corner, we want that resize
-  // action to be anchored to the OPPOSITE corner. e.g. if C goes ↘️, A stays
-  // static, B goes ➡️, D goes ⬇️, and O goes ↘️.
-  // To do this in our code, we need to define which edges (AB, BC, CD, DA) stay
-  // static, and which can move... which also accounts for the angle.
 
   return (
     <g onPointerUp={active ? onFinish : undefined}>
@@ -103,7 +85,7 @@ function RotateRectangle({
           x={x_left}
           y={y_top}
           dragMove={(e, d) => {
-            mark.resizeByCorner({
+            onHandleDrag({
               dx: d.x,
               dy: d.y,
               corner: 'top left'
@@ -118,7 +100,7 @@ function RotateRectangle({
           x={x_right}
           y={y_top}
           dragMove={(e, d) => {
-            mark.resizeByCorner({
+            onHandleDrag({
               dx: d.x,
               dy: d.y,
               corner: 'top right'
@@ -133,7 +115,7 @@ function RotateRectangle({
           x={x_right}
           y={y_bottom}
           dragMove={(e, d) => {
-            mark.resizeByCorner({
+            onHandleDrag({
               dx: d.x,
               dy: d.y,
               corner: 'bottom right'
@@ -148,7 +130,7 @@ function RotateRectangle({
           x={x_left}
           y={y_bottom}
           dragMove={(e, d) => {
-            mark.resizeByCorner({
+            onHandleDrag({
               dx: d.x,
               dy: d.y,
               corner: 'bottom left'

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
@@ -68,13 +68,13 @@ function RotateRectangle({
         <DragHandle
           x={x_left}
           y={y_top}
-          dragMove={(e, d) => {
+          dragMove={(e, d) =>
             onHandleDrag({
               dx: d.x,
               dy: d.y,
               corner: 'top left'
             })
-          }}
+          }
         />
       )}
 
@@ -83,13 +83,13 @@ function RotateRectangle({
         <DragHandle
           x={x_right}
           y={y_top}
-          dragMove={(e, d) => {
+          dragMove={(e, d) =>
             onHandleDrag({
               dx: d.x,
               dy: d.y,
               corner: 'top right'
             })
-          }}
+          }
         />
       )}
 
@@ -98,13 +98,13 @@ function RotateRectangle({
         <DragHandle
           x={x_right}
           y={y_bottom}
-          dragMove={(e, d) => {
+          dragMove={(e, d) =>
             onHandleDrag({
               dx: d.x,
               dy: d.y,
               corner: 'bottom right'
             })
-          }}
+          }
         />
       )}
 
@@ -113,13 +113,13 @@ function RotateRectangle({
         <DragHandle
           x={x_left}
           y={y_bottom}
-          dragMove={(e, d) => {
+          dragMove={(e, d) =>
             onHandleDrag({
               dx: d.x,
               dy: d.y,
               corner: 'bottom left'
             })
-          }}
+          }
         />
       )}
     </g>

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
@@ -38,10 +38,22 @@ function RotateRectangle({
     return { x: xTheta, y: yTheta }
   }
 
+  // Resizing behaviour:
+  // Given a rectangle with corners ABCD and origin/centre O...
+  //   A-------B
+  //   |   O   |
+  //   D-------C
+  // ...when we resize the rectangle by dragging one corner, we want that resize
+  // action to be anchored to the OPPOSITE corner. e.g. if C goes ↘️, A stays
+  // static, B goes ➡️, D goes ⬇️, and O goes ↘️.
+  // To do this in our code, we need to define which edges (AB, BC, CD, DA) stay
+  // static, and which can move... which also accounts for the angle.
+
   return (
     <g onPointerUp={active ? onFinish : undefined}>
       <g style={{
         stroke: 'none',
+        fontSize: '0.75em',
         fill: '#00ffff'
       }}>
         <text x={x_center} y={y_center}>
@@ -122,17 +134,15 @@ function RotateRectangle({
       {/* Original Bottom Right corner */}
       {active && (
         <DragHandle
+          fill='red'
           x={x_right}
           y={y_bottom}
-          dragMove={(e, d) =>
-            onHandleDrag({
-              x_left: x_left - rotateXY(d, angle).x,
-              x_right: x_right + rotateXY(d, angle).x,
-              y_top: y_top - rotateXY(d, angle).y,
-              y_bottom: y_bottom + rotateXY(d, angle).y,
-              angle: angle
+          dragMove={(e, d) => {
+            mark.resizeByCorner({
+              dx: d.x,
+              dy: d.y
             })
-          }
+          }}
         />
       )}
 

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
@@ -33,22 +33,6 @@ function RotateRectangle({
 
   return (
     <g onPointerUp={active ? onFinish : undefined}>
-      <g style={{
-        stroke: 'none',
-        fontSize: '0.75em',
-        fill: '#00ffff'
-      }}>
-        <text x={x_center} y={y_center}>
-          {x_center?.toFixed(0)}, {y_center?.toFixed(0)}
-        </text>
-        <text x={x_center} y={y_center + 16}>
-          {width?.toFixed(0)} x {height?.toFixed(0)}
-        </text>
-        <text x={x_center} y={y_center + 32}>
-          {angle?.toFixed(0)}º
-        </text>
-      </g>
-
       <rect x={x_left} y={y_top} width={width} height={height} vectorEffect={'non-scaling-stroke'} />
       <rect
         x={x_left}

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.jsx
@@ -40,6 +40,21 @@ function RotateRectangle({
 
   return (
     <g onPointerUp={active ? onFinish : undefined}>
+      <g style={{
+        stroke: 'none',
+        fill: '#00ffff'
+      }}>
+        <text x={x_center} y={y_center}>
+          {x_center?.toFixed(0)}, {y_center?.toFixed(0)}
+        </text>
+        <text x={x_center} y={y_center + 16}>
+          {width?.toFixed(0)} x {height?.toFixed(0)}
+        </text>
+        <text x={x_center} y={y_center + 32}>
+          {angle?.toFixed(0)}º
+        </text>
+      </g>
+
       <rect x={x_left} y={y_top} width={width} height={height} vectorEffect={'non-scaling-stroke'} />
       <rect
         x={x_left}

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
@@ -32,6 +32,26 @@ const RotateRectangleModel = types
       self.width = Math.abs(x_right - x_left)
       self.height = Math.abs(y_bottom - y_top)
       self.angle = angle
+    },
+
+    resizeByCorner({ dx, dy }) {
+      if (dx === 0 && dy === 0) return
+      const angleOfResizeAction = Math.atan2(dy, dx)  // Radians
+      const distanceOfResizeAction = Math.sqrt(dx * dx + dy * dy)
+
+      const modifiedAngle = angleOfResizeAction - (self.angle * Math.PI / 180)  // Radians. self.angle is in degrees.
+      const modifiedDx = Math.cos(modifiedAngle) * distanceOfResizeAction
+      const modifiedDy = Math.sin(modifiedAngle) * distanceOfResizeAction
+
+      // console.log('+++ ',
+      //   `${(angleOfResizeAction * 180 / Math.PI).toFixed(1)}º => ${(modifiedAngle * 180 / Math.PI).toFixed(1)}º \n`,
+      //   `${dx.toFixed(1)}, ${dy.toFixed(1)} => ${modifiedDx.toFixed(1)}, ${modifiedDy.toFixed(1)}`
+      // )
+
+      self.width += modifiedDx
+      self.height += modifiedDy
+      self.x_center += dx * 0.5
+      self.y_center += dy * 0.5
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
@@ -34,7 +34,36 @@ const RotateRectangleModel = types
       self.angle = angle
     },
 
-    resizeByCorner({ dx, dy, corner }) {
+    /*
+    Resize RotateRectangle mark by moving/dragging a corner
+
+    Input:
+    - dx: number, delta X. Indicates distance that mark was moved/dragged by the
+        user, across the x-axis OF THE DRAWING CANVAS. (i.e. this is relative
+        to the drawing canvas, not relative to the rotated axes of the
+        RotateRectangle)
+    - dy: number, delta Y. As above, but for x-axis OF THE DRAWING CANVAS.
+    - corner: string indicating which corner (drag handle) of the RotateRectangle
+        component is being moved/dragged by the user. Value is either
+        'top left', 'top right', 'bottom right', or 'bottom left'.
+
+    Effect:
+    - Changes width, height, x_center, and y_center of this RotateRectangle.
+
+    Output: 
+    - none
+
+    Resizing Behaviour:
+    Given a rectangle with corners ABCD and origin/centre O...
+      A-------B
+      |   O   |
+      D-------C
+    ...when we resize the rectangle by dragging one corner, we want that resize
+    action to be anchored to the OPPOSITE corner. e.g. if C goes ↘️, A stays
+    static, B goes ➡️, D goes ⬇️, and O goes ↘️.
+
+     */
+    resizeByCorner({ dx = 0, dy = 0, corner = '' }) {
       if (dx === 0 && dy === 0) return
       if (!['top left', 'top right', 'bottom right', 'bottom left'].includes(corner)) return
       const angleOfResizeAction = Math.atan2(dy, dx)  // Radians
@@ -43,11 +72,6 @@ const RotateRectangleModel = types
       const modifiedAngle = angleOfResizeAction - (self.angle * Math.PI / 180)  // Radians. self.angle is in degrees.
       const modifiedDx = Math.cos(modifiedAngle) * distanceOfResizeAction
       const modifiedDy = Math.sin(modifiedAngle) * distanceOfResizeAction
-
-      // console.log('+++ ',
-      //   `${(angleOfResizeAction * 180 / Math.PI).toFixed(1)}º => ${(modifiedAngle * 180 / Math.PI).toFixed(1)}º \n`,
-      //   `${dx.toFixed(1)}, ${dy.toFixed(1)} => ${modifiedDx.toFixed(1)}, ${modifiedDy.toFixed(1)}`
-      // )
 
       switch (corner) {
         case 'top left':

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
@@ -35,7 +35,7 @@ const RotateRectangleModel = types
     },
 
     /*
-    Resize RotateRectangle mark by moving/dragging a corner
+    Resize RotateRectangle mark by moving/dragging a corner.
 
     Input:
     - dx: number, delta X. Indicates distance that mark was moved/dragged by the
@@ -64,42 +64,51 @@ const RotateRectangleModel = types
 
      */
     resizeByCorner({ dx = 0, dy = 0, corner = '' }) {
+      // Sanity check: discard action if input is invalid.
       if (dx === 0 && dy === 0) return
       if (!['top left', 'top right', 'bottom right', 'bottom left'].includes(corner)) return
-      const angleOfResizeAction = Math.atan2(dy, dx)  // Radians
-      const distanceOfResizeAction = Math.sqrt(dx * dx + dy * dy)
 
-      const modifiedAngle = angleOfResizeAction - (self.angle * Math.PI / 180)  // Radians. self.angle is in degrees.
-      const modifiedDx = Math.cos(modifiedAngle) * distanceOfResizeAction
-      const modifiedDy = Math.sin(modifiedAngle) * distanceOfResizeAction
+      // First, we need to transform the original delta of movement (dx, dy) into
+      // polar coordinates.
+      const deltaAngle = Math.atan2(dy, dx)  // Radians
+      const deltaDistance = Math.sqrt(dx * dx + dy * dy)
 
+      // Second, we need rotate the original delta's angle to compensate for the
+      // rotation angle of this RotateRectangle.
+      const transformedAngle = deltaAngle - (self.angle * Math.PI / 180)  // Radians. self.angle is in degrees.
+      
+      // Now, we can figure out the transformed delta of movement, which is
+      // relative to the rotated axis of the RotateRectangle.  
+      const transformedDx = Math.cos(transformedAngle) * deltaDistance
+      const transformedDy = Math.sin(transformedAngle) * deltaDistance
+
+      // The corner that's being moved will determine how the RotateRectangle's
+      // width & height will be modified by the transformed delta.
       switch (corner) {
         case 'top left':
-          self.width = Math.max(self.width - modifiedDx, 1)
-          self.height = Math.max(self.height - modifiedDy, 1)
-          self.x_center += dx * 0.5
-          self.y_center += dy * 0.5
+          self.width = Math.max(self.width - transformedDx, 1)
+          self.height = Math.max(self.height - transformedDy, 1)
           break
         case 'top right':
-          self.width = Math.max(self.width + modifiedDx, 1)
-          self.height = Math.max(self.height - modifiedDy, 1)
-          self.x_center += dx * 0.5
-          self.y_center += dy * 0.5
+          self.width = Math.max(self.width + transformedDx, 1)
+          self.height = Math.max(self.height - transformedDy, 1)
           break
         case 'bottom right':
-          self.width = Math.max(self.width + modifiedDx, 1)
-          self.height = Math.max(self.height + modifiedDy, 1)
-          self.x_center += dx * 0.5
-          self.y_center += dy * 0.5
+          self.width = Math.max(self.width + transformedDx, 1)
+          self.height = Math.max(self.height + transformedDy, 1)
           break
         case 'bottom left':
-          self.width = Math.max(self.width - modifiedDx, 1)
-          self.height = Math.max(self.height + modifiedDy, 1)
-          self.x_center += dx * 0.5
-          self.y_center += dy * 0.5
+          self.width = Math.max(self.width - transformedDx, 1)
+          self.height = Math.max(self.height + transformedDy, 1)
           break
-
       }
+
+      // Finally, the RotateRectangle's origin/centre needs to scoot over by
+      // half the original delta, so the opposite corner remains anchored in
+      // place.
+      self.x_center += dx * 0.5
+      self.y_center += dy * 0.5
+
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
@@ -48,8 +48,8 @@ const RotateRectangleModel = types
       //   `${dx.toFixed(1)}, ${dy.toFixed(1)} => ${modifiedDx.toFixed(1)}, ${modifiedDy.toFixed(1)}`
       // )
 
-      self.width += modifiedDx
-      self.height += modifiedDy
+      self.width = Math.max(self.width + modifiedDx, 1)
+      self.height = Math.max(self.height + modifiedDy, 1)
       self.x_center += dx * 0.5
       self.y_center += dy * 0.5
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
@@ -34,8 +34,9 @@ const RotateRectangleModel = types
       self.angle = angle
     },
 
-    resizeByCorner({ dx, dy }) {
+    resizeByCorner({ dx, dy, corner }) {
       if (dx === 0 && dy === 0) return
+      if (!['top left', 'top right', 'bottom right', 'bottom left'].includes(corner)) return
       const angleOfResizeAction = Math.atan2(dy, dx)  // Radians
       const distanceOfResizeAction = Math.sqrt(dx * dx + dy * dy)
 
@@ -48,10 +49,33 @@ const RotateRectangleModel = types
       //   `${dx.toFixed(1)}, ${dy.toFixed(1)} => ${modifiedDx.toFixed(1)}, ${modifiedDy.toFixed(1)}`
       // )
 
-      self.width = Math.max(self.width + modifiedDx, 1)
-      self.height = Math.max(self.height + modifiedDy, 1)
-      self.x_center += dx * 0.5
-      self.y_center += dy * 0.5
+      switch (corner) {
+        case 'top left':
+          self.width = Math.max(self.width - modifiedDx, 1)
+          self.height = Math.max(self.height - modifiedDy, 1)
+          self.x_center += dx * 0.5
+          self.y_center += dy * 0.5
+          break
+        case 'top right':
+          self.width = Math.max(self.width + modifiedDx, 1)
+          self.height = Math.max(self.height - modifiedDy, 1)
+          self.x_center += dx * 0.5
+          self.y_center += dy * 0.5
+          break
+        case 'bottom right':
+          self.width = Math.max(self.width + modifiedDx, 1)
+          self.height = Math.max(self.height + modifiedDy, 1)
+          self.x_center += dx * 0.5
+          self.y_center += dy * 0.5
+          break
+        case 'bottom left':
+          self.width = Math.max(self.width - modifiedDx, 1)
+          self.height = Math.max(self.height + modifiedDy, 1)
+          self.x_center += dx * 0.5
+          self.y_center += dy * 0.5
+          break
+
+      }
     }
   }))
 


### PR DESCRIPTION
## PR Overview

Package: lib-classifier
Affects: Drawing Task -> RotateRectangle drawing tool
Closes #7052 

This PR changes how the RotateRectangle marks behaves, when a user resizes it by moving/dragging one of its four corners (drag handles).

Say we have a rectangle mark, with four corners ABCD, and origin/centre-coordinate O:
```
  A-------B
  |       |
  |   O   |
  |       |
  D-------C
```

New behaviour:

- RotateRectangle: when resizing by dragging a corner, the action is _anchored_ to the _opposite corner._
  - So if we drag C ↘️, A will remain static, B will move ➡ and D will move ⬇️. O will move ↘️ too, by half the distance that C moves.
  - This is basically the same as how the standard Rectangle drawing tool works, except that it _respects the rotation_ of the RotateRectangle.
- **Important: the annotation data shape remains unchanged; only the UI behaviour changed.**

### Testing

What you're looking for is that the **resize behaviour of the RotateRectangle feels natural,** and that the behaviour is consistent no matter how rotated the rectangle _(or the Subject image!)_ is.

- Choose a workflow with a Drawing Task with 1x Rotate Rectangle and 1x Rectangle tool
  - Example: https://local.zooniverse.org:8080/?env=production&project=blicksam/demonstration-project&workflow=29992 (lib-classifier)
  - Compare with current baseline: https://frontend.preview.zooniverse.org/projects/blicksam/demonstration-project/classify/workflow/29992
- For the RotateRectangle too:
  - Select the tool.
  - Click & drag to create a mark.
  - Drag a corner to resize. Confirm that the opposite corner remains anchored in place while the other corners + origin/centre moves.
  - Rotate the mark.
  - Drag a corner to resize and confirm etc etc
  - Pan, zoom, and rotate _the Subject Image._
  - Drag a corner to resize and confirm etc etc
- For comparison, also try the Rectangle mark:
  - Create a mark.
  - Drag a corner to resize the rectangle. The feel between resizing a RotateRectangle mark and resizing a Rectangle mark should be similar.

### Status

Ready for review. Tagging @snblickhan for eyes on this. We want to get this merged soon, so it can get deployed next week.
