### PR TITLE
lib-subject-viewers: Change storybook port

### DIFF
--- a/packages/lib-subject-viewers/package.json
+++ b/packages/lib-subject-viewers/package.json
@@ -28,7 +28,7 @@
     "build:es6": "BABEL_ENV=es6 babel ./src/ --out-dir ./dist/esm --copy-files --no-copy-ignored --ignore 'src/**/*.spec.js' --ignore 'src/**/*.stories.jsx'",
     "lint": "zoo-standard --fix | snazzy",
     "prepare": "yarn build",
-    "storybook": "storybook dev -p 6008",
+    "storybook": "storybook dev -p 6009",
     "build-storybook": "storybook build",
     "test": "vitest run",
     "test:ci": "vitest run --silent='passed-only'",


### PR DESCRIPTION
Duplicated storybook port with lib-user, changes lib-subject-viewers storybook port to 6009. Noticed when ran parallel `storybook` script from root while reviewing #7078 .

## Package
- lib-subject-viewers