### PR TITLE
lib-content: Change label of All in project status dropdown

### DIFF
--- a/packages/lib-content/src/translations/en.json
+++ b/packages/lib-content/src/translations/en.json
@@ -1,10 +1,10 @@
 {
   "404": {
     "Default404": {
+      "findNewProject": "Find a new project to explore",
       "heading": "Nothing here.",
       "message": "The page you're looking for no longer exists.",
-      "returnHome": "Return to the homepage",
-      "findNewProject": "Find a new project to explore"
+      "returnHome": "Return to the homepage"
     }
   },
   "AboutHeader": {
@@ -27,18 +27,18 @@
   },
   "AboutPage": {
     "contact": {
-      "heading": "Contact Us",
-      "subheading": "What can we help you with?",
       "categories": {
         "first": "General Zooniverse questions",
         "second": "Collaborating on a project",
         "third": "Press inquiry"
       },
+      "heading": "Contact Us",
       "paragraphs": {
         "first": "Please read through our <0>FAQ page</0> and the <1>Zooniverse Solutions webpage</1>.",
         "second": "Do you have an issue related to a specific project? We recommend reaching out directly to the research team on their Talk page.",
         "third": "Can't access the Contact Us button? Email us directly at <0>contact@zooniverse.org</0>."
-      }
+      },
+      "subheading": "What can we help you with?"
     },
     "highlights": {
       "description": "Available for purchase at <0>Blurb.com</0>",
@@ -58,31 +58,31 @@
     },
     "howItWorks": {
       "heading": "How It Works",
-      "subheading": "People-powered research",
       "participants": {
-        "link": "Explore projects",
         "description": "As a participant",
+        "link": "Explore projects",
         "steps": {
           "first": "Find a project that interests you",
+          "fourth": "Generate an official certificate verifying your efforts on the platform",
           "second": "Learn the process of classifying that project",
-          "third": "Submit your classification and help with real research!",
-          "fourth": "Generate an official certificate verifying your efforts on the platform"
+          "third": "Submit your classification and help with real research!"
         }
       },
       "researchers": {
-        "link": "Build a project",
         "description": "As a researcher",
+        "link": "Build a project",
         "steps": {
           "first": "Build your project using the Zooniverse Project Builder",
+          "fourth": "Download your data and publish your results!",
           "second": "Submit your project for approval",
-          "third": "Launch your project and engage with volunteers on Talk while the classifications come in",
-          "fourth": "Download your data and publish your results!"
+          "third": "Launch your project and engage with volunteers on Talk while the classifications come in"
         }
-      }
+      },
+      "subheading": "People-powered research"
     },
     "mobile": {
-      "altImage": "Picture of mobile phone with Zooniverse app",
       "altAppStore": "Download on the App Store",
+      "altImage": "Picture of mobile phone with Zooniverse app",
       "altPlayStore": "Get It On Google Play",
       "description": "Bring the Zooniverse with you. Download the app for iOS and Android devices.",
       "heading": "Check Out Our Mobile App",
@@ -90,30 +90,30 @@
       "subheading": "Discover, teach, and learn - anywhere"
     },
     "ourMission": {
+      "discoveries": {
+        "first": "Green Pea Galaxies",
+        "fourth": "Boyajian's Star",
+        "second": "New Exoplanets Located",
+        "third": "An Earlier Use of 'White Lie'",
+        "tip": "Click on any discovery for more info"
+      },
       "heading": "Our Mission",
       "paragraphs": {
         "first": "The Zooniverse is the world's largest and most popular platform for people-powered research. This research is made possible by volunteers—millions of people around the world who come together to assist professional researchers. Our goal is to enable research that would not be possible, or practical, otherwise. Zooniverse research results in new discoveries, datasets useful to the wider research community, and many <0>publications</0>.",
+        "fourth": "Volunteers and professionals make real discoveries together. Zooniverse projects are constructed with the aim of converting volunteers' efforts into measurable results. In some cases, Zooniverse volunteers have even made completely unexpected and significant discoveries. A substantial amount of this research takes place on Talk, the Zooniverse discussion boards, where volunteers work together with research team members and each other. These boards are integrated within each project to allow for everything from quick hash-tagging to in-depth collaborative analysis. There is also a <0>central Zooniverse Talk board</0> for general chat and discussion about platform-wide matters. We encourage all users to join the conversation on Talk for more in-depth participation.",
         "second": "You don't need any specialized background, training, or expertise to participate in Zooniverse projects. We make it easy for anyone to contribute to real academic research, on their own computer, at their convenience. You'll be able to study authentic data gathered by researchers, like images of faraway galaxies, historical records and diaries, or videos of animals in their natural habitats. By participating in projects, you'll help contribute to our understanding of the world, the universe, and more. With our wide-ranging and ever-expanding suite of projects, which cover many disciplines and topics across the sciences and humanities, there's a place for anyone and everyone to explore, learn, and have fun in the Zooniverse. To volunteer, visit the <0>Projects page</0>, choose one you like the look of, and get started.",
-        "third": "The major challenge of 21st century research is dealing with the flood of information we can now collect about the world around us. Computers can help, but in many fields the human ability for pattern recognition—and our ability to be surprised—makes us superior. With the help of Zooniverse volunteers, researchers can analyze their information more quickly and accurately than would otherwise be possible, getting to exciting results more quickly. Your effort saves time and resources, advances the ability of computers to do the same tasks, and leads to faster progress and understanding of the world. Our projects combine contributions from multiple individual volunteers, relying on a version of the <0>'wisdom of the crowd'</0> to produce reliable and accurate results. Having many people look at the data often leads to better estimates of how likely we are to make an error. The products of Zooniverse projects are often exactly what's needed to make progress in many fields of research.",
-        "fourth": "Volunteers and professionals make real discoveries together. Zooniverse projects are constructed with the aim of converting volunteers' efforts into measurable results. In some cases, Zooniverse volunteers have even made completely unexpected and significant discoveries. A substantial amount of this research takes place on Talk, the Zooniverse discussion boards, where volunteers work together with research team members and each other. These boards are integrated within each project to allow for everything from quick hash-tagging to in-depth collaborative analysis. There is also a <0>central Zooniverse Talk board</0> for general chat and discussion about platform-wide matters. We encourage all users to join the conversation on Talk for more in-depth participation."
-      },
-      "subheadings": {
-        "first": "The wisdom of the crowd",
-        "second": "Anyone can be a researcher",
-        "third": "We accelerate important research by working together",
-        "fourth": "The Zooniverse Works",
-        "fifth": "Our projects lead to great discoveries"
-      },
-      "discoveries": {
-        "first": "Green Pea Galaxies",
-        "second": "New Exoplanets Located",
-        "third": "An Earlier Use of 'White Lie'",
-        "fourth": "Boyajian's Star",
-        "tip": "Click on any discovery for more info"
+        "third": "The major challenge of 21st century research is dealing with the flood of information we can now collect about the world around us. Computers can help, but in many fields the human ability for pattern recognition—and our ability to be surprised—makes us superior. With the help of Zooniverse volunteers, researchers can analyze their information more quickly and accurately than would otherwise be possible, getting to exciting results more quickly. Your effort saves time and resources, advances the ability of computers to do the same tasks, and leads to faster progress and understanding of the world. Our projects combine contributions from multiple individual volunteers, relying on a version of the <0>'wisdom of the crowd'</0> to produce reliable and accurate results. Having many people look at the data often leads to better estimates of how likely we are to make an error. The products of Zooniverse projects are often exactly what's needed to make progress in many fields of research."
       },
       "stats": {
         "classifications": "Classifications so far",
         "volunteers": "Registered volunteers"
+      },
+      "subheadings": {
+        "fifth": "Our projects lead to great discoveries",
+        "first": "The wisdom of the crowd",
+        "fourth": "The Zooniverse Works",
+        "second": "Anyone can be a researcher",
+        "third": "We accelerate important research by working together"
       },
       "video": "A Brief Introduction to the Zooniverse"
     },
