### PR TITLE
fix(classifier): scroll to task area on next/back navigation (#7168)

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.jsx
@@ -71,6 +71,7 @@ export default function TaskArea({
       <TaskContainer
         data-testid="task-area"
         ref={taskArea}
+        tabIndex={-1}
       >
         <Tabs
           activeIndex={activeIndex}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/BackButton/BackButtonConnector.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/BackButton/BackButtonConnector.jsx
@@ -14,10 +14,12 @@ function storeMapper(classifierStore) {
     function onClick() {
       back()
 
-      // ensures dom update completes before scrolling back to top of Task Area
       requestAnimationFrame(() => {
         const taskArea = document.querySelector('[data-testid="task-area"]')
-        taskArea?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        taskArea?.focus()
+        if (taskArea?.getBoundingClientRect().top < 0) {
+          taskArea.scrollIntoView({ block: 'start' })
+        }
       })
     }
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButtonConnector.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButtonConnector.jsx
@@ -21,10 +21,12 @@ function storeMapper(classifierStore) {
       step.completeAndValidate(annotations)
       next()
 
-      // ensures dom update completes before scrolling back to top of Task Area
       requestAnimationFrame(() => {
         const taskArea = document.querySelector('[data-testid="task-area"]')
-        taskArea?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        taskArea?.focus()
+        if (taskArea?.getBoundingClientRect().top < 0) {
+          taskArea.scrollIntoView({ block: 'start' })
+        }
       })
     }
 


### PR DESCRIPTION
## Package
`lib-classifier`

## Linked Issue and/or Talk Post
Fixes #7168

## Describe your changes
Added scroll-to-task-area behavior when clicking Next or Back buttons in multi-step workflows. After navigating between steps, the view now smoothly scrolls to the top of the task area, reducing user confusion and unnecessary scrolling. The Done and Done&Talk buttons automatically come back into view due to the subject change re-render.

## How to Review
1. Start `lib-classifier` and visit https://local.zooniverse.org:8080/?project=kieftrav%2Fsimpledropdown&env=staging&workflow=3770
2. Make sure the browser height is smaller / forcing a scroll on the task.. Complete the first task and click **Next** - verify the view scrolls to show the top of the task area 
3. Click **Back** - verify the view scrolls to show the top of the task area
4. Verify **Done** button behavior is unchanged (new subject load already handles this)

## Checklist

### General
- [ ] Tests are passing locally and on Github

### Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
