### PR TITLE
Projects Landing page: modify the page SSR query so it respects env param in production

### DIFF
--- a/packages/app-root/src/app/projects/page.js
+++ b/packages/app-root/src/app/projects/page.js
@@ -61,7 +61,11 @@ async function fetchActiveProjects(searchParams) {
 
   Object.keys(params).forEach(key => {
     if (key === 'discipline') {
-      panoptesUrl.searchParams.append('tags', params[key])
+      if (params[key] === 'space') {
+        panoptesUrl.searchParams.append('tags', 'astronomy')
+      } else {
+        panoptesUrl.searchParams.append('tags', params[key])
+      }
     } else if (key !== 'env' && params[key]) {
       panoptesUrl.searchParams.append(key, params[key])
     }


### PR DESCRIPTION
## Package
app-root

## Linked Issue and/or Talk Post
Follow-up from https://github.com/zooniverse/front-end-monorepo/pull/7137

## Describe your changes
- I modified the query params in the page SSR to better respond to `searchParams` on page load:
    - Read the `env` correctly in dev mode or production mode
    - If `searchParams.state === 'all'` then remove `state` from the query
    - If `searchParams.languages === 'en'` then remove `languages` from the query
    - If `searchParams.discipline` exists, then replace that param with `tags` in the query
    - If `searchParams.discipline === 'space'` replace it with 'astronomy'

# Checklist

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)