@@ -125,22 +125,22 @@
   },
   "Collaborate": {
     "paragraphs": {
-      "first": "Would your research benefit from the involvement of thousands of volunteers? The Zooniverse is the world’s largest and most successful online platform for crowdsourced research; we have millions of registered volunteers working in collaboration with professional researchers on research projects across a range of disciplines, from astronomy to the humanities.",
-      "second": "Research teams can build Zooniverse projects in two ways.",
-      "third": "Teams can use our free-to-use <0>Project Builder</0> tool to create their very own Zooniverse project. In order to launch publicly and be featured on our projects page, teams must go through our review process to ensure the project is appropriate for the platform and ready to be launched. This is the quickest and most straightforward option for creating a Zooniverse project. For more information on this process, including estimated timelines for review, please see our <1>Project Review Best Practices & Flowchart</1>. ",
-      "fourth": "In cases where the tools available in the <0>Project Builder</0> aren’t quite right for the research goals of a particular team, researchers may want to consider partnering with the Zooniverse to create new, custom tools. We work with these teams to apply for funding to support the research, design, and development process. Those who have applied for grant funding before will know that this process can take a long time. Once we’ve applied for a grant, it can take 6 months or more to hear back about whether or not our efforts were successful. Funded projects typically require at least 6 months to design, build, and test, depending on the complexity of the features being created. We then need additional time to generalize (and often revise) them for inclusion in the Project Builder toolkit. ",
-      "fifth": "If you are interested in partnering with us to create custom project tools or infrastructure, please <0>contact us</0>.",
-      "sixth": "Are you a researcher working on a project relevant to one of NASA’s Science Mission Directorate divisions (Astrophysics, Biological and Physical Sciences, Heliophysics, and the Planetary Science) who would benefit from contributions from Zooniverse volunteers? As part of an on-going partnership with NASA, the Zooniverse seeks to build on its current support of NASA research teams and encourage the development of new projects on our platform.",
-      "seventh": "Whether you are already building workflows using the Project Builder or you are just starting to consider how crowdsourced contributions could advance your research, the Zooniverse team has dedicated effort to support teams during development and implementation of NASA-focused projects. We are happy to discuss and support proposals to NASA citizen science funding calls (including the Citizen Science Seed Funding Program, the Citizen Science for Earth Systems Program, and other NASA ROSES funding opportunities) for projects interested in using the Zooniverse platform.",
       "eighth": "If you have questions or require any further guidance, please contact Cliff Johnson, Zooniverse Science Lead and NASA Liaison: <0>cliff@zooniverse.org</0>.",
-      "nineth": "Over half a dozen organizations to date leverage Adler Zooniverse as an opportunity to fulfill their corporate social responsibility. Participation can fulfill service hour requirements for employees, graduation, scholarships, etc. A unique volunteer opportunity, participants take time to reflect on how their efforts (and the community’s collective efforts) are contributing to our understanding of our world and the broader universe. <0>Contact us</0> to learn more about this initiative."
+      "fifth": "If you are interested in partnering with us to create custom project tools or infrastructure, please <0>contact us</0>.",
+      "first": "Would your research benefit from the involvement of thousands of volunteers? The Zooniverse is the world’s largest and most successful online platform for crowdsourced research; we have millions of registered volunteers working in collaboration with professional researchers on research projects across a range of disciplines, from astronomy to the humanities.",
+      "fourth": "In cases where the tools available in the <0>Project Builder</0> aren’t quite right for the research goals of a particular team, researchers may want to consider partnering with the Zooniverse to create new, custom tools. We work with these teams to apply for funding to support the research, design, and development process. Those who have applied for grant funding before will know that this process can take a long time. Once we’ve applied for a grant, it can take 6 months or more to hear back about whether or not our efforts were successful. Funded projects typically require at least 6 months to design, build, and test, depending on the complexity of the features being created. We then need additional time to generalize (and often revise) them for inclusion in the Project Builder toolkit. ",
+      "nineth": "Over half a dozen organizations to date leverage Adler Zooniverse as an opportunity to fulfill their corporate social responsibility. Participation can fulfill service hour requirements for employees, graduation, scholarships, etc. A unique volunteer opportunity, participants take time to reflect on how their efforts (and the community’s collective efforts) are contributing to our understanding of our world and the broader universe. <0>Contact us</0> to learn more about this initiative.",
+      "second": "Research teams can build Zooniverse projects in two ways.",
+      "seventh": "Whether you are already building workflows using the Project Builder or you are just starting to consider how crowdsourced contributions could advance your research, the Zooniverse team has dedicated effort to support teams during development and implementation of NASA-focused projects. We are happy to discuss and support proposals to NASA citizen science funding calls (including the Citizen Science Seed Funding Program, the Citizen Science for Earth Systems Program, and other NASA ROSES funding opportunities) for projects interested in using the Zooniverse platform.",
+      "sixth": "Are you a researcher working on a project relevant to one of NASA’s Science Mission Directorate divisions (Astrophysics, Biological and Physical Sciences, Heliophysics, and the Planetary Science) who would benefit from contributions from Zooniverse volunteers? As part of an on-going partnership with NASA, the Zooniverse seeks to build on its current support of NASA research teams and encourage the development of new projects on our platform.",
+      "third": "Teams can use our free-to-use <0>Project Builder</0> tool to create their very own Zooniverse project. In order to launch publicly and be featured on our projects page, teams must go through our review process to ensure the project is appropriate for the platform and ready to be launched. This is the quickest and most straightforward option for creating a Zooniverse project. For more information on this process, including estimated timelines for review, please see our <1>Project Review Best Practices & Flowchart</1>. "
     },
     "subheadings": {
+      "fifth": "Corporate social responsibility opportunities",
       "first": "Collaborate with us",
-      "second": "Our supporters",
-      "third": "Selected collaborators",
       "fourth": "Call for projects",
-      "fifth": "Corporate social responsibility opportunities"
+      "second": "Our supporters",
+      "third": "Selected collaborators"
     },
     "title": "Collaborate"
   },
