### PR TITLE
lib-react-components: Remove unneeded rel attribute from ImageIconButton

### DIFF
--- a/packages/lib-react-components/src/IconActionButton/IconActionButton.stories.jsx
+++ b/packages/lib-react-components/src/IconActionButton/IconActionButton.stories.jsx
@@ -52,7 +52,6 @@ export const Anchor = {
     a11yTitle: 'Home',
     href: 'https://www.zooniverse.org',
     icon: <Home />,
-    rel: 'noopener noreferrer',
     target: '_blank'
   }
 }

--- a/packages/lib-react-components/src/ImageIconButton/ImageIconButton.jsx
+++ b/packages/lib-react-components/src/ImageIconButton/ImageIconButton.jsx
@@ -17,7 +17,6 @@ function ImageIconButton({
       disabled={disabled}
       href={disabled ? undefined : href}
       icon={<Image />}
-      rel={disabled ? undefined : 'noopener noreferrer'}
       target={disabled ? undefined : '_blank'}
       {...props}
     />


### PR DESCRIPTION
## Package
- lib-react-components

## Linked Issue and/or Talk Post
- noted in https://github.com/zooniverse/front-end-monorepo/pull/6964#discussion_r2218379267
- [related MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#security_and_privacy): in newer browser versions setting target="_blank" implicitly provides the same protection as setting `rel="noopener"`

## Describe your changes
- remove `rel='noopener noreferrer` attribute from `ImageIconButton`

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected