### PR TITLE
[DRAFT] Add StartDiscussionModal component

### DIFF
--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussions/Discussions.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussions/Discussions.jsx
@@ -11,6 +11,7 @@ import { useDiscussions } from '@hooks'
 import Discussion from '../Discussion'
 import ParticipantsAndComments from '../ParticipantsAndComments'
 import SectionHeading from '../SectionHeading'
+import StartDiscussionModal from './components/StartDiscussionModal'
 
 const StyledDiscussions = styled(Box)`
   max-height: auto;
@@ -60,6 +61,8 @@ function Discussions({
   subjectId
 }) {
   const [sort, setSort] = useState('-last_comment_created_at')
+  const [startDiscussionModalActive, setStartDiscussionModalActive] = useState(false)
+  
   const { t } = useTranslation('screens')
 
   const query = {
@@ -96,128 +99,141 @@ function Discussions({
     ))
   }
 
+  function handleStartDiscussionActive() {
+    setStartDiscussionModalActive(!startDiscussionModalActive)
+  }
+
   return (
-    <StyledDiscussions
-      gap='xsmall'
-      pad='small'
-    >
-      <Box
-        align='center'
-        direction='row-responsive'
-        justify='between'
-        height={{ min: 'auto' }}
+    <>
+      {startDiscussionModalActive && (
+        <StartDiscussionModal
+          active={startDiscussionModalActive}
+          onClose={handleStartDiscussionActive}
+        />
+      )}
+      <StyledDiscussions
+        gap='xsmall'
+        pad='small'
       >
         <Box
           align='center'
-          direction='row'
-          gap='small'
+          direction='row-responsive'
+          justify='between'
+          height={{ min: 'auto' }}
         >
-          <SectionHeading
-            icon={
-              <Chat
-                color={{ dark: 'light-1', light: 'dark-4' }}
-                size='1rem'
-              />
-            }
-            title={discussionsTitle}
-          />
-          {discussions?.length > 0 && (
-            <ParticipantsAndComments
-              commentsCount={totalCommentsCount}
-              usersCount={totalUsersCount}
-            />
-          )}
-        </Box>
-        {discussions?.length > 1 && (
           <Box
             align='center'
-            alignSelf='end'
             direction='row'
-            gap='xsmall'
+            gap='small'
           >
-            <Text size='1rem'>{t('Talk.Discussions.sortBy')}</Text>
-            <StyledButton
-              onClick={handleSortChange}
-              label={(
-                <Box
-                  align='center'
-                  direction='row'
-                  gap='xxsmall'
-                >
-                  <SpacedText weight={700}>
-                    {sortButtonLabel}
-                  </SpacedText>
-                  {sort === 'last_comment_created_at' ? (
-                    <Up
-                      color='neutral-1'
-                      size='14px'
-                    />
-                  ) : (
-                    <Down
-                      color='neutral-1'
-                      size='14px'
-                    />
-                  )}
-                </Box>
-              )}
-              pad={{ horizontal: 'small', vertical: 'xsmall' }}
+            <SectionHeading
+              icon={
+                <Chat
+                  color={{ dark: 'light-1', light: 'dark-4' }}
+                  size='1rem'
+                />
+              }
+              title={discussionsTitle}
             />
-          </Box>
-        )}
-      </Box>
-      {discussions?.length > 0 && (
-        <StyledOrderedList
-          forwardedAs='ol'
-          border='between'
-          gap='60px'
-          margin='none'
-          overflow={{ vertical: 'auto' }}
-          pad='none'
-        >
-          {discussions?.map((discussion) => (
-            <li key={discussion.id}>
-              <Discussion
-                discussion={discussion}
-                login={login}
+            {discussions?.length > 0 && (
+              <ParticipantsAndComments
+                commentsCount={totalCommentsCount}
+                usersCount={totalUsersCount}
               />
-            </li>
-          ))}
-        </StyledOrderedList>
-      )}
-      <StyledBox
-        align='center'
-        direction='row'
-      >
-        <StyledDiscussionButton
-          label={(
+            )}
+          </Box>
+          {discussions?.length > 1 && (
             <Box
               align='center'
+              alignSelf='end'
               direction='row'
               gap='xsmall'
-              justify='center'
             >
-              <Chat
-                color={{ dark: 'accent-1', light: 'neutral-1' }}
-                size='18px'
-              />
-              <SpacedText
-                color={{ dark: 'accent-1', light: 'neutral-1' }}
-                size='1.125rem'
-                weight={600}
-              >
-                {t('Talk.Discussions.startDiscussion')}
-              </SpacedText>
-              <Add
-                color={{ dark: 'accent-1', light: 'neutral-1' }}
-                size='18px'
+              <Text size='1rem'>{t('Talk.Discussions.sortBy')}</Text>
+              <StyledButton
+                onClick={handleSortChange}
+                label={(
+                  <Box
+                    align='center'
+                    direction='row'
+                    gap='xxsmall'
+                  >
+                    <SpacedText weight={700}>
+                      {sortButtonLabel}
+                    </SpacedText>
+                    {sort === 'last_comment_created_at' ? (
+                      <Up
+                        color='neutral-1'
+                        size='14px'
+                      />
+                    ) : (
+                      <Down
+                        color='neutral-1'
+                        size='14px'
+                      />
+                    )}
+                  </Box>
+                )}
+                pad={{ horizontal: 'small', vertical: 'xsmall' }}
               />
             </Box>
           )}
-          margin={{ horizontal: 'xsmall' }}
-          plain
-        />
-      </StyledBox>
-    </StyledDiscussions>
+        </Box>
+        {discussions?.length > 0 && (
+          <StyledOrderedList
+            forwardedAs='ol'
+            border='between'
+            gap='60px'
+            margin='none'
+            overflow={{ vertical: 'auto' }}
+            pad='none'
+          >
+            {discussions?.map((discussion) => (
+              <li key={discussion.id}>
+                <Discussion
+                  discussion={discussion}
+                  login={login}
+                />
+              </li>
+            ))}
+          </StyledOrderedList>
+        )}
+        <StyledBox
+          align='center'
+          direction='row'
+        >
+          <StyledDiscussionButton
+            label={(
+              <Box
+                align='center'
+                direction='row'
+                gap='xsmall'
+                justify='center'
+              >
+                <Chat
+                  color={{ dark: 'accent-1', light: 'neutral-1' }}
+                  size='18px'
+                />
+                <SpacedText
+                  color={{ dark: 'accent-1', light: 'neutral-1' }}
+                  size='1.125rem'
+                  weight={600}
+                >
+                  {t('Talk.Discussions.startDiscussion')}
+                </SpacedText>
+                <Add
+                  color={{ dark: 'accent-1', light: 'neutral-1' }}
+                  size='18px'
+                />
+              </Box>
+            )}
+            margin={{ horizontal: 'xsmall' }}
+            onClick={handleStartDiscussionActive}
+            plain
+          />
+        </StyledBox>
+      </StyledDiscussions>
+    </>
   )
 }
 

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussions/components/StartDiscussionModal/StartDiscussionModal.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussions/components/StartDiscussionModal/StartDiscussionModal.jsx
@@ -1,0 +1,100 @@
+import { Modal, SpacedText } from '@zooniverse/react-components'
+import { Box, Button, Form, FormField, RadioButtonGroup, TextInput } from 'grommet'
+import { useEffect, useState } from 'react'
+
+const DEFAULT_HANDLER = () => true
+
+const DEFAULT_VALUE = {
+  discussion_board: 'General',
+  discussion_title: '',
+  discussion_comment: ''
+}
+
+function StartDiscussionModal({
+  active = false,
+  defaultValue = DEFAULT_VALUE,
+  onClose
+}) {
+  const [value, setValue] = useState(defaultValue)
+
+  useEffect(() => {
+    setValue(defaultValue)
+  }, [defaultValue])
+
+  function handleChange(nextValue, { touched }) {
+    setValue(nextValue)
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault()
+    console.log('form submitted', value)
+  }
+
+  return (
+    <Modal
+      active={active}
+      bodyBackground='transparent'
+      closeFn={onClose}
+      headingBackground='transparent'
+      pad={{ horizontal: 'small', top: 'xsmall', bottom: 'medium' }}
+      role='dialog'
+      title='Start a new discussion'
+      titleColor='black'
+    >
+      <Box
+        gap='small'
+        width='600px'
+      >
+        <Form
+          onChange={handleChange}
+          onSubmit={handleSubmit}
+          value={value}
+        >
+          <FormField
+            htmlFor='discussion_board'
+            label={<SpacedText>Discussion Board</SpacedText>}
+            name='discussion_board'
+            required
+          >
+            <RadioButtonGroup
+              name='discussion_board'
+              options={['General', 'Question', 'Idea', 'Problem']}
+            />
+          </FormField>
+          <FormField
+            htmlFor='discussion_title'
+            label={<SpacedText>Discussion Title</SpacedText>}
+            name='discussion_title'
+            required
+          >
+            <TextInput name='discussion_title' />
+          </FormField>
+          <FormField
+            htmlFor='discussion_comment'
+            label={<SpacedText>Initial Comment</SpacedText>}
+            name='discussion_comment'
+            required
+          >
+            <TextInput
+              name='discussion_comment'
+              type='textarea'
+            />
+          </FormField>
+          <Box
+            align='center'
+            direction='row'
+            justify='end'
+          >
+            <Button
+              label='Start a new discussion'
+              primary
+              type='submit'
+            />
+          </Box>
+        </Form>
+      </Box>
+    </Modal>
+  )
+}
+
+export default StartDiscussionModal

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussions/components/StartDiscussionModal/StartDiscussionModal.stories.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussions/components/StartDiscussionModal/StartDiscussionModal.stories.jsx
@@ -1,0 +1,22 @@
+import { Box } from 'grommet'
+
+import StartDiscussionModal from './StartDiscussionModal'
+
+export default {
+  title: 'Project App / Screens / Subject Talk / Talk Data / Discussions / StartDiscussionModal',
+  component: StartDiscussionModal,
+  decorators: [(Story) => (
+    <Box
+      pad='large'
+    >
+      <Story />
+    </Box>
+  )]
+}
+
+export const Default = {
+  args: {
+    active: true,
+    onClose: () => console.log('closing modal')
+  }
+}

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussions/components/StartDiscussionModal/index.js
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkData/components/Discussions/components/StartDiscussionModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './StartDiscussionModal'


### PR DESCRIPTION
## Package
- app-project

## Describe your changes
- [ ...incoming ]

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).