### PR TITLE
lib-classifier: Fix InputIcon when drawing color is black 

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/components/InputIcon/InputIcon.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/components/InputIcon/InputIcon.jsx
@@ -9,7 +9,7 @@ export const StyledInputIcon = styled.span`
   display: flex;
   align-items: center;
   padding: 15px;
- ${props => props.color === 'rgb(0, 0, 0)' ? css`background: radial-gradient(#cbcccb 0%, #2D2D2D 80%);` : css`background: #2D2D2D;`}
+ ${props => props.color === 'rgb(0, 0, 0)' || props.color === '#000000' ? css`background: radial-gradient(#cbcccb 0%, #2D2D2D 80%);` : css`background: #2D2D2D;`}
 
   > svg {
     fill-opacity: 0.1;


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Follow-up to https://github.com/zooniverse/front-end-monorepo/pull/7060

## Describe your changes
- Add a check for `#000000`.

## How to Review
- https://localhost.zooniverse.org:3000/projects/bofosubamfo/ghanaphenopulse/classify/workflow/27701?env=production

# Checklist

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed