### PR TITLE
Node 22: Ignore sugarClient during SSR

### DIFF
--- a/packages/app-project/src/hooks/useSugarProject.js
+++ b/packages/app-project/src/hooks/useSugarProject.js
@@ -1,16 +1,28 @@
 import { useEffect } from 'react'
 // panoptes-client / sugarClient requires engine.io-client 
 // see https://github.com/zooniverse/Panoptes-Front-End/pull/4712#issuecomment-400752308 for additional discussion
-import { sugarClient } from 'panoptes-client/lib/sugar'
 
 const isBrowser = typeof window !== 'undefined'
+let sugarClient
+
+/*
+An immediately-invoked async function is a workaround
+when top-level await is not supported.
+  https://v8.dev/features/top-level-await
+*/
+(async function initSugarClient() {
+  if (isBrowser) {
+    const sugarModule = await import('panoptes-client/lib/sugar')
+    sugarClient = sugarModule.sugarClient
+  }
+})()
 
 export default function useSugarProject(project) {
   const projectID = project?.id
 
   useEffect(function onProjectChange() {
     let cleanup
-    if (isBrowser && projectID) {
+    if (sugarClient && projectID) {
       const channel = `project-${projectID}`
       sugarClient.subscribeTo(channel)
       cleanup = () => {

--- a/packages/app-project/stores/User/UserPersonalization/Notifications/Notifications.js
+++ b/packages/app-project/stores/User/UserPersonalization/Notifications/Notifications.js
@@ -1,12 +1,26 @@
 import { flow, getRoot, types } from 'mobx-state-tree'
 // panoptes-client / sugarClient requires engine.io-client 
 // see https://github.com/zooniverse/Panoptes-Front-End/pull/4712#issuecomment-400752308 for additional discussion
-import { sugarClient } from 'panoptes-client/lib/sugar'
 import auth from 'panoptes-client/lib/auth'
 import asyncStates from '@zooniverse/async-states'
 
 import getUnreadConversationsIds from './helpers/getTalkUnreadConversationsIds'
 import getUnreadNotificationsCount from './helpers/getTalkUnreadNotificationsCount'
+
+const isBrowser = typeof window !== 'undefined'
+let sugarClient
+
+/*
+An immediately-invoked async function is a workaround
+when top-level await is not supported.
+  https://v8.dev/features/top-level-await
+*/
+(async function initSugarClient() {
+  if (isBrowser) {
+    const sugarModule = await import('panoptes-client/lib/sugar')
+    sugarClient = sugarModule.sugarClient
+  }
+})()
 
 // NOTES
 // This store is for the Notifications and Messages count displayed in ZooHeader.


### PR DESCRIPTION
Dynamically import the Sugar client, so that it isn't loaded during SSR.