@@ -156,12 +156,17 @@
   },
   "Educate": {
     "articles": {
-      "heading": "How are Educators using the Zooniverse?",
       "first": {
         "datePublished": "October 28, 2022",
         "excerpt": "There is a critical need for research-based active learning instructional materials for the teaching and learning of STEM in online courses. Every year, hundreds of thousands of undergraduate non-science majors enroll in general education astronomy courses to fulfill their institution’s liberal arts requirements. When designing instructional materials for this population of learners, a central...",
         "title": "A New Curriculum Development Model for Improving Undergraduate Students’ Data Literacy and Self-Efficacy..."
       },
+      "fourth": {
+        "datePublished": "April 29, 2015",
+        "excerpt": "Today’s blog post comes from Fran Wilson, a second grade teacher at Madeira Elementary School. Fran strives to promote an interest in science in her classroom and help students discover that not all scientists work in labs wearing white lab coats and safety goggles. She seeks meaningful opportunities for her students to participate in citizen scientist work to be responsible...",
+        "title": "Floating Forests: Teaching Young Children About Kelp"
+      },
+      "heading": "How are Educators using the Zooniverse?",
       "second": {
         "datePublished": "August 14, 2019",
         "excerpt": "“Everyone try to grab the same galaxy,” a boy exclaimed while motioning to his classmates. Around the table, six students began dragging an image of a galaxy from the center of a large touch screen onto their own workstation. It’s very likely these students are the first people to set eyes upon this galaxy and decide how it should be classified...",
@@ -171,11 +176,6 @@
         "datePublished": "February 7, 2018",
         "excerpt": "As a social studies teacher, I hope for my students to develop an appreciation of the discipline of history itself. Rather than emphasizing memorization of dates and names – the kind of things that fall out of our memory as soon as we put them down on the test – my goals include exposing students to the intricacies of professional work done by historians. Recently, my 8th grade Ancient World...",
         "title": "8th graders in Missouri transcribe anti-slavery documents and learn about the abolitionist movement"
-      },
-      "fourth": {
-        "datePublished": "April 29, 2015",
-        "excerpt": "Today’s blog post comes from Fran Wilson, a second grade teacher at Madeira Elementary School. Fran strives to promote an interest in science in her classroom and help students discover that not all scientists work in labs wearing white lab coats and safety goggles. She seeks meaningful opportunities for her students to participate in citizen scientist work to be responsible...",
-        "title": "Floating Forests: Teaching Young Children About Kelp"
       }
     },
     "buttons": {
@@ -186,15 +186,15 @@
     "forEducators": {
       "classrooms": "Explore Zooniverse Classrooms",
       "heading": "Resources for Educators",
-      "subheadings": {
-        "first": "Group stats",
-        "second": "Project-specific educational opportunities",
-        "third": "Volunteer certificate"
-      },
       "paragraphs": {
         "first": "Set classification milestones, track effort, and celebrate collective impact. Read our <0>announcement</0> for more details.",
         "second": "Each project team can share additional educator resources including lesson plans, video tutorials, research links, and more. Be sure to check a project’s <0>Education</0> tab.",
         "third": "Support for students fulfilling student service hours for scholarships, graduation requirements, and more. See this <0>blog post</0> for details."
+      },
+      "subheadings": {
+        "first": "Group stats",
+        "second": "Project-specific educational opportunities",
+        "third": "Volunteer certificate"
       }
     },
     "introduction": "Are you an educator interested in using Zooniverse in the classroom? Great! Millions of people around the world participate in about 100 active projects, each with a supportive and welcoming discussion forum in which researchers engage with the public around the research and broader interests. The Zooniverse is a wonderful place for students.",
@@ -207,10 +207,13 @@
   },
   "FAQ": {
     "help": "Don't see the answer to your question? Visit the <0>Zooniverse Solutions webpage</0>, ask on <1>Zooniverse Talk</1>, or <2>contact us</2>.",
-    "title": "Frequently Asked Questions",
     "item0": {
       "answer": "Humans are better than computers at many tasks. For most Zooniverse projects, computers just aren’t good enough to do the required task, or they may miss interesting features that a human would spot - this is why we need your help. Some Zooniverse projects are also using human classifications to help train computers to do better at these research tasks in the future. When you participate in a Zooniverse project, you are contributing to real research.",
       "question": "Why do researchers need your help? Why can't computers do these tasks?"
+    },
+    "item10": {
+      "answer": "We support major browsers up to the second to last version.",
+      "question": "What browser version does Zooniverse support?"
     },
     "item1": {
       "answer": "For most of the subjects shown in Zooniverse projects, the researchers don't know the correct answer and that's why they need your help. Human beings are really good at pattern recognition tasks, so generally your first guess is likely the right one. Don’t worry too much about making an occasional mistake - more than one person will review each image, video or graph in a project. Most Zooniverse projects have a Help button, a Frequently Asked Questions (FAQ) page, and a Field Guide with more information to guide you when classifying.",
@@ -250,29 +253,17 @@
       "answer": "You can find more details on how to cite the Zooniverse in research publications using data derived from use of the Zooniverse Project Builder on our <0>Resources page</0>.",
       "question": "I'm a project owner/research team member, how do I acknowledge the Zooniverse and the Project Builder Platform in my paper, talk abstract, etc.?"
     },
-    "item10": {
-      "answer": "We support major browsers up to the second to last version.",
-      "question": "What browser version does Zooniverse support?"
-    }
+    "title": "Frequently Asked Questions"
   },
   "Home": {
     "Community": {
-      "heading": "The Zooniverse Community",
-      "subheading": "What's Happening?",
       "feedOne": "The Daily Zooniverse",
       "feedTwo": "The Zooniverse Blog",
-      "seeAll": "See all posts"
+      "heading": "The Zooniverse Community",
+      "seeAll": "See all posts",
+      "subheading": "What's Happening?"
     },
     "DefaultHome": {
-      "heroText": "Join millions of people who help to advance real research, science, and knowledge.",
-      "mainHeading": "People-powered research",
-      "projects": "Explore projects",
-      "headings": {
-        "first": "What is the Zooniverse?",
-        "second" : "Featured Projects",
-        "third": "Real researchers, real results",
-        "fourth": "Check out our mobile app"
-      },
       "FeaturedProjects": {
         "heading": "Featured Projects",
         "none": "No featured projects"
@@ -280,21 +271,35 @@
       "Introduction": {
         "description1": "The Zooniverse is the world's largest platform for people-powered research. We connect professional researchers with millions of volunteers worldwide. Facilitating real results from impractical, or otherwise impossible research. This has led to new discoveries, policy impacts, and research publications.",
         "description2": "Our platform is driven by volunteers, like you. All ages and backgrounds are welcome to participate, no PhD required — just a sense of wonder and a few clicks. Many of the most interesting findings from Zooniverse projects have emerged from discussions between volunteers and researchers. Join us today to take part in cutting-edge research and make your own discoveries!",
-        "signIn": "Sign in",
         "register": "Register",
+        "signIn": "Sign in",
         "video": "A Brief Introduction to the Zooniverse"
       },
       "Researchers": {
         "build": "Build a project",
         "description": "From classifying animals to discovering exoplanets to transcribing historical documents, and more, researchers across the disciplines have used the Project Builder to create engaging, accessible projects. Anyone can build a Zooniverse project. Simply upload your data, choose the tasks you want the volunteers to do, and join us in nurturing an inclusive and welcoming online community engaged in real research."
       },
+      "headings": {
+        "first": "What is the Zooniverse?",
+        "fourth": "Check out our mobile app",
+        "second": "Featured Projects",
+        "third": "Real researchers, real results"
+      },
+      "heroText": "Join millions of people who help to advance real research, science, and knowledge.",
+      "mainHeading": "People-powered research",
+      "projects": "Explore projects",
       "subheadings": {
         "first": "The wisdom of the crowd",
+        "fourth": "Discover, teach, and learn - anywhere",
         "second": "The Zooniverse works",
-        "third": "Meet the researchers who've created projects on the Zooniverse",
-        "fourth": "Discover, teach, and learn - anywhere"
+        "third": "Meet the researchers who've created projects on the Zooniverse"
       }
     }
+  },
+  "OurTeam": {
+    "description": "The people who make the Zooniverse.",
+    "sidebarLabel": "Institution",
+    "title": "Our Team"
   },
   "Projects": {
     "disciplines": {
@@ -315,20 +320,20 @@
       "label": "Filter projects by available translations"
     },
     "organizations": {
-      "heading": "Organizations",
       "description": "Organizations bring together multiple related Zooniverse projects, making it easier for participants to explore connected research efforts.",
+      "heading": "Organizations",
       "none": "No organizations found."
     },
     "projects": {
       "description": "<0>Welcome! We’re so glad you’re here.</0> Scroll down to browse all of our active projects, search for a specific project, or filter projects based on your interests. Have fun, and happy classifying! ",
-      "error": "There was an error fetching projects.",
-      "heading": "All projects",
-      "none": "No projects found",
-      "showingNum": "{{range}} of {{total}} projects",
       "empty": {
         "clear": "Reset Filters",
         "status": "Sometimes a project will temporarily be out of data, or may have finished! Try searching <0>Any Project Status</0>"
-      }
+      },
+      "error": "There was an error fetching projects.",
+      "heading": "All projects",
+      "none": "No projects found",
+      "showingNum": "{{range}} of {{total}} projects"
     },
     "search": {
       "placeholder": "Search projects",
@@ -336,26 +341,26 @@
     },
     "sortBy": {
       "label": "Sort By",
-      "newest": "Newest",
-      "oldest": "Oldest",
+      "mostActive": "Most Active",
+      "mostPopular": "Most Popular",
       "nameAZ": "Name A - Z",
       "nameZA": "Name Z - A",
-      "mostActive": "Most Active",
-      "mostPopular": "Most Popular"
+      "newest": "Newest",
+      "oldest": "Oldest"
     },
     "status": {
-      "all": "All",
-      "label": "Filter projects by status",
       "active": "Active",
-      "paused": "Paused",
-      "finished": "Finished"
+      "all": "Any Status",
+      "finished": "Finished",
+      "label": "Filter projects by status",
+      "paused": "Paused"
     }
   },
   "Publications": {
     "description": "A list of academic publications that use Zooniverse-generated data.",
     "formInfo": "We aim to post links to published papers that can be accessed by the public. Articles accepted for publication but not yet published are also fine.",
-    "formLabel": "please use this form",
     "formInstruction": "To submit a new publication or update an existing one, ",
+    "formLabel": "please use this form",
     "sidebarLabel": "Discipline",
     "title": "Publications"
   },
@@ -364,20 +369,20 @@
       "heading": "Brand Resources",
       "links": {
         "first": "Download official Zooniverse logos",
+        "fourth": "Storybook - Our coded components used on the site",
         "second": "Download printable handouts, presentation templates, and project images",
-        "third": "Zooniverse Design System - Our styles, brand colors, and typography rules",
-        "fourth": "Storybook - Our coded components used on the site"
+        "third": "Zooniverse Design System - Our styles, brand colors, and typography rules"
       }
     },
     "cite": {
       "heading": "How to Cite the Zooniverse",
       "paragraphs": {
-        "first": "Per the <0>Zooniverse Project Builder Policies</0>, all research publications using data derived from Zooniverse projects are asked to acknowledge the Zooniverse and the Project Builder platform using the following text:",
-        "second": "We strongly encourage project owners to report accepted and published research publications using Zooniverse-produced data to us by filling out <0>this form</0>. You can find a current list of publications resulting from Zooniverse projects and related research on our <1>Publications page</1>.",
-        "third": "If you have any questions about how to acknowledge the Zooniverse, such as referencing a particular individual or custom code, please <0>contact us</0>.",
-        "fourth": "When writing about specific Zooniverse projects in the press, please include a link or URL to the project, in print as well as digital editions.",
         "fifth": "When writing about the Zooniverse in general, please include a link or URL to the Zooniverse home page somewhere in your article.",
-        "sixth": "If you are interested in interviewing a member of the Zooniverse team, please <0>contact us</0>."
+        "first": "Per the <0>Zooniverse Project Builder Policies</0>, all research publications using data derived from Zooniverse projects are asked to acknowledge the Zooniverse and the Project Builder platform using the following text:",
+        "fourth": "When writing about specific Zooniverse projects in the press, please include a link or URL to the project, in print as well as digital editions.",
+        "second": "We strongly encourage project owners to report accepted and published research publications using Zooniverse-produced data to us by filling out <0>this form</0>. You can find a current list of publications resulting from Zooniverse projects and related research on our <1>Publications page</1>.",
+        "sixth": "If you are interested in interviewing a member of the Zooniverse team, please <0>contact us</0>.",
+        "third": "If you have any questions about how to acknowledge the Zooniverse, such as referencing a particular individual or custom code, please <0>contact us</0>."
       },
       "quote": "This publication uses data generated via the <0>Zooniverse.org</0> platform, development of which is funded by generous support, including a Global Impact Award from Google, and by a grant from the Alfred P. Sloan Foundation.",
       "subheadings": {
@@ -389,11 +394,6 @@
   },
   "Sidebar": {
     "all": "All"
-  },
-  "OurTeam": {
-    "description": "The people who make the Zooniverse.",
-    "sidebarLabel": "Institution",
-    "title": "Our Team"
   },
   "Volunteer": {
     "beta": {
@@ -427,11 +427,11 @@
       "button": "Register Today",
       "heading": "The Benefits of Registration with the Zooniverse",
       "paragraphs": {
+        "fifth": "Translated versions of the registration page are available in <0>Spanish</0> and <1>French</1>. Please note that not all elements on a page may be translated.",
         "first": "Track your classifications, hours, and more. Discover your favorite projects and observe trends. Then, export your data for even more options.",
-        "second": "Generate an official certificate verifying your efforts on the Zooniverse platform. Simply specify a time period or project.",
-        "third": "Registered users are able to post on project-specific and Zooniverse-wide Talk boards giving you the ability to ask questions to real experts.",
         "fourth": "For those under 16 years old, a parent/guardian needs to sign off on their registration. <0>https://www.zooniverse.org/accounts/register</0> is the direct link to register.",
-        "fifth": "Translated versions of the registration page are available in <0>Spanish</0> and <1>French</1>. Please note that not all elements on a page may be translated."
+        "second": "Generate an official certificate verifying your efforts on the Zooniverse platform. Simply specify a time period or project.",
+        "third": "Registered users are able to post on project-specific and Zooniverse-wide Talk boards giving you the ability to ask questions to real experts."
       },
       "subheadings": {
         "first": "Personal stats",

--- a/packages/lib-content/src/translations/test.json
+++ b/packages/lib-content/src/translations/test.json
@@ -29,14 +29,14 @@
     "contact": {
       "categories": {
         "first": "Translated",
-        "third": "Translated",
-        "second": "Translated"
+        "second": "Translated",
+        "third": "Translated"
       },
       "heading": "Translated",
       "paragraphs": {
         "first": "Translated <0>Translated</0> <1>Translated</1>",
-        "third": "Translated <0>Translated</0>",
-        "second": "Translated"
+        "second": "Translated",
+        "third": "Translated <0>Translated</0>"
       },
       "subheading": "Translated"
     },
@@ -49,8 +49,8 @@
       },
       "pictures": {
         "first": "Translated",
-        "third": "Translated",
-        "second": "Translated"
+        "second": "Translated",
+        "third": "Translated"
       },
       "sidebar": "Translated",
       "subheading": "Translated",
@@ -62,20 +62,20 @@
         "description": "Translated",
         "link": "Translated",
         "steps": {
-          "fourth": "Translated",
           "first": "Translated",
-          "third": "Translated",
-          "second": "Translated"
+          "fourth": "Translated",
+          "second": "Translated",
+          "third": "Translated"
         }
       },
       "researchers": {
         "description": "Translated",
         "link": "Translated",
         "steps": {
-          "fourth": "Translated",
           "first": "Translated",
-          "third": "Translated",
-          "second": "Translated"
+          "fourth": "Translated",
+          "second": "Translated",
+          "third": "Translated"
         }
       },
       "subheading": "Translated"
@@ -91,29 +91,29 @@
     },
     "ourMission": {
       "discoveries": {
-        "fourth": "Translated",
         "first": "Translated",
+        "fourth": "Translated",
+        "second": "Translated",
         "third": "Translated",
-        "tip": "Translated",
-        "second": "Translated"
+        "tip": "Translated"
       },
       "heading": "Translated",
       "paragraphs": {
-        "fourth": "Translated <0>Translated</0>",
         "first": "Translated <0>Translated</0>",
-        "third": "Translated <0>Translated</0>",
-        "second": "Translated <0>Translated</0>"
+        "fourth": "Translated <0>Translated</0>",
+        "second": "Translated <0>Translated</0>",
+        "third": "Translated <0>Translated</0>"
       },
       "stats": {
-        "first": "Translated",
-        "second": "Translated"
+        "classifications": "Translated",
+        "volunteers": "Translated"
       },
       "subheadings": {
         "fifth": "Translated",
-        "fourth": "Translated",
         "first": "Translated",
-        "third": "Translated",
-        "second": "Translated"
+        "fourth": "Translated",
+        "second": "Translated",
+        "third": "Translated"
       },
       "video": "Translated"
     },
@@ -127,20 +127,20 @@
     "paragraphs": {
       "eighth": "Translated <0>Translated</0>",
       "fifth": "Translated <0>Translated</0>",
+      "first": "Translated",
       "fourth": "Translated",
       "nineth": "Translated <0>Translated</0>",
-      "first": "Translated",
+      "second": "Translated",
       "seventh": "Translated",
       "sixth": "Translated",
-      "third": "Translated <0>Translated</0> <1>Translated</1>",
-      "second": "Translated"
+      "third": "Translated <0>Translated</0> <1>Translated</1>"
     },
     "subheadings": {
       "fifth": "Translated",
-      "fourth": "Translated",
       "first": "Translated",
-      "third": "Translated",
-      "second": "Translated"
+      "fourth": "Translated",
+      "second": "Translated",
+      "third": "Translated"
     },
     "title": "Translated"
   },
