### PR TITLE
Classifier: add debug messages when "This Workflow Does Not Exist", add error message when no workflow selected

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
@@ -233,9 +233,9 @@ export default function ClassifierContainer({
   - https://github.com/zooniverse/front-end-monorepo/issues/7176
   - https://github.com/zooniverse/front-end-monorepo/issues/7193
    */
-  let errorMessage = ''
+  let debugMessage = ''
   if (!allowedWorkflowID) {
-    errorMessage = `selected_workflow: ${workflowID}, available_workflows: ${allowedWorkflows?.join?.(',')}, project_id: ${project?.id}, project_updated: ${project?.updated_at}`
+    debugMessage = `selected_workflow: ${workflowID}, available_workflows: ${allowedWorkflows?.join?.(',')}, project_id: ${project?.id}, project_updated: ${project?.updated_at}, url: ${window?.location?.toString()}, timestamp: ${Date?.now()}`
   }
 
   try {
@@ -251,11 +251,10 @@ export default function ClassifierContainer({
               This workflow does not exist or you do not have permission to view it.
             </Paragraph>
             <Paragraph
-              className='error-message'
-              size='small'
-              style={{ opacity: '0.5' }}
+              className='debug-message'
+              style={{ fontSize: '0.5em', opacity: '0.5' }}
             >
-              {errorMessage}
+              {debugMessage}
             </Paragraph>
           </>
         : classifierIsReady ?

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
@@ -235,7 +235,7 @@ export default function ClassifierContainer({
    */
   let debugMessage = ''
   if (!allowedWorkflowID) {
-    debugMessage = `selected_workflow: ${workflowID}, available_workflows: ${allowedWorkflows?.join?.(',')}, project_id: ${project?.id}, project_updated: ${project?.updated_at}, url: ${window?.location?.toString()}, timestamp: ${Date?.now()}`
+    debugMessage = `selected_workflow: ${workflowID}, available_workflows: ${allowedWorkflows?.join?.(',')}, project_id: ${project?.id}, url: ${window?.location?.toString()}, timestamp: ${Date?.now()}`
   }
 
   try {

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
@@ -226,19 +226,46 @@ export default function ClassifierContainer({
   const projectIsReady = !!classifierStore.projects.active
   const classifierIsReady = userHasLoaded && workflowIsReady && projectIsReady
 
+  /*
+  The "This workflow does not exist" error message has proven very unhelpful
+  with troubleshoots. We need to provide additional information to understand
+  why volunteers are encountering the problem. See:
+  - https://github.com/zooniverse/front-end-monorepo/issues/7176
+  - https://github.com/zooniverse/front-end-monorepo/issues/7193
+   */
+  let errorMessage = ''
+  if (!allowedWorkflowID) {
+    errorMessage = `selected_workflow: ${workflowID}, available_workflows: ${allowedWorkflows?.join?.(',')}, project_id: ${project?.id}, project_updated: ${project?.updated_at}`
+  }
+
   try {
     return (
       <Provider classifierStore={classifierStore}>
-      {!allowedWorkflowID && userHasLoaded ?
-        <Paragraph>This workflow does not exist or you do not have permission to view it.</Paragraph>
+        {/* If the Workflow ID isn't specified, it's usually when the volunteer is seeing a "select a workflow" modal. */}
+        {!workflowID ? (
+          <Paragraph>No workflow selected.</Paragraph>
+        )
+        : workflowID && !allowedWorkflowID && userHasLoaded ?
+          <>
+            <Paragraph>
+              This workflow does not exist or you do not have permission to view it.
+            </Paragraph>
+            <Paragraph
+              className='error-message'
+              size='small'
+              style={{ opacity: '0.5' }}
+            >
+              {errorMessage}
+            </Paragraph>
+          </>
         : classifierIsReady ?
-           <Classifier
-              onError={onError}
-              showTutorial={showTutorial}
-              subjectSetID={subjectSetID}
-              subjectID={subjectID}
-              workflowSnapshot={workflowSnapshot}
-            /> :
+          <Classifier
+            onError={onError}
+            showTutorial={showTutorial}
+            subjectSetID={subjectSetID}
+            subjectID={subjectID}
+            workflowSnapshot={workflowSnapshot}
+          /> :
           <Paragraph>Loading the Classifier</Paragraph>
         }
       </Provider>


### PR DESCRIPTION
## PR Overview

Supports: #7193 
Package: lib-classifier

This PR updates the Classifier with more verbose error messages.

New behaviour:
- 🆕 If NO workflow is selected[^1] => a new error message, "No workflow selected", is displayed.
- If an INVALID workflows is selected[^2] => the standard "This workflow does not exist or you do not have permission to view it" message is displayed, PLUS 🆕 additional debug data.
  - 🆕 Debug data includes: selected workflow ID, allowed workflow IDs, project ID, ~~project updated time,~~[^3] url, timestamp.
  - Q: why? A: if a volunteer encounters this message, we want to know WHY they received it. The debug data includes everything need (hopefully) to understand why `allowedWorkflowID` is null. (See 7193)
- Otherwise, display the Classifier if everything has loaded, or show "Loading the Classifier" if it's still loading.

Current behaviour:
- If NO workflow is selected[^1] => "This workflow does not exist or you do not have permission to view it"
- If an INVALID workflow is selected[^2] => "This workflow does not exist or you do not have permission to view it"
- Otherwise, display the Classifier if everything has loaded etc etc.

[^1]: For example, when a volunteer goes to the /classify page of a project with multiple workflows, the classifier will load in the background with no workflow selected, while the "pls select your workflow" modal appears in the foreground.
[^2]: For example, when a volunteer tries to look at a retired workflow. NOTE: if you view a workflow that does not exist, or exists for a different project, then you get different results depending on whether you're looking at it on lib-classifier or app-project. On the former, you'll get the "This workflow does not exist" error message. On the latter, you'll get a 404.
[^3]: Apparently, we're not capturing project updated time. Hmm, this might be worth adding if we want to test that cache problem.

### Testing

Test on localhost with _app-project._

Testing Steps (project with one workflow):
- Choose a test project with one workflow, e.g. Snapshot Wisconsin.
- Go to the Classify page: https://local.zooniverse.org:3000/projects/zooniverse/snapshot-wisconsin/classify?env=production
  - You should be auto-directed to the one active workflow, e.g. https://local.zooniverse.org:3000/projects/zooniverse/snapshot-wisconsin/classify/workflow/30961?env=production
  - You should see the Classifier functioning normally.
- Go to a retired workflow, e.g. https://local.zooniverse.org:3000/projects/zooniverse/snapshot-wisconsin/classify/workflow/30760?env=production
  - You should see the error message _"This workflow does not exist or you do not have permission to view it."_
  - You should see some very tiny debug message beneath it, e.g. _"selected_workflow: 30760, available_workflows: 30961, project_id: 2439, url: https://local.zooniverse.org:3000/projects/zooniverse/snapshot-wisconsin/classify/workflow/30760?env=production, timestamp: 1769204018981"_
      <img width="400" alt="image" src="https://github.com/user-attachments/assets/5fdf9986-4189-4a78-8a4c-0f7d8c22290a" />
- Choose an invalid workflow, e.g. https://local.zooniverse.org:3000/projects/zooniverse/snapshot-wisconsin/classify/workflow/666?env=production
  - You should see a 404.

Testing Steps (project with multiple workflows):
- Choose a test project with many workflows, e.g. https://local.zooniverse.org:3000/projects/victorav/spyfish-aotearoa/classify?env=production
- Go to the Classify page: https://local.zooniverse.org:3000/projects/victorav/spyfish-aotearoa/classify?env=production
  - You should see the "Choose a workflow" modal.
  - In the background, you should see the error message "No workflow selected" INSTEAD OF "This workflow does not exist".
      <img width="400" alt="image" src="https://github.com/user-attachments/assets/a4445c39-0960-4a11-af3b-e9de125794d8" />
- Choose any workflow.
  - You should be taken to that workflow, and you should see the Classifier functioning normally.

### Status

Solution proposed. Ready for review.