### PR TITLE
lib-subject-viewers: Fix SortedSet crash in VolumetricViewer

### DIFF
--- a/packages/lib-subject-viewers/src/VolumetricViewer/components/Cube.jsx
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/components/Cube.jsx
@@ -261,6 +261,9 @@ export const Cube = ({ annotations, tool, viewer, orbitControlsEnabled = true })
   function renderPlanePoints () {
     // const t0 = performance.now()
 
+    // Guard against disposed or uninitialized viewer/component
+    if (!viewer || viewer.base <= 0 || !threeRef.current?.meshPlane) return
+
     const frames = viewer.planeFrameActive
     const sets = frames.map((frame, dimension) =>
       viewer.getPlaneSet({ dimension, frame })
@@ -268,9 +271,12 @@ export const Cube = ({ annotations, tool, viewer, orbitControlsEnabled = true })
 
     meshPlaneSet.current = SortedSetUnion({ sets })
 
+    const meshPlane = threeRef.current?.meshPlane
+    if (!meshPlane) return
+
     meshPlaneSet.current.data.forEach((point, index) => {
       drawMeshPoint({
-        mesh: threeRef.current.meshPlane,
+        mesh: meshPlane,
         meshPointIndex: index,
         point
       })
@@ -279,8 +285,8 @@ export const Cube = ({ annotations, tool, viewer, orbitControlsEnabled = true })
 
     renderPlaneOutline({ frames })
 
-    threeRef.current.meshPlane.instanceMatrix.needsUpdate = true
-    threeRef.current.meshPlane.instanceColor.needsUpdate = true
+    if (meshPlane.instanceMatrix) meshPlane.instanceMatrix.needsUpdate = true
+    if (meshPlane.instanceColor) meshPlane.instanceColor.needsUpdate = true
   }
 
   function renderPlaneOutline ({ frames }) {

--- a/packages/lib-subject-viewers/src/VolumetricViewer/helpers/SortedSet.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/helpers/SortedSet.js
@@ -18,7 +18,11 @@ export const BinarySearch = ({ data, left, right, value }) => {
 }
 
 export const SortedSetIntersection = ({ sets }) => {
-  const [firstSet, ...restSets] = sets
+  // Filter out undefined/null sets to prevent crashes
+  const validSets = sets.filter(s => s?.data != null)
+  if (validSets.length === 0) return SortedSet({ data: [] })
+
+  const [firstSet, ...restSets] = validSets
     .map((s) => s.data)
     .sort((a, b) => a.length - b.length)
   const results = []
@@ -61,7 +65,11 @@ export const SortedSetIntersection = ({ sets }) => {
 }
 
 export const SortedSetUnion = ({ sets }) => {
-  const sortedSets = sets
+  // Filter out undefined/null sets to prevent crashes when getPlaneSet returns undefined
+  const validSets = sets.filter(s => s?.data != null)
+  if (validSets.length === 0) return SortedSet({ data: [] })
+
+  const sortedSets = validSets
     .map((s) => s.data)
     .sort((a, b) => a.length - b.length)
 

--- a/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelViewer.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/models/ModelViewer.js
@@ -96,7 +96,12 @@ export const ModelViewer = () => {
       return pointModel.planeFrameActive[dimension]
     },
     getPlaneSet: ({ dimension = 0, frame = 0 }) => {
-      return pointModel.planesAbsoluteSets[dimension][frame]
+      // Return empty SortedSet if dimension or frame is out of bounds
+      const dimensionSets = pointModel.planesAbsoluteSets[dimension]
+      if (!dimensionSets || frame < 0 || frame >= dimensionSets.length) {
+        return SortedSet({ data: [] })
+      }
+      return dimensionSets[frame] ?? SortedSet({ data: [] })
     },
     getPointAnnotationIndex: ({ point }) => {
       if (point === undefined || point === null || !pointModel.points[point]) {

--- a/packages/lib-subject-viewers/src/VolumetricViewer/tests/SortedSet.spec.js
+++ b/packages/lib-subject-viewers/src/VolumetricViewer/tests/SortedSet.spec.js
@@ -1,4 +1,4 @@
-import { SortedSet } from './../helpers/SortedSet'
+import { SortedSet, SortedSetUnion, SortedSetIntersection } from './../helpers/SortedSet'
 
 describe('Component > VolumetricViewer > SortedSet', () => {
   const testSet1 = SortedSet()
@@ -144,5 +144,40 @@ describe('Component > VolumetricViewer > SortedSet', () => {
     expect(union3n4n2.data).deep.to.equal([1, 3, 5, 7, 9, 11])
     expect(union4n2n3.data).deep.to.equal([1, 3, 5, 7, 9, 11])
     expect(union4n3n2.data).deep.to.equal([1, 3, 5, 7, 9, 11])
+  })
+
+  // Edge cases: undefined/null sets should not crash
+  describe('handles undefined/null sets gracefully', () => {
+    it('SortedSetUnion should filter out undefined sets', () => {
+      const validSet = SortedSet({ data: [1, 2, 3] })
+      const result = SortedSetUnion({ sets: [validSet, undefined, null] })
+      expect(result.data).deep.to.equal([1, 2, 3])
+    })
+
+    it('SortedSetUnion should return empty set when all sets are undefined', () => {
+      const result = SortedSetUnion({ sets: [undefined, null] })
+      expect(result.data).deep.to.equal([])
+    })
+
+    it('SortedSetUnion should return empty set for empty sets array', () => {
+      const result = SortedSetUnion({ sets: [] })
+      expect(result.data).deep.to.equal([])
+    })
+
+    it('SortedSetIntersection should filter out undefined sets', () => {
+      const validSet = SortedSet({ data: [1, 2, 3] })
+      const result = SortedSetIntersection({ sets: [validSet, undefined, null] })
+      expect(result.data).deep.to.equal([1, 2, 3])
+    })
+
+    it('SortedSetIntersection should return empty set when all sets are undefined', () => {
+      const result = SortedSetIntersection({ sets: [undefined, null] })
+      expect(result.data).deep.to.equal([])
+    })
+
+    it('SortedSetIntersection should return empty set for empty sets array', () => {
+      const result = SortedSetIntersection({ sets: [] })
+      expect(result.data).deep.to.equal([])
+    })
   })
 })


### PR DESCRIPTION
## Package
lib-subject-viewers

## Linked Issue and/or Talk Post
Issue #7217 

## Describe your changes
Add defensive guards to prevent TypeError when SortedSet receives undefined sets, which can occur during component unmount or malformed subject data.

- Filter undefined/null sets in SortedSetUnion and SortedSetIntersection
- Add bounds checking in getPlaneSet to return empty SortedSet
- Guard renderPlanePoints against disposed viewer and null meshPlane refs
- Add unit tests for undefined set handling

## How to Review
- checkout main, make sure to run pnpm build in lib-subject-viewers and then in lib-classifier before running pnpm start in the lib-classifier (build introduces it's own issues with how it wraps all code).
- Visit classifier: https://local.zooniverse.org:8080/?project=cmcbrain%2Fmind-mapper&env=production&demo=true
- Click "Done" to see 25+ subjects with the dev console open. Analyze the console errors + monitor browser memory pressure + crashing.
- Compare with the PR branch

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated