### PR TITLE
lib-grommet-theme: Convert CJS syntax and module type to ESM

### DIFF
--- a/packages/lib-grommet-theme/CHANGELOG.md
+++ b/packages/lib-grommet-theme/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.0.0]
+### Changed
+- Convert CJS syntax and module type to ESM.
+
 ## [3.3.0]
 ### Changed
 - Adjust paragraph default font size to 16px.

--- a/packages/lib-grommet-theme/package.json
+++ b/packages/lib-grommet-theme/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
   "version": "3.3.0",
-  "type": "commonjs",
+  "type": "module",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -1,4 +1,4 @@
-const deepFreeze = require('deep-freeze')
+import deepFreeze from 'deep-freeze'
 // Base Grommet Theme: https://github.com/grommet/grommet/blob/master/src/js/themes/base.js
 
 // Zooniverse brand: https://www.figma.com/proto/HUWCyrjkwgPsGKLXhLGb21/Design-System
@@ -560,4 +560,4 @@ const theme = deepFreeze({
   }
 })
 
-module.exports = theme
+export default theme


### PR DESCRIPTION
## Package
lib-grommet-theme

## Linked Issue and/or Talk Post
Toward: https://github.com/zooniverse/front-end-monorepo/issues/7049

## Describe your changes
- Convert CJS syntax and module type to ESM
- Update the changelog

(Will publish the new version after this PR is approved and merged)

## How to Review
- Both apps should run locally and show successful hydration of styling from the grommet theme.
- Note that in a pnpm monorepo, any changes to lib-grommet-theme will be automatically reflected locally in the apps that use it due to [workspaces](https://pnpm.io/workspaces). For instance, you can change the `brand` color and don't need to rebuild or refresh an app-project page.

# Checklist

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
