### PR TITLE
[DRAFT] Add AddTagModal component

### DIFF
--- a/packages/app-project/src/hooks/useTagVotes.js
+++ b/packages/app-project/src/hooks/useTagVotes.js
@@ -6,8 +6,7 @@ import usePanoptesAuthToken from '@hooks/usePanoptesAuthToken'
 const SWRoptions = {
   revalidateIfStale: true,
   revalidateOnMount: true,
-  revalidateOnFocus: false, // can be false because its unlikely a user will change
-                           // their own tagVotes on one subject in multiple browser tabs
+  revalidateOnFocus: true,
   revalidateOnReconnect: true,
   refreshInterval: 0
 }

--- a/packages/app-project/src/screens/SubjectTalkPage/SubjectTalkPage.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/SubjectTalkPage.jsx
@@ -40,6 +40,7 @@ const StyledTalkDataBox = styled(Box)`
 
 function SubjectTalkPage({
   login,
+  projectDisplayName,
   projectId,
   projectSlug,
   subject,
@@ -77,6 +78,7 @@ function SubjectTalkPage({
           >
             <SubjectTalkData
               login={login}
+              projectDisplayName={projectDisplayName}
               projectId={projectId}
               subjectId={subjectId}
               userId={userId}

--- a/packages/app-project/src/screens/SubjectTalkPage/SubjectTalkPageConnector.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/SubjectTalkPageConnector.jsx
@@ -9,6 +9,7 @@ function useStores() {
   const { project, user } = stores.store
   return {
     login: user?.login,
+    projectDisplayName: project?.display_name,
     projectId: project?.id,
     projectSlug: project?.slug,
     userId: user?.id
@@ -21,6 +22,7 @@ function SubjectTalkPageConnector({
 }) {
   const {
     login,
+    projectDisplayName,
     projectId,
     projectSlug,
     userId
@@ -29,6 +31,7 @@ function SubjectTalkPageConnector({
   return (
     <SubjectTalkPage
       login={login}
+      projectDisplayName={projectDisplayName}
       projectId={projectId}
       projectSlug={projectSlug}
       subject={subject}

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/SubjectTalkData.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/SubjectTalkData.jsx
@@ -15,6 +15,7 @@ const StyledHeading = styled(Heading)`
 
 function SubjectTalkData({
   login,
+  projectDisplayName,
   projectId,
   subjectId,
   userId
@@ -54,6 +55,7 @@ function SubjectTalkData({
           </StyledHeading>
         </Box>
         <Tags
+          projectDisplayName={projectDisplayName}
           projectId={projectId}
           subjectId={subjectId}
           userId={userId}

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Tags/Tags.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Tags/Tags.jsx
@@ -40,6 +40,7 @@ const DEFAULT_HANDLER = () => true
 function Tags({
   error = undefined,
   loading = false,
+  onAddTagClick = DEFAULT_HANDLER,
   onTagClick = DEFAULT_HANDLER,
   tags = undefined,
   userId = undefined,
@@ -101,7 +102,7 @@ function Tags({
                 </Box>
               )}
               margin={{ horizontal: 'xsmall' }}
-              onClick={() => window.alert('coming soon!')}
+              onClick={onAddTagClick}
               plain
             />
           ) : tags?.length > 0 ? (
@@ -175,7 +176,7 @@ function Tags({
               </Box>
             )}
             margin={{ horizontal: 'xsmall' }}
-            onClick={() => window.alert('coming soon!')}
+            onClick={onAddTagClick}
             plain
           />
         </StyledBox>

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Tags/TagsContainer.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Tags/TagsContainer.jsx
@@ -14,12 +14,15 @@ import {
 } from '@hooks'
 
 import Tags from './Tags'
+import AddTagModal from './components/AddTagModal'
 
 function TagsContainer({
+  projectDisplayName,
   projectId,
   subjectId,
   userId
 }) {
+  const [addTagModalActive, setAddTagModalActive] = useState(false)
   const [voteUpdating, setVoteUpdating] = useState(false)
 
   // Fetch popular tags for the subject, unrelated to the user
@@ -312,6 +315,10 @@ function TagsContainer({
       }
     )
   }
+  
+  function handleAddTagModalActive() {
+    setAddTagModalActive(!addTagModalActive)
+  }
 
   function handleClick(tag) {
     if (!tag.vote_count) {
@@ -324,14 +331,25 @@ function TagsContainer({
   }
 
   return (
-    <Tags
-      loading={popularTagsIsLoading || votableTagsIsLoading || tagVotesIsLoading}
-      error={popularTagsError || votableTagsError || tagVotesError}
-      tags={combinedTags}
-      onTagClick={handleClick}
-      userId={userId}
-      voteUpdating={voteUpdating || tagVotesIsValidating}
-    />
+    <>
+      <AddTagModal
+        active={addTagModalActive}
+        combinedTags={combinedTags}
+        handleClose={handleAddTagModalActive}
+        projectDisplayName={projectDisplayName}
+        projectId={projectId}
+        subjectId={subjectId}
+      />
+      <Tags
+        loading={popularTagsIsLoading || votableTagsIsLoading || tagVotesIsLoading}
+        error={popularTagsError || votableTagsError || tagVotesError}
+        tags={combinedTags}
+        onAddTagClick={handleAddTagModalActive}
+        onTagClick={handleClick}
+        userId={userId}
+        voteUpdating={voteUpdating || tagVotesIsValidating}
+      />
+    </>
   )
 }
 

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Tags/components/AddTagModal/AddTagModal.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Tags/components/AddTagModal/AddTagModal.jsx
@@ -1,0 +1,104 @@
+import { Modal, SpacedText } from '@zooniverse/react-components'
+import { Box } from 'grommet'
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import {
+  createVotableTag
+} from '@helpers'
+
+import {
+  usePopularTags
+} from'@hooks'
+
+import Tag from '../Tag'
+
+const StyledOrderedList = styled(Box)`
+  list-style: none;
+  row-gap: 10px;
+  column-gap: 10px;
+`
+
+function AddTagModal({
+  active = false,
+  combinedTags = [],
+  handleClose,
+  projectDisplayName = '',
+  projectId,
+  subjectId,
+}) {
+  const [loading, setLoading] = useState(false)
+
+  const popularTagsQuery = {
+    limit: 20,
+    page_size: 20,
+    section: `project-${projectId}`
+  }
+
+  const {
+    data: popularTags,
+    error: popularTagsError,
+    isLoading: popularTagsIsLoading
+  } = usePopularTags(popularTagsQuery)
+
+  const filteredPopularTags = popularTags?.filter(tag => !combinedTags.some(combinedTag => combinedTag.name === tag.name))
+
+  async function handleClick(name) {
+    const newVotableTag = {
+      name: name,
+      section: `project-${projectId}`,
+      taggable_id: subjectId,
+      taggable_type: 'Subject'
+    }
+
+    try {
+      setLoading(true)
+      await createVotableTag(newVotableTag)
+      setLoading(false)
+      handleClose()
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  return (
+    <Modal
+      active={active}
+      closeFn={handleClose}
+      headingBackground='transparent'
+      role='dialog'
+      round='8px'
+      title='Add a Tag'
+      titleColor='black'
+    >
+      <Box
+        gap='small'
+      >
+        <SpacedText>
+          {`From ${projectDisplayName}`}
+        </SpacedText>
+        <StyledOrderedList
+          forwardedAs='ol'
+          direction='row'
+          margin='none'
+          pad='none'
+          wrap
+        >
+          {filteredPopularTags?.map(tag => (
+            <li
+              key={`${tag.id}-${tag.name}`}
+            >
+              <Tag
+                disabled={loading}
+                name={tag.name}
+                onClick={() => handleClick(tag.name)}
+              />
+            </li>
+          ))}
+        </StyledOrderedList>
+      </Box>
+    </Modal>
+  )
+}
+
+export default AddTagModal

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Tags/components/AddTagModal/index.js
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Tags/components/AddTagModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './AddTagModal'


### PR DESCRIPTION
## Package
- app-project

## Describe your changes
- [ ...incoming ]

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).