### PR TITLE
Disable DoneButton and DoneAndTalkButton when Task component could not be rendered

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.jsx
@@ -34,7 +34,7 @@ function Task ({
   task,
   ...props
 }) {
-  const TaskPlugin = task.type === 'dropdown-simple'? tasks.dropdownSimple : tasks[task.type]
+  const TaskPlugin = task.type === 'dropdown-simple' ? tasks.dropdownSimple : tasks[task.type]
   const TaskComponent = TaskPlugin?.TaskComponent
   let annotation
   let suggestions

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonConnector.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonConnector.jsx
@@ -11,6 +11,7 @@ function storeMapper(classifierStore) {
       active: subject
     },
     workflowSteps: {
+      hasUnsupportedTasks,
       shouldWeShowDoneAndTalkButton
     }
   } = classifierStore
@@ -26,6 +27,7 @@ function storeMapper(classifierStore) {
     }
 
     return {
+      hasUnsupportedTasks,
       onClick,
       talkURL: subject.talkURL,
       visible
@@ -36,9 +38,10 @@ function storeMapper(classifierStore) {
 }
 
 function DoneAndTalkConnector(props) {
-  const { onClick, talkURL, visible } = useStores(storeMapper)
+  const { hasUnsupportedTasks, onClick, talkURL, visible } = useStores(storeMapper)
+  const isDisabled = hasUnsupportedTasks || props.disabled
 
-  return visible ? <DoneAndTalkButton onClick={onClick} {...props} talkURL={talkURL} /> : null
+  return visible ? <DoneAndTalkButton {...props} disabled={isDisabled} onClick={onClick} talkURL={talkURL} /> : null
 }
 
 export default observer(DoneAndTalkConnector)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButtonConnector.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButtonConnector.jsx
@@ -12,7 +12,8 @@ function storeMapper(classifierStore) {
       completeClassification
     },
     workflowSteps: {
-      active: step
+      active: step,
+      hasUnsupportedTasks
     }
   } = classifierStore
 
@@ -37,6 +38,7 @@ function storeMapper(classifierStore) {
     }
 
     return {
+      hasUnsupportedTasks,
       hasNextStep,
       onClick
     }
@@ -46,8 +48,10 @@ function storeMapper(classifierStore) {
 }
 
 function DoneButtonConnector(props) {
-  const { hasNextStep, onClick } = useStores(storeMapper)
-  return hasNextStep ? null : <DoneButton onClick={onClick} {...props} />
+  const { hasUnsupportedTasks, hasNextStep, onClick } = useStores(storeMapper)
+  const isDisabled = hasUnsupportedTasks || props.disabled
+
+  return hasNextStep ? null : <DoneButton {...props} disabled={isDisabled} onClick={onClick} />
 }
 
 export default observer(DoneButtonConnector)

--- a/packages/lib-classifier/src/store/WorkflowStepStore/Step/Step.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/Step/Step.js
@@ -42,6 +42,10 @@ const baseStep = types
       return isValid
     },
 
+    get hasUnsupportedTasks() {
+      return self.taskKeys.length !== self.tasks.length
+    },
+
     get isThereBranching () {
       // We return the first single choice task
       // It doesn't make sense to have more than one single choice task in a step

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -48,6 +48,10 @@ const WorkflowStepStore = types
       return false
     },
 
+    get hasUnsupportedTasks() {
+      return Array.from(self.steps.values()).some(step => step.hasUnsupportedTasks)
+    },
+
     findTasksByType (type) {
       const tasksByType = Array.from(self.steps).map(([stepKey, step]) => {
         if (step?.tasks && step.tasks.length > 0) {


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- [ ] lib-classifier

## Linked Issue and/or Talk Post
- Closes Issue #2105 

## Describe your changes
Add check in the Step & WorkflowStepStore for if a task couldn't be rendered (i.e. doesn't exist). Pull this into the DoneAndTalkButton and DoneButton so that we disable the button if there's a task count mismatch (i.e. a rendering issue). 

## How to Review
Load up the classifier and test out with a couple projects to see that the Done and Done&Talk buttons operate as expected.

- Workflow Disabled: https://local.zooniverse.org:8080/?project=markb-panoptes%2Ffocus-testing-project&env=staging&workflow=3487
- Workflow Enabled: (any other valid workflow): https://localhost:8080/?project=kieftrav%2Fdrawing-tools&env=staging&workflow=3867


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).