### PR TITLE
lib-content: Move Microsoft logo to the supporters section on Collaborate

### DIFF
--- a/packages/lib-content/src/screens/Collaborate/Logos.jsx
+++ b/packages/lib-content/src/screens/Collaborate/Logos.jsx
@@ -57,24 +57,22 @@ export function Supporters() {
           alt='National Science Foundation'
         />
         <LogoImage
+          src='https://static.zooniverse.org/fem-assets/collaborate/microsoft.jpg'
+          alt='Microsoft'
+        />
+        <LogoImage
           src='https://static.zooniverse.org/fem-assets/collaborate/neh.jpeg'
           alt='National Endowment for the Humanities'
         />
+        <LogoImage
+          src='https://static.zooniverse.org/fem-assets/collaborate/simons.jpg'
+          alt='Simons Foundation'
+        />
+        <LogoImage
+          src='https://static.zooniverse.org/fem-assets/collaborate/noaa.png'
+          alt='National Oceanic and Atmospheric Administration (NOAA)'
+        />
       </Grid>
-      <Box direction='row' justify='center' gap='40px'>
-        <Box width='28%'>
-          <LogoImage
-            src='https://static.zooniverse.org/fem-assets/collaborate/noaa.png'
-            alt='National Oceanic and Atmospheric Administration (NOAA)'
-          />
-        </Box>
-        <Box width='28%'>
-          <LogoImage
-            src='https://static.zooniverse.org/fem-assets/collaborate/simons.jpg'
-            alt='Simons Foundation'
-          />
-        </Box>
-      </Box>
     </Box>
   )
 }
@@ -194,28 +192,22 @@ export function SelectedTools() {
             alt='BrowserStack'
           />
         </Anchor>
+        <Anchor href='https://github.com'>
+          <LogoImage
+            src='https://static.zooniverse.org/fem-assets/collaborate/github.png'
+            alt='Github'
+          />
+        </Anchor>
         <Anchor href='https://newrelic.com'>
           <LogoImage
             src='https://static.zooniverse.org/fem-assets/collaborate/new-relic.png'
             alt='NewRelic'
           />
         </Anchor>
-        <Anchor href='https://www.microsoft.com'>
-          <LogoImage
-            src='https://static.zooniverse.org/fem-assets/collaborate/microsoft.jpg'
-            alt='Microsoft'
-          />
-        </Anchor>
         <Anchor href='https://sentry.io'>
           <LogoImage
             src='https://static.zooniverse.org/fem-assets/collaborate/sentry.png'
             alt='Sentry'
-          />
-        </Anchor>
-        <Anchor href='https://github.com'>
-          <LogoImage
-            src='https://static.zooniverse.org/fem-assets/collaborate/github.png'
-            alt='Github'
           />
         </Anchor>
       </Grid>


### PR DESCRIPTION
## Package
lib-content

## Linked Issue and/or Talk Post
Follows https://github.com/zooniverse/front-end-monorepo/pull/7280

## Describe your changes
- Move Microsoft logo to the Supporters section on the Collaborate page

# Checklist

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)