### PR TITLE
Check InteractionLayer finish() for same-frame behavior mark registration

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.jsx
@@ -116,6 +116,12 @@ function InteractionLayer({
     event?.stopPropagation?.()
     setCreating(false)
 
+    /*
+      When multi_image_clone_markers is enabled, marks are always created with frame: 0 regardless of which frame the user clicks.
+      When viewed in separates frames mode, the isInBounds() check isn't accurate and will delete the active mark.
+      Improvements to isInBounds() would be helpful in the future, but for now the check for activeMark.frame
+      is a fix for https://github.com/zooniverse/front-end-monorepo/issues/7195.
+    */
     if (activeMark.frame !== frame) {
       return
     }


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
Fixes #7195

## Describe your changes
When multi_image_clone_markers is enabled, marks are always created with frame: 0 regardless of which image the user clicks. The onFinish() bounds check was comparing the mark's DOM element (rendered in frame 0's SVG) against the clicked frame's canvas bounds, causing marks to be incorrectly deleted as "out of bounds."

This fix adds a frame ownership check before bound validation in each InteractionLayer frame.

## How to Review
Project: [Space Warps ESA Euclid](https://local.zooniverse.org:8080/?project=aprajita%2Fspace-warps-esa-euclid&workflow=27623)

Steps:
- Load the classifier with a multi-image subject (4 images in grid)
- Click on each of the 4 images to create marks

Before fix: Only top-left image creates marks; all other images fail
After fix: All 4 images successfully create marks

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated