### PR TITLE
fix(lib-classifier): prevent mark gaining focus after drawing task has ended

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.jsx
@@ -85,22 +85,16 @@ const Mark = forwardRef(function Mark(
   }
 
   useEffect(function onSelectMark() {
-    if (isActive && mark.finished) {
+    if (isActive && mark.finished && !mark.subTaskVisibility) {
       focusMark(markRoot.current)
     }
-  }, [isActive, mark.finished])
+  }, [isActive, mark.finished, mark.subTaskVisibility])
 
   useEffect(function onFinishMarkWithSubTasks() {
     if (usesSubTasks && mark.finished) {
       openSubTaskPopup()
     }
   }, [usesSubTasks, mark.finished])
-
-  useEffect(function onCloseSubTasks() {
-    if (mark.finished && !mark.subTaskVisibility) {
-      focusMark(markRoot.current)
-    }
-  }, [mark.finished, mark.subTaskVisibility])
 
   function onKeyDown(event) {
     switch (event.key) {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.spec.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.spec.jsx
@@ -117,7 +117,7 @@ describe('Drawing tools > Mark', function () {
             </Mark>
           </svg>, { wrapper: withGrommetWrapper() }
         )
-        await user.tab()
+        await user.tab() // set focus on the mark so that it receives keyboard events
         await user.keyboard('{Backspace}')
       })
 
@@ -151,7 +151,7 @@ describe('Drawing tools > Mark', function () {
             </Mark>
           </svg>, { wrapper: withGrommetWrapper() }
         )
-        point.setSubTaskVisibility(false)
+        await user.tab()
         await user.keyboard('{Enter}')
         await when(() => point.subTaskVisibility)
       })
@@ -190,7 +190,7 @@ describe('Drawing tools > Mark', function () {
             </Mark>
           </svg>, { wrapper: withGrommetWrapper() }
         )
-        point.setSubTaskVisibility(false)
+        await user.tab()
         await user.keyboard('{ }')
         await when(() => point.subTaskVisibility)
       })
@@ -229,7 +229,6 @@ describe('Drawing tools > Mark', function () {
             </Mark>
           </svg>, { wrapper: withGrommetWrapper() }
         )
-        point.setSubTaskVisibility(false)
         await user.tab()
         await user.keyboard('{Tab}')
       })


### PR DESCRIPTION
## Package

- lib-classifier

## Linked Issue and/or Talk Post

- closes #7156

## Describe your changes

- Cause of issue is that the `onCloseSubTasks` effect handler in [Mark.jsx](https://github.com/zooniverse/front-end-monorepo/blob/main/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.jsx) can run even when the mark is not active (`isActive = false`), for example after the drawing task has ended.
- Add a check for `isActive` by subsuming the logic of `onCloseSubTaks` into `onSelectMark` and removing the former. 
- Modify keyboard tests to ensure that the mark has focus before dispatching the key event.

## How to Review

### Workflow mentioned in issue

1. On the dev server navigate to https://localhost:8080/?project=24686&workflow=28447&subject_set=131644&subject=113435307&env=production
2. Draw a line on the subject.
3. Click 'Next'. Notice that the first `textarea` has focus.

### Workflow with drawing subtasks - confirm subtask popup logic still works

1. On the dev server navigate to https://localhost:8080/?project=11300&env=production
2. Draw a line, and add a transcription.
3. Click 'Save and Close'. Notice that the line has focus (e.g. pressing 'Enter' re-opens the popup).

### Storybook 

http://localhost:6006/?path=/story/drawing-tools-line--complete&args=finished:!true

- Note that `finished=true` is required to be able to manipulate the mark with the keyboard.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
