### PR TITLE
refactor: replace Object.assign with spread syntax

### DIFF
--- a/packages/lib-classifier/src/store/Classification/Classification.js
+++ b/packages/lib-classifier/src/store/Classification/Classification.js
@@ -25,8 +25,7 @@ const Classification = types
       self.annotations.forEach(annotation => {
         annotations = annotations.concat(annotation.toSnapshot())
       })
-      snapshot = Object.assign({}, snapshot, { annotations })
-      return snapshot
+      return { ...snapshot, annotations }
     },
 
     // Use this to retrieve previous drawing or transcription task annotations.
@@ -38,7 +37,7 @@ const Classification = types
     }
   }))
   .preProcessSnapshot(snapshot => {
-    let newSnapshot = Object.assign({}, snapshot)
+    let newSnapshot = { ...snapshot }
     // generate classification IDs, if not present
     newSnapshot.id = snapshot.id || cuid()
     // convert any annotations arrays to a map
@@ -53,7 +52,7 @@ const Classification = types
     return newSnapshot
   })
   .postProcessSnapshot(snapshot => {
-    const newSnapshot = Object.assign({}, snapshot)
+    const newSnapshot = { ...snapshot }
     // convert annotations to an array
     newSnapshot.annotations = Object.values(snapshot.annotations)
     return newSnapshot


### PR DESCRIPTION
Replace `Object.assign` with the much faster spread operator in the `Classification` model.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._

## Package
lib-classifier

## How to Review
No functional changes here. This modernises the classification code but doesn’t change how classifications work. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Refactoring
- [ ] The PR creator has described the reason for refactoring.
- [ ] The refactored component(s) continue to work as expected.
