### PR TITLE
AuthModal and TutorialModal: set max height to 90% to account for Safari iOS

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.jsx
@@ -8,10 +8,6 @@ import { useTranslation } from '@translations/i18n'
 import { withStores } from '@helpers'
 import SlideTutorial from '../SlideTutorial'
 
-const StyledModal = styled(Modal)`
-  max-height: 80vh;
-`
-
 function storeMapper (classifierStore) {
   const {
     active: tutorial
@@ -49,10 +45,11 @@ function ModalTutorial ({
 
   if (tutorial) {
     return (
-      <StyledModal
+      <Modal
         {...props}
         active={active}
         closeFn={onClose}
+        height={{ max: '90%' }} // To account for Safari mobile browser. Don't use vh units.
         title={t('ModalTutorial.title')}
       >
         <SlideTutorial
@@ -60,7 +57,7 @@ function ModalTutorial ({
           pad='none'
           width={width}
         />
-      </StyledModal>
+      </Modal>
     )
   }
 

--- a/packages/lib-react-components/src/AuthModal/AuthModal.jsx
+++ b/packages/lib-react-components/src/AuthModal/AuthModal.jsx
@@ -50,6 +50,7 @@ function AuthModal({
       closeFn={closeModal}
       role='dialog'
       pad='0'
+      height={{ max: '90%' }} // To account for Safari mobile browser. Don't use vh units.
     >
       <StyledTabs activeIndex={activeIndex} onActive={onActive}>
         <Tab title={t("AuthModal.LoginForm.signIn")}>

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.jsx
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.jsx
@@ -37,7 +37,8 @@ const PrivacyPolicyLink = () => {
 // default form field box layout.
 const contentProps = {
   direction: 'row',
-  gap: 'xsmall'
+  gap: 'xsmall',
+  align: 'center'
 }
 
 const DEFAULT_VALUES = {
@@ -257,7 +258,7 @@ function Form({
             required
           />
           <Text>
-            (<PrivacyPolicyLink />)
+            <PrivacyPolicyLink />
           </Text>
         </FormField>
 

--- a/packages/lib-react-components/src/Modal/Modal.jsx
+++ b/packages/lib-react-components/src/Modal/Modal.jsx
@@ -1,5 +1,5 @@
 import { bool, func, node, object, oneOfType, string } from 'prop-types'
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useRef } from 'react'
 import { Box } from 'grommet'
 import withLayer from '../helpers/withLayer'
 import ModalBody from './components/ModalBody'


### PR DESCRIPTION
## Package
lib-react-components
lib-classifier

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/7081
Related to https://github.com/zooniverse/front-end-monorepo/issues/6093

## Describe your changes
- Set max height to 90% to account for Safari iOS in AuthModal and TutorialModal
- A similar bug exists in the field guide and likely other modals too because the Modal component defaults to a height of `100vh` on small screen sizes :( I want to keep this PR focused on making the register button accessible on mobile Safari, but will open an Issue for making general improvements to LRC's Modal component.

## How to Review
- View the ModalTutorial on any project by running app-project locally. Look at the desktop version and use your IP with https://xxx.xxx.xxx.xxx:3000/projects/mschwamb/planet-hunters-ngts/classify/workflow/13693?env=production on an iphone if possible. This project is also a good example to see how the bottom of the field guide modal can't be scrolled to.
- Go to any project while signed out and open the Register link from the ZooHeader. You should be able to scroll down to the Register submit button.

# Checklist
## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook