### PR TITLE
Project Landing page: Edit the CSS styling of DisciplineButton for aria-selected

### DIFF
--- a/packages/lib-content/src/screens/Projects/components/Projects/components/DisciplineSelect.jsx
+++ b/packages/lib-content/src/screens/Projects/components/Projects/components/DisciplineSelect.jsx
@@ -69,8 +69,7 @@ const StyledButton = styled(Button)`
     border-color: ${props =>
       props.theme.dark ? 'white' : props.theme.global.colors['neutral-1']};
 
-    &:hover:not([aria-selected='true']),
-    &:focus:not([aria-selected='true']) {
+    &:not([aria-selected='true']) {
       background: ${props =>
         props.theme.dark
           ? props.theme.global.colors['dark-5']


### PR DESCRIPTION
## Package
lib-content

Follows on the base Projects Landing Page PR: https://github.com/zooniverse/front-end-monorepo/pull/7137
[Google Doc](https://docs.google.com/document/d/1Asfn-Ba9WWP8gji4e0JNGSkvvhjPOB_6TgdSdRyMBgw)

## Describe your changes
- Edit the CSS rules for the buttons in DisciplineSelect

## How to Review
- [ ] Dark mode sometimes has incorrect CSS styling on the discipline buttons
    - Haven’t been able to figure out the exact cause because it only happens in a production env like https://fe-root.preview.zooniverse.org/projects. This seems specific to dark mode, like the stylesheet isn’t completely created on first page load. The borders are missing and padding is incorrect, unless you click on one of the buttons.
There could be some competing style rules between aria-selected and focus, so that's what I've edited in this PR.

# Checklist

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)