@@ -148,22 +148,27 @@
     "button": "Translated",
     "paragraphs": {
       "first": "Translated",
-      "third": "Translated",
-      "second": "Translated"
+      "second": "Translated",
+      "third": "Translated"
     },
     "subheading": "Translated",
     "title": "Translated"
   },
   "Educate": {
     "articles": {
+      "first": {
+        "datePublished": "Translated 28, 2022",
+        "excerpt": "Translated",
+        "title": "Translated"
+      },
       "fourth": {
         "datePublished": "April 29, 2015",
         "excerpt": "Translated",
         "title": "Translated"
       },
       "heading": "Translated",
-      "first": {
-        "datePublished": "Translated 28, 2022",
+      "second": {
+        "datePublished": "Translated 14, 2019",
         "excerpt": "Translated",
         "title": "Translated"
       },
@@ -171,30 +176,25 @@
         "datePublished": "Translated 7, 2018",
         "excerpt": "Translated",
         "title": "Translated"
-      },
-      "second": {
-        "datePublished": "Translated 14, 2019",
-        "excerpt": "Translated",
-        "title": "Translated"
       }
     },
     "buttons": {
       "first": "Translated",
-      "third": "Translated",
-      "second": "Translated"
+      "second": "Translated",
+      "third": "Translated"
     },
     "forEducators": {
       "classrooms": "Translated",
       "heading": "Translated",
       "paragraphs": {
         "first": "Translated <0>Translated</0>",
-        "third": "Translated <0>Translated</0>",
-        "second": "Translated <0>Translated</0>"
+        "second": "Translated <0>Translated</0>",
+        "third": "Translated <0>Translated</0>"
       },
       "subheadings": {
         "first": "Translated",
-        "third": "Translated",
-        "second": "Translated"
+        "second": "Translated",
+        "third": "Translated"
       }
     },
     "introduction": "Translated",
@@ -280,19 +280,19 @@
         "description": "Translated"
       },
       "headings": {
-        "fourth": "Translated",
         "first": "Translated",
-        "third": "Translated",
-        "second": "Translated"
+        "fourth": "Translated",
+        "second": "Translated",
+        "third": "Translated"
       },
       "heroText": "Translated",
       "mainHeading": "Translated",
       "projects": "Translated",
       "subheadings": {
-        "fourth": "Translated",
         "first": "Translated",
-        "third": "Translated",
-        "second": "Translated"
+        "fourth": "Translated",
+        "second": "Translated",
+        "third": "Translated"
       }
     }
   },
