### PR TITLE
lib-classifier: Use a contrasting gradient in InputIcon when drawing color is black

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/components/InputIcon/InputIcon.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/components/InputIcon/InputIcon.jsx
@@ -1,12 +1,15 @@
 import { node, string } from 'prop-types'
 import styled, { css } from 'styled-components'
 
+// In some cases, project teams choose 'black' as their drawing tool color
+// and we need to style the InputIcon with a lighter background for contrast.
+// 'black' is not in the drawingTools colors in lib-grommet-theme, but could be use in a legacy Zooniverse project.
 export const StyledInputIcon = styled.span`
   ${props => props.color && css`color: ${props.color};`}
-  background-color: #2D2D2D;
   display: flex;
   align-items: center;
   padding: 15px;
+ ${props => props.color === 'rgb(0, 0, 0)' ? css`background: radial-gradient(#cbcccb 0%, #2D2D2D 80%);` : css`background: #2D2D2D;`}
 
   > svg {
     fill-opacity: 0.1;

--- a/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.stories.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.stories.jsx
@@ -58,6 +58,10 @@ export function Drawing({ isThereTaskHelp, required, subjectReadyState }) {
           color: zooTheme.global.colors['drawing-yellow'],
           help: '',
           type: 'ellipse',
+        }, {
+          color: 'rgb(0, 0, 0)', // a legacy case from PFE
+          help: '',
+          type: 'rectangle',
         }
       ],
       type: 'drawing'


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Toward migration of https://frontend.preview.zooniverse.org/projects/bofosubamfo/ghanaphenopulse/classify/workflow/27701
See [Slack convo](https://zooniverse.slack.com/archives/CANKLB50E/p1759172403665809).

## Describe your changes
- Detect when the `color` of InputIcon is "rbg(0, 0, 0)" and apply a gradient background. This is a legacy case from PFE projects. Black is not included in the `drawingColors` in [lib-grommet-theme](https://github.com/zooniverse/front-end-monorepo/blob/d7d6e9694a4cd1bede309d8901e6f519c26b9614/packages/lib-grommet-theme/src/index.js#L85), nor in [TOOL_COLOR_OPTIONS](https://github.com/zooniverse/Panoptes-Front-End/blob/286f53097f7065a8ca0e13045edc2792223b9f40/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/DrawingTask/DrawingTool.jsx#L6) in the new workflow editor (located for now in PFE).

## How to Review
- Run lib-classifier's Storybook and view the drawing task. I added a case for when `color` is black.
- Run app-project and go to https://localhost.zooniverse.org:3000/projects/bofosubamfo/ghanaphenopulse/classify/workflow/27701?env=production. Drawing is the second step of that workflow.

# Checklist
## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook