### PR TITLE
Markdown & Media: implement defaultMimeType

### DIFF
--- a/packages/lib-react-components/src/Markdownz/Markdownz.jsx
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.jsx
@@ -37,7 +37,18 @@ export function renderMedia(nodeProps) {
     alt = alt.split(match[0])[0].trim()
   }
 
-  if (src) return <Media alt={alt} height={height} src={src} width={width} />
+  if (src) {
+    return (
+      <Media
+        alt={alt}
+        defaultMimeType='image'
+        height={height}
+        src={src}
+        width={width}
+      />
+    )
+  }
+
   return null
 }
 

--- a/packages/lib-react-components/src/Media/Media.jsx
+++ b/packages/lib-react-components/src/Media/Media.jsx
@@ -4,11 +4,29 @@ import { propTypes, defaultProps } from './helpers/mediaPropTypes'
 
 export default function Media(props) {
   const mimeType = mime.getType(props.src)
-  const [ type ] = mimeType ? mimeType.split('/') : []
+  const [ mimeTypeFromUrl ] = mimeType ? mimeType.split('/') : []
   const componentProps = {
     ...defaultProps,
     ...props
   }
+
+  // WARNING: mime.getType() doesn't always return sensible results. If (1) the
+  // file extension isn't obvious in the URL, and/or (2) the URL has search
+  // params, then the extrapolated MIME type will be incorrect.
+  //
+  // For example:
+  // - https://example.com/valid-image-url returns "undefined"
+  // - https://example.com/valid-image.jpg?width=100 returns "undefined"
+  //
+  // This is pertinent where Markdown is being used. In cases such as these, we
+  // can specify a default mime type to fall back on. It can still be wrong
+  // (e.g. we set defaultMimeType='image' but the user actually set
+  // https://example.com/valid-VIDEO-url) but it should work in most practical
+  // cases.
+  //
+  // See https://github.com/zooniverse/front-end-monorepo/issues/7181
+  
+  const type = mimeTypeFromUrl || props.defaultMimeType
 
   if (type === 'image') {
     return (

--- a/packages/lib-react-components/src/Media/Media.stories.jsx
+++ b/packages/lib-react-components/src/Media/Media.stories.jsx
@@ -48,6 +48,12 @@ export function Image() {
       </Box>
       <hr/>
       <Box>
+        <Text>Same as above - the image URL has search params - BUT we now define a defaultMimeType to fall back on. An image should be rendered below.</Text>
+        <Media alt='A galaxy' src={IMAGE_URL_WITH_SEARCH_PARAMS} width={270} defaultMimeType='image' />
+        <Text>(If the image was going to be rendered, it would have rendered right above this paragraph.)</Text>
+      </Box>
+      <hr/>
+      <Box>
         <Text>Has a placeholder (delay 3sec). Width and height set as 200</Text>
         <Media
           alt='A galaxy'

--- a/packages/lib-react-components/src/Media/README.md
+++ b/packages/lib-react-components/src/Media/README.md
@@ -5,11 +5,13 @@ The Media component dynamically renders an appropriate child media component bas
 - alt: _(string)_ the alt attribute for accessibility. Either passed onto aria-label or alt.
 - controls: _(bool)_ whether or not to show the controls for video and audio. Defaults to true.
 - delay: _(number)_ millisecond loading delay for react-progressive-image. Defaults to 0.
+- defaultMimeType: _(string)_ default MIME type to use, IF the MIME type can't be guessed from the `src`. 
 - fit: _(string)_ CSS object-fit property to set. Grommet prop. Only `'contain'` or `'cover'`.
 - height: _(number)_ height in CSS pixels.
 - origin: _(string)_ The origin for the Zooniverse thumbnail service. Defaults to `'https://thumbnails.zooniverse.org'`
 - placeholder: _(node)_ React component or HTML to render as a child of the placeholder container while the image is loading
 - src: _(string)_ the source of the media. Required.
+  - NOTE: MIME type and the corresponding child media component is determined by this string. If a MIME type can't be guessed, consider specifying a `defaultMimeType`
 - width: _(number)_ width in CSS pixels.
 
 ## mimetype is image


### PR DESCRIPTION
## PR Overview

Package: lib-react-components
Affects: Media components rendered via Markdown
Fixes #7181

This PR fixes an issue where the Media component, _when it can't guess the media file's MIME type via the src url,_ will just render _nothing._ [Nothing! Absolutely nothing!](https://www.youtube.com/watch?v=GB7mHxdHlRY)

This was particularly problematic in Markdown, where volunteers and project owners can input valid image URLs like https://images.unsplash.com/photo-1697954373792-3d1b5fa59c15 [^1] and https://panoptes-uploads.zooniverse.org/user_avatar/57ce57cc-63cf-46e1-bc9f-a7e52c3f4c05.jpeg?blorp [^2]

[^1]: doesn't have a file extension in the URL.
[^2]: file extension is interrupted by a search param. Blorp!

This PR attempts to solve the issue by instructing the Media component (in Markdown only) to use "image" as a fallback MIME type.

Changes:

- `Media` component:
  - Now accepts `defaultMimeType` attribute.
  - Media > Image Storybook story updated with an example.
  - Documentation updated accordingly.
- `Markdown` component:
  - Now specifies defaultMimeType='image' for the Media it spawns.
- NOTE: Media used in other instances (e.g. Subject Thumbnail) should NOT be affected.

⚠️ **Known Limitations:**

- Setting a default MIME type to be 'image' isn't a cure-all solution; I can still think of ways to bork this.
- For example, `![my home movie](https://example.com/valid-movie-url)` will be incorrectly rendered as an image. 😬 
- For the Zooniverse's use case of Markdown however, I believe that falling back to 'image' should be correct for _most scenarios._
- For the exceptions, we can inform the volunteers/researchers that a **workaround** for forcing a specific media component is to add a search param. e.g. `https://example.com/valid-movie-url?media-override.mp4`

### Testing

On lib-react-components, test it via Storybook.

- Run storybook.
- Go to [Media -> Image story](http://localhost:6007/?path=/story/components-media--image)
- Find the first example that states "image URL has search params" and observe that no image is rendered.
- Find the second example that states "image URL has search params" and observe that, by adding defaultMimeType='image', an image IS rendered.

On app-project, test via a, uh, test project I guess.

- Run `pnpm dev`
- Find or create a test project that uses Markdown with "problematic" image URLs
- For example: https://local.zooniverse.org:3000/projects/darkeshard/test-project-2025/about/research?env=staging
  - This About page has two images: the first has src=https://panoptes-uploads.zooniverse.org/user_avatar/57ce57cc-63cf-46e1-bc9f-a7e52c3f4c05.jpeg and the second has src=https://panoptes-uploads.zooniverse.org/user_avatar/57ce57cc-63cf-46e1-bc9f-a7e52c3f4c05.jpeg?blorp
  - Without this PR, ONLY the first image will be rendered.
  - With this PR, BOTH images will be rendered.

For bonus points, feel free to confirm that the Media used in non-Markdown components (e.g. Project avatars) are working as normal with no changes to behaviour.

### Status

Ready for review: tagging @kieftrav as main reviewer, and rest of the team as an FYI.