@@ -300,6 +300,61 @@
     "description": "Translated",
     "sidebarLabel": "Translated",
     "title": "Translated"
+  },
+  "Projects": {
+    "disciplines": {
+      "all": "Translated",
+      "arts": "Translated",
+      "biology": "Translated",
+      "climate": "Translated",
+      "history": "Translated",
+      "language": "Translated",
+      "literature": "Translated",
+      "medicine": "Translated",
+      "nature": "Translated",
+      "physics": "Translated",
+      "social": "Translated",
+      "space": "Translated"
+    },
+    "languages": {
+      "label": "Translated"
+    },
+    "organizations": {
+      "description": "Translated",
+      "heading": "Translated",
+      "none": "Translated"
+    },
+    "projects": {
+      "description": "<0>Translated</0> Translated",
+      "empty": {
+        "clear": "Translated",
+        "status": "Translated <0>Translated</0>"
+      },
+      "error": "Translated",
+      "heading": "Translated",
+      "none": "Translated",
+      "showingNum": "{{range}} Translated {{total}} Translated"
+    },
+    "search": {
+      "placeholder": "Translated",
+      "warning": "Translated"
+    },
+    "sortBy": {
+      "label": "Translated",
+      "mostActive": "Translated",
+      "mostPopular": "Translated",
+      "nameAZ": "Translated",
+      "nameZA": "Translated",
+      "newest": "Translated",
+      "oldest": "Translated"
+    },
+    "status": {
+      "active": "Translated",
+      "all": "Translated",
+      "finished": "Translated",
+      "label": "Translated",
+      "paused": "Translated"
+    }
   },
   "Publications": {
     "description": "Translated",
@@ -313,21 +368,21 @@
     "brand": {
       "heading": "Translated",
       "links": {
-        "fourth": "Translated",
         "first": "Translated",
-        "third": "Translated",
-        "second": "Translated"
+        "fourth": "Translated",
+        "second": "Translated",
+        "third": "Translated"
       }
     },
     "cite": {
       "heading": "Translated",
       "paragraphs": {
         "fifth": "Translated",
-        "fourth": "Translated",
         "first": "Translated <0>Translated</0>",
+        "fourth": "Translated",
+        "second": "Translated <0>Translated</0> <1>Translated</1>",
         "sixth": "Translated <0>Translated</0>",
-        "third": "Translated <0>Translated</0>",
-        "second": "Translated <0>Translated</0> <1>Translated</1>"
+        "third": "Translated <0>Translated</0>"
       },
       "quote": "Translated <0>Translated</0>",
       "subheadings": {
@@ -346,8 +401,8 @@
       "heading": "Translated",
       "paragraphs": {
         "first": "Translated",
-        "third": "Translated <0>Translated</0>",
-        "second": "Translated <0>Translated</0>"
+        "second": "Translated <0>Translated</0>",
+        "third": "Translated <0>Translated</0>"
       }
     },
     "classify": {
@@ -373,15 +428,15 @@
       "heading": "Translated",
       "paragraphs": {
         "fifth": "Translated <0>Translated</0> <1>Translated</1>",
-        "fourth": "Translated <0>https://www.zooniverse.org/accounts/register</0>",
         "first": "Translated",
-        "third": "Translated",
-        "second": "Translated"
+        "fourth": "Translated <0>https://www.zooniverse.org/accounts/register</0>",
+        "second": "Translated",
+        "third": "Translated"
       },
       "subheadings": {
         "first": "Translated",
-        "third": "Translated",
-        "second": "Translated"
+        "second": "Translated",
+        "third": "Translated"
       }
     },
     "title": "Translated"


### PR DESCRIPTION
Re-organizes the English dictionary and Test Language dictionary alphabetically via Lokalise export.

Replaces `Projects.status.all` with "Any Status".

Closes: https://github.com/zooniverse/front-end-monorepo/issues/7257