### PR TITLE
app-project: Minor styling adjustments to the hero grid

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.jsx
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.jsx
@@ -13,6 +13,7 @@ import WorkflowSelector from '@shared/components/WorkflowSelector'
 const StyledGrid = styled(Grid)`
   width: 100%;
   grid-template-columns: 62% 38%;
+  flex-grow: 1; // This applies when the Hero doesn't have enough content to grow to its layout parent's 90vh
 
   @media (width < 769px) {
     grid-template-columns: none;
@@ -55,6 +56,7 @@ function Hero({ workflows = [] }) {
           light: 'white'
         }}
         gap='small'
+        justify='between'
         pad='medium'
         margin={
           size === 'small'

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Background/Background.jsx
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Background/Background.jsx
@@ -2,20 +2,23 @@ import { string } from 'prop-types'
 import styled from 'styled-components'
 import { observer, MobXProviderContext } from 'mobx-react'
 import { useContext } from 'react'
-import { Image } from 'grommet'
+import { Box } from 'grommet'
 
-const Img = styled(Image)`
-  object-position: 0 50%;
-  object-fit: cover;
+const StyledBox = styled(Box)`
   width: 100%;
   height: 100%;
+  background-image: url("${props => props.$imageSrc}");
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: 0 50%;
 
   // Grommet small breakpoint
   @media (width < 769px) {
-    height: 230px;
-    min-height: inherit;
+    background-position: 50% 50%;
+    min-height: 230px;
   }
 `
+
 
 function useStores() {
   const { store } = useContext(MobXProviderContext)
@@ -28,7 +31,7 @@ function useStores() {
 function Background() {
   const { backgroundSrc } = useStores()
 
-  return <Img alt='' src={backgroundSrc} />
+  return <StyledBox $imageSrc={backgroundSrc} />
 }
 
 Background.propTypes = {


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Follow-up to https://github.com/zooniverse/front-end-monorepo/pull/7175

## Describe your changes
- Minor adjustments to CSS styling of the Hero grid and background. This is primarily for projects with minimal content in their Hero displayed on a large screen. We want the Hero to grow to its layout parent styled with `90vh`.

## How to Review
- I'll be merging this and reviewing via frontend.preview for deploy this week.

# Checklist

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out