### PR TITLE
Classify page: make redirects for solo workflows NOT permanent redirects

### DIFF
--- a/packages/app-project/pages/[panoptesEnv]/[owner]/[project]/classify/index.js
+++ b/packages/app-project/pages/[panoptesEnv]/[owner]/[project]/classify/index.js
@@ -19,7 +19,9 @@ export async function getStaticProps({ defaultLocale, locale, params }) {
     return ({
       redirect: {
         destination: `${pathname}/workflow/${props.workflowID}${search}`,
-        permanent: true
+        permanent: false
+        // Do NOT use permanent: true, since the target workflowID can change.
+        // See https://github.com/zooniverse/front-end-monorepo/issues/7193
       }
     })
   }


### PR DESCRIPTION
## PR Overview

Package: app-project
Fixes #7193 _aka the semi-random "this Workflow does not exist" errors_

This PR changes the redirect action from a 308 Permanent Redirect to a **307 Temporary Redirect,** to ensure that (for projects with only one active workflow) volunteers are always redirected to the **current** solo workflow.

**Context**

When a volunteer goes to the /classify route of a project _with only one active (solo) workflow,_ that volunteer is immediately redirected to that solo workflow. e.g. `/projects/foo/bar/classify` redirects to `/projects/foo/bar/classify/workflow/1234`

The problem is that this http-level redirect is a **308 Permanent Redirect,** but the _active workflow ID will always change._ This can result in volunteers having a "permanent redirect" to an old/defunct workflow stored in their browser cache, leading them to see the dreaded "This workflow does not exist or you do not have permission to view it" error.

A 307 will inform the browser that /projects/foo/bar/classify will some days lead to /projects/foo/bar/classify/workflow/1234 and some days lead to /projects/foo/bar/classify/workflow/5678. That said, I have no idea if this will help volunteers who have existing 308 redirects stored in the browser caches. 😬 

### Testing

Preparation:

- Prepare a test project, e.g. [Test Project 2025b](https://www.zooniverse.org/lab/2023/workflows?env=staging)
  - This project must have 2 or more workflows to switch between, e.g. workflows 🍎 3889 and 🍏 3890
  - This project must have _exactly one workflow active,_ e.g. workflow ✔️🍏 3890
      <img width="783" height="227" alt="image" src="https://github.com/user-attachments/assets/3008467a-5426-4ed2-ad00-932bd13482ac" />
- In your browser dev console, ensure you're preserving traffic logs, because we'll be redirecting between pages and we want to pay attention to the HTTP responses.
- _Ensure you're testing with either an anonymous account or a Tester account, because a Zooniverse admin account might bypass workflow ownership checks._

Testing steps:

- Run app-project, `pnpm dev`
- Go to the project's /classify route, e.g. https://local.zooniverse.org:3000/projects/darkeshard/test-project-2025b/classify
- Check the HTTP response:
  - The /classify path should respond with a **307 Temporary Redirect** (not a 308 Permanent Redirect) to the active workflow.
- Confirm that you're successfully redirected to the active workflow, e.g. ✔️🍏 https://local.zooniverse.org:3000/projects/darkeshard/test-project-2025b/classify/workflow/3890

(BONUS) Extended testing steps:

- Open the URL to an _inactive_ workflow, e.g. ✖️🍎 https://local.zooniverse.org:3000/projects/darkeshard/test-project-2025b/classify/workflow/3889
  - Ensure that the _"This workflow does not exist or you do not have permission to view it."_ error triggers.
- Go back to the test project and switch the active workflow, e.g. 🍏 3890 --> ✔️🍎 3899.
- Go to the project's /classify route.
- Confirm that the 307 Temporary Redirect now directs you to the new active workflow, i.e. ✔️🍎 https://local.zooniverse.org:3000/projects/darkeshard/test-project-2025b/classify/workflow/3889
- Confirm that the currently inactive workflow returns the "This workflow does not exist" error, i.e. ✖️🍏 https://local.zooniverse.org:3000/projects/darkeshard/test-project-2025b/classify/workflow/3889

### Status

Ready for review. Due to how many projects this issue may now be affecting, (i.e. post-FEM switch,) I'd place this on a higher priority than usual.