### PR TITLE
lib-subject-viewers: Fix memory leaks and forced crashes in VolumetricViewer

### DIFF
--- a/packages/lib-subject-viewers/src/VolumetricViewer/VolumetricFull/VolumetricFull.jsx
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/VolumetricFull/VolumetricFull.jsx
@@ -51,6 +51,16 @@ export default function VolumetricFull ({
     })
 
     setModelState(state)
+
+    // Cleanup function to dispose resources when data changes or component unmounts
+    return () => {
+      if (state.viewer?.dispose) {
+        state.viewer.dispose()
+      }
+      if (state.annotations?.dispose) {
+        state.annotations.dispose()
+      }
+    }
   }, [data])
 
   const isLoading = loadingState === asyncStates.initialized ||

--- a/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelAnnotations.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelAnnotations.js
@@ -233,6 +233,16 @@ export const ModelAnnotations = ({ onAnnotation }) => {
         }
       })
     },
+    // Cleanup
+    dispose: () => {
+      // Clear all annotations to allow garbage collection
+      annotationModel.annotations = []
+      annotationModel.config.activeAnnotation = null
+      annotationModel.config.algorithm = null
+      annotationModel.config.viewer = null
+      annotationModel._listeners = []
+    },
+
     // Listeners
     _listeners: [],
     publish: (eventName, data) => {

--- a/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelViewer.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelViewer.js
@@ -99,9 +99,15 @@ export const ModelViewer = () => {
       return pointModel.planesAbsoluteSets[dimension][frame]
     },
     getPointAnnotationIndex: ({ point }) => {
+      if (point === undefined || point === null || !pointModel.points[point]) {
+        return -1
+      }
       return pointModel.points[point][5]
     },
     getPointCoordinates: ({ point }) => {
+      if (point === undefined || point === null || !pointModel.points[point]) {
+        return [0, 0, 0]
+      }
       return pointModel.points[point].slice(1, 4)
     },
     getPointFromStructured: ({ point }) => {
@@ -113,9 +119,15 @@ export const ModelViewer = () => {
         .reduce((acc, val) => acc + val, 0)
     },
     getPointValue: ({ point }) => {
+      if (point === undefined || point === null || !pointModel.points[point]) {
+        return 0
+      }
       return pointModel.points[point][0]
     },
     isPointInThreshold: ({ point }) => {
+      if (point === undefined || point === null || !pointModel.points[point]) {
+        return false
+      }
       return pointModel.points[point][4]
     },
     saveScreenshot: () => {
@@ -139,6 +151,16 @@ export const ModelViewer = () => {
         point[4] = min <= point[0] && max >= point[0]
       })
       pointModel.publish('change:threshold', { min, max })
+    },
+
+    // Cleanup
+    dispose: () => {
+      // Clear all data arrays to allow garbage collection
+      pointModel.data = []
+      pointModel.points = []
+      pointModel.baseFrames = [[], [], []]
+      pointModel.planesAbsoluteSets = [[], [], []]
+      pointModel._listeners = []
     },
 
     // Listeners


### PR DESCRIPTION
## Package
- lib-subject-viewers

## Linked Issue and/or Talk Post
#7209 

## Describe your changes
- Cancel requestAnimationFrame loop on component unmount (Cube.jsx)
- Dispose Three.js renderer, geometries, materials, and OrbitControls
- Move offscreen canvas creation to useRef to prevent per-render allocation
- Close ImageBitmap resources after drawing (Plane.jsx)
- Add dispose() methods to ModelViewer and ModelAnnotations
- Add null checks for point accessors to prevent undefined errors
- Clean up model state when switching subjects (VolumetricFull.jsx)

## How to Review
- checkout main, make sure to run `pnpm build` in `lib-subject-viewers` and then in `lib-classifier` before running `pnpm start` in the `lib-classifier` (build introduces it's own issues with how it wraps all code).
- Visit classifier: https://local.zooniverse.org:8080/?project=cmcbrain%2Fmind-mapper&env=production&demo=true
- Click "Done" to see 10+ subjects with the dev console open. Analyze the console errors + monitor browser memory pressure + crashing. 
- Compare with the PR branch (remember to rerun `pnpm build` after switching branches!). For me, this resulted in more consistent behavior, fewer console errors over time, and I couldn't crash it

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated