### PR TITLE
SubjectTalkViewer: fix audio+image subject display on Talk page (#7315)

### DIFF
--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkViewer/SubjectTalkViewer.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkViewer/SubjectTalkViewer.jsx
@@ -19,15 +19,19 @@ const StyledMedia = styled(Media)`
 `
 
 function processSubjectLocations(rawLocations) {
-  return rawLocations.map(location => {
-    const [mimeType, url] = Object.entries(location)[0];
-    const [type] = mimeType.split('/');
-    return {
-      mimeType: mimeType,
-      type: type,
-      url: url
-    }
+  const locations = []
+  let firstImageIndex = -1
+  let audioUrl = null
+
+  rawLocations.forEach((location, index) => {
+    const [mimeType, url] = Object.entries(location)[0]
+    const [type] = mimeType.split('/')
+    locations.push({ mimeType, type, url })
+    if (type === 'image' && firstImageIndex === -1) firstImageIndex = index
+    if (type === 'audio') audioUrl = url
   })
+
+  return { locations, firstImageIndex, audioUrl }
 }
 
 function SubjectTalkViewer({
@@ -37,22 +41,18 @@ function SubjectTalkViewer({
     subject,
     userId
   }) {
-  const [frame, setFrame] = useState(0)
-  const [flipbookSpeed, setFlipbookSpeed] = useState(1)
+  const { locations, firstImageIndex, audioUrl } = processSubjectLocations(subject?.locations)
+  const defaultFrame = firstImageIndex >= 0 ? firstImageIndex : 0
+
+  const [frame, setFrame] = useState(defaultFrame)
   const [invert, setInvert] = useState(false)
-  const [playing, setPlaying] = useState(false)
 
   const { t } = useTranslation('screens')
-  
+
   const subjectId = subject?.id
-  const processedLocations = processSubjectLocations(subject?.locations)
 
   function onInvert() {
     setInvert(!invert)
-  }
-
-  function onPlayPause() {
-    setPlaying(!playing)
   }
 
   return (
@@ -88,19 +88,20 @@ function SubjectTalkViewer({
           />
         }
         subject={subject}
-        src={processedLocations?.[frame]?.url}
+        src={locations?.[frame]?.url}
       />
       <Box flex={false}>
-        {subject?.locations?.length > 1 ? (
-          <FlipbookControls
-            currentFrame={frame}
-            flipbookSpeed={flipbookSpeed}
-            locations={processedLocations}
+        {audioUrl ? (
+          <Box pad='xsmall'>
+            <audio controls preload='metadata' src={audioUrl} style={{ width: '100%' }}>
+              <track kind='captions' />
+            </audio>
+          </Box>
+        ) : locations.length > 1 ? (
+          <FlipbookControlsWrapper
+            locations={locations}
+            frame={frame}
             onFrameChange={setFrame}
-            onPlayPause={onPlayPause}
-            playing={playing}
-            playIterations={1}
-            setFlipbookSpeed={setFlipbookSpeed}
           />
         ) : null}
         <MetaTools
@@ -115,6 +116,25 @@ function SubjectTalkViewer({
         />
       </Box>
     </Box>
+  )
+}
+
+/** Isolates flipbook playback state from SubjectTalkViewer */
+function FlipbookControlsWrapper({ locations, frame, onFrameChange }) {
+  const [flipbookSpeed, setFlipbookSpeed] = useState(1)
+  const [playing, setPlaying] = useState(false)
+
+  return (
+    <FlipbookControls
+      currentFrame={frame}
+      flipbookSpeed={flipbookSpeed}
+      locations={locations}
+      onFrameChange={onFrameChange}
+      onPlayPause={() => setPlaying(p => !p)}
+      playing={playing}
+      playIterations={1}
+      setFlipbookSpeed={setFlipbookSpeed}
+    />
   )
 }
 

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkViewer/SubjectTalkViewer.spec.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkViewer/SubjectTalkViewer.spec.jsx
@@ -2,7 +2,8 @@ import { render, screen } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
 import Meta, {
   SingleImageSubject,
-  MultiImageSubject
+  MultiImageSubject,
+  AudioSpectrogramSubject
 } from './SubjectTalkViewer.stories'
 import { vi } from 'vitest'
 
@@ -13,6 +14,7 @@ import { vi } from 'vitest'
 
 const SingleImageSubjectStory = composeStory(SingleImageSubject, Meta)
 const MultiImageSubjectStory = composeStory(MultiImageSubject, Meta)
+const AudioSpectrogramSubjectStory = composeStory(AudioSpectrogramSubject, Meta)
 
 describe('Component > SubjectTalkPage > SubjectTalkViewer', function () {
   describe('with a single image subject', function () {
@@ -43,6 +45,37 @@ describe('Component > SubjectTalkPage > SubjectTalkViewer', function () {
 
       const imageThumbnails = screen.getByLabelText('Image thumbnails')
       expect(imageThumbnails).toBeDefined()
+    })
+  })
+
+  describe('with an audio+image (spectrogram) subject', function () {
+    it('should render without crashing', async function () {
+      const output = render(<AudioSpectrogramSubjectStory />)
+      await vi.dynamicImportSettled()
+      expect(output).toBeTruthy()
+    })
+
+    it('should not render flipbook controls', async function () {
+      render(<AudioSpectrogramSubjectStory />)
+      await vi.dynamicImportSettled()
+      const imageThumbnails = screen.queryByLabelText('Image thumbnails')
+      expect(imageThumbnails).to.equal(null)
+    })
+
+    it('should render native audio controls', async function () {
+      const { container } = render(<AudioSpectrogramSubjectStory />)
+      await vi.dynamicImportSettled()
+      const audio = container.querySelector('audio')
+      expect(audio).toBeDefined()
+      expect(audio.hasAttribute('controls')).to.equal(true)
+    })
+
+    it('should render the audio source from the subject', async function () {
+      const { container } = render(<AudioSpectrogramSubjectStory />)
+      await vi.dynamicImportSettled()
+      const audio = container.querySelector('audio')
+      expect(audio).toBeDefined()
+      expect(audio.src).toContain('panoptes-uploads.zooniverse.org')
     })
   })
 })

--- a/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkViewer/SubjectTalkViewer.stories.jsx
+++ b/packages/app-project/src/screens/SubjectTalkPage/components/SubjectTalkViewer/SubjectTalkViewer.stories.jsx
@@ -38,6 +38,20 @@ const VideoSubjectMock = {
   ],
 }
 
+const AudioSpectrogramSubjectMock = {
+  id: '112321080',
+  locations: [
+    {
+      'audio/mpeg':
+        'https://panoptes-uploads.zooniverse.org/subject_location/8ae1583c-008f-4c4d-9697-efd3257626ec.mpga'
+    },
+    {
+      'image/png':
+        'https://panoptes-uploads.zooniverse.org/subject_location/3ae42d57-b01d-4ee1-820e-d3c7904de42d.png'
+    }
+  ]
+}
+
 export default {
   title: 'Project App / Screens / Subject Talk / SubjectTalkViewer',
   component: SubjectTalkViewer
@@ -61,6 +75,13 @@ export const VideoSubject = {
   args: {
     login: 'zootester1',
     subject: VideoSubjectMock
+  }
+}
+
+export const AudioSpectrogramSubject = {
+  args: {
+    login: 'zootester1',
+    subject: AudioSpectrogramSubjectMock
   }
 }
 


### PR DESCRIPTION
## Package
- app-project

## Linked Issue and/or Talk Post
- Closes #7315
- Related: #7304 (Audio + Spectrogram Subject Viewer)

## Describe your changes
- `processSubjectLocations` now returns `firstImageIndex` and `audioUrl` alongside the locations array in a single pass
- Default `frame` to the first image location instead of `0`, so audio+image subjects show the spectrogram on load
- For subjects with an audio location, render native `<audio controls>` below the spectrogram instead of FlipbookControls (frame cycling between audio placeholder and spectrogram is not useful)
- Extract `FlipbookControlsWrapper` to colocate flipbook playback state (`playing`, `flipbookSpeed`) with the component that uses it
- Add `AudioSpectrogramSubject` story and 4 unit tests

## How to Review
- What Zooniverse project should my reviewer use to review UX?
  - [Chirp Check](https://www.zooniverse.org/projects/hannah-dot-slesinski/chirp-check/) — a project with AudioSpectrogramSubjects (1 audio + 1 image)
- What user actions should my reviewer step through to review this PR?
  1. Set up app-project locally
  2. Navigate to a Chirp Check Talk page: https://local.zooniverse.org:3000/projects/hannah-dot-slesinski/chirp-check/talk/subjects/112321080?env=production
  3. Confirm the spectrogram image is displayed (not the audio placeholder with headphone icon)
  4. Confirm native audio controls appear below the spectrogram with play, scrubber, and volume
  5. Confirm flipbook controls do NOT appear for this subject type
  6. Navigate to a multi-image subject Talk page and confirm FlipbookControls still work normally
- Which storybook stories should be reviewed?
  - Project App / Screens / Subject Talk / SubjectTalkViewer - AudioSpectrogramSubject: http://localhost:9001/?path=/story/project-app-screens-subject-talk-subjecttalkviewer--audio-spectrogram-subject
- Are there plans for follow up PR's to further fix this bug or develop this feature?
  - No immediate follow-ups. The custom audio toolbar from `feat-7211-audio-subject-viewer-design` may eventually replace the native `<audio controls>` here as well.

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated