### PR TITLE
Finalize MachineLearnt reductions

### DIFF
--- a/packages/lib-classifier/src/hooks/useMachineLearntReductions.js
+++ b/packages/lib-classifier/src/hooks/useMachineLearntReductions.js
@@ -33,13 +33,11 @@ export default function useMachineLearntReductions() {
     
     if (caesarMarks) {
       caesarMarks.forEach(caesarMark => {
-        const { stepKey, taskKey, taskType, toolType, taskIndex, toolIndex, ...newMark } = caesarMark
+        const { stepKey, taskKey, taskIndex, taskType, toolIndex, toolType, ...newMark } = caesarMark
         newMark.id = newMark.markId;
         delete newMark.markId;
 
-        const resolvedTaskIndex = taskIndex ?? 0
-        const resolvedToolIndex = toolIndex ?? 0
-        step?.tasks[resolvedTaskIndex]?.tools[resolvedToolIndex]?.createMark(newMark)
+        step?.tasks[taskIndex]?.tools[toolIndex]?.createMark(newMark)
       })
     }
 

--- a/packages/lib-classifier/src/hooks/useMachineLearntReductions.js
+++ b/packages/lib-classifier/src/hooks/useMachineLearntReductions.js
@@ -33,12 +33,13 @@ export default function useMachineLearntReductions() {
     
     if (caesarMarks) {
       caesarMarks.forEach(caesarMark => {
-        const { stepKey, taskIndex, taskKey, taskType, toolType, ...newMark } = caesarMark
+        const { stepKey, taskKey, taskType, toolType, taskIndex, toolIndex, ...newMark } = caesarMark
         newMark.id = newMark.markId;
         delete newMark.markId;
 
-        // we only get access to one task at a time in a step
-        step?.tasks[0].tools[newMark.toolIndex]?.createMark(newMark)
+        const resolvedTaskIndex = taskIndex ?? 0
+        const resolvedToolIndex = toolIndex ?? 0
+        step?.tasks[resolvedTaskIndex]?.tools[resolvedToolIndex]?.createMark(newMark)
       })
     }
 

--- a/packages/lib-classifier/src/hooks/useMachineLearntReductions.js
+++ b/packages/lib-classifier/src/hooks/useMachineLearntReductions.js
@@ -22,13 +22,14 @@ export default function useMachineLearntReductions() {
   if (loaded
     && getType(caesarReductions).name === 'MachineLearntReductions'
     && activeSubject.caesarReductionsLoadedForStep[stepIndex] !== true) {
-    
+
     // step.tasks is only the CURRENT TASK
     // Test project with 3 steps means we need to run this 3 times to check for reductions on each step
     // This is likely due to the potentially recursive nature of step navigation
 
     const caesarMarks = caesarReductions.findCurrentTaskMarks({
-      stepKey: step.stepKey
+      stepKey: step.stepKey,
+      workflow
     })
     
     if (caesarMarks) {

--- a/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.js
@@ -23,8 +23,14 @@ const MachineLearntReductions = types
           let { data } = reduction.data   // Caesar expects data attribute to be an object
 
           data.forEach(datum => {
-            if (datum.stepKey === stepKey) {
-              caesarMarks.push(datum)
+            const mark = {
+              stepKey: 'S0',
+              taskIndex: 0,
+              toolIndex: 0,
+              ...datum
+            }
+            if (mark.stepKey === stepKey) {
+              caesarMarks.push(mark)
             }
           })
         })

--- a/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.js
@@ -24,10 +24,10 @@ const MachineLearntReductions = types
 
           data.forEach(datum => {
             const mark = {
-              stepKey: 'S0',
-              taskIndex: 0,
-              toolIndex: 0,
-              ...datum
+              ...datum,
+              stepKey: datum.stepKey ?? 'S0',
+              taskIndex: datum.taskIndex ?? 0,
+              toolIndex: datum.toolIndex ?? 0,
             }
             if (mark.stepKey === stepKey) {
               caesarMarks.push(mark)

--- a/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.js
@@ -12,7 +12,7 @@ const MachineLearntReductions = types
   })
   .views(self => {
     return {
-      findCurrentTaskMarks({ stepKey }) {
+      findCurrentTaskMarks({ stepKey, workflow }) {
         if (stepKey === undefined) {
           return
         }
@@ -25,7 +25,8 @@ const MachineLearntReductions = types
           data.forEach(datum => {
             const mark = {
               ...datum,
-              stepKey: datum.stepKey ?? 'S0',
+              // Stepless Caesar data attaches to the workflow's first step. See PR #7319.
+              stepKey: datum.stepKey ?? workflow?.steps?.[0]?.[0],
               taskIndex: datum.taskIndex ?? 0,
               toolIndex: datum.toolIndex ?? 0,
             }

--- a/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.spec.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.spec.js
@@ -1,4 +1,4 @@
-import { reducedSubjectMocks } from './reducedSubjectMocks'
+import { reducedSubjectMocks, multiIndexMock, minimalKeysMocks } from './reducedSubjectMocks'
 import MachineLearntReductions from './MachineLearntReductions'
 
 let reductionsTaskStub = {
@@ -40,13 +40,76 @@ describe('Models > MachineLearntReductions', () => {
         reductionsModel.reductions.forEach(reduction => {
           expect(reduction.data.data[0].markId).to.equal(reducedSubject.markId)
         })
-        expect(Object.keys(reductionsModel.findCurrentTaskMarks(reductionsTaskStub)[0]).length).to.be.above(0)
+        expect(Object.keys(reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })[0]).length).to.be.above(0)
       })
 
       it('should have array of x and y values', () => {
-        let caesarMarks = reductionsModel.findCurrentTaskMarks(reductionsTaskStub)
-        expect(caesarMarks[0]).to.deep.equal(reducedSubject)
+        let caesarMarks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+        expect(caesarMarks[0]).to.deep.include(reducedSubject)
       })
+    })
+  })
+
+  describe('multi-index marks', () => {
+    let reductionsModel
+
+    before(() => {
+      reductionsModel = MachineLearntReductions.create({
+        reducer: 'machineLearnt',
+        subjectId: '174701',
+        workflowId: '3691',
+        reductions: [{ data: { data: [multiIndexMock] } }]
+      })
+    })
+
+    it('should return marks for the matching stepKey', () => {
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S1' })
+      expect(marks).to.have.lengthOf(1)
+      expect(marks[0].markId).to.equal('multiIdx1')
+      expect(marks[0].taskIndex).to.equal(1)
+      expect(marks[0].toolIndex).to.equal(2)
+    })
+
+    it('should not return marks for a non-matching stepKey', () => {
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+      expect(marks).to.have.lengthOf(0)
+    })
+  })
+
+  describe('default values for missing keys', () => {
+    let reductionsModel
+
+    before(() => {
+      reductionsModel = MachineLearntReductions.create({
+        reducer: 'machineLearnt',
+        subjectId: '174701',
+        workflowId: '3691',
+        reductions: [{ data: { data: minimalKeysMocks } }]
+      })
+    })
+
+    it('should default stepKey to S0 when absent', () => {
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+      expect(marks).to.have.lengthOf(2)
+    })
+
+    it('should default taskIndex to 0 when absent', () => {
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+      marks.forEach(mark => {
+        expect(mark.taskIndex).to.equal(0)
+      })
+    })
+
+    it('should default toolIndex to 0 when absent', () => {
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+      marks.forEach(mark => {
+        expect(mark.toolIndex).to.equal(0)
+      })
+    })
+
+    it('should not return minimal marks for a non-default stepKey', () => {
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S1' })
+      expect(marks).to.have.lengthOf(0)
     })
   })
 })

--- a/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.spec.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.spec.js
@@ -15,6 +15,9 @@ let reductionsTaskStub = {
   frame: 0,
 }
 
+const workflowS0 = { steps: [['S0', {}]] }
+const workflowP0 = { steps: [['P0', {}]] }
+
 describe('Models > MachineLearntReductions', () => {
   reducedSubjectMocks.forEach(reducedSubject => {
     describe(`ToolType: ${reducedSubject.toolType}`, () => {
@@ -40,11 +43,11 @@ describe('Models > MachineLearntReductions', () => {
         reductionsModel.reductions.forEach(reduction => {
           expect(reduction.data.data[0].markId).to.equal(reducedSubject.markId)
         })
-        expect(Object.keys(reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })[0]).length).to.be.above(0)
+        expect(Object.keys(reductionsModel.findCurrentTaskMarks({ stepKey: 'S0', workflow: workflowS0 })[0]).length).to.be.above(0)
       })
 
       it('should have array of x and y values', () => {
-        let caesarMarks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+        let caesarMarks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0', workflow: workflowS0 })
         expect(caesarMarks[0]).to.deep.include(reducedSubject)
       })
     })
@@ -63,7 +66,7 @@ describe('Models > MachineLearntReductions', () => {
     })
 
     it('should return marks for the matching stepKey', () => {
-      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S1' })
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S1', workflow: workflowS0 })
       expect(marks).to.have.lengthOf(1)
       expect(marks[0].markId).to.equal('multiIdx1')
       expect(marks[0].taskIndex).to.equal(1)
@@ -71,7 +74,7 @@ describe('Models > MachineLearntReductions', () => {
     })
 
     it('should not return marks for a non-matching stepKey', () => {
-      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0', workflow: workflowS0 })
       expect(marks).to.have.lengthOf(0)
     })
   })
@@ -88,28 +91,46 @@ describe('Models > MachineLearntReductions', () => {
       })
     })
 
-    it('should default stepKey to S0 when absent', () => {
-      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+    it("should default stepKey to the workflow's first step when absent", () => {
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0', workflow: workflowS0 })
       expect(marks).to.have.lengthOf(2)
     })
 
     it('should default taskIndex to 0 when absent', () => {
-      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0', workflow: workflowS0 })
       marks.forEach(mark => {
         expect(mark.taskIndex).to.equal(0)
       })
     })
 
     it('should default toolIndex to 0 when absent', () => {
-      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0' })
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0', workflow: workflowS0 })
       marks.forEach(mark => {
         expect(mark.toolIndex).to.equal(0)
       })
     })
 
     it('should not return minimal marks for a non-default stepKey', () => {
-      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S1' })
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S1', workflow: workflowS0 })
       expect(marks).to.have.lengthOf(0)
+    })
+
+    it("should resolve the default stepKey from the workflow, not hardcoded 'S0'", () => {
+      // Pages Editor workflows use 'P0'. The stepless mark (minimal1) should default to 'P0' and match.
+      // minimal2 has an explicit 'S0' and shouldn't match.
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'P0', workflow: workflowP0 })
+      expect(marks).to.have.lengthOf(1)
+      expect(marks[0].markId).to.equal('minimal1')
+      expect(marks[0].stepKey).to.equal('P0')
+    })
+
+    it("should not leak stepless marks to a step that is not the workflow's first", () => {
+      // Workflow's first step is 'P0'. Asking for marks on 'S0':
+      // - minimal1 (no stepKey) defaulted to 'P0' → doesn't match.
+      // - minimal2 (explicit 'S0') matches.
+      const marks = reductionsModel.findCurrentTaskMarks({ stepKey: 'S0', workflow: workflowP0 })
+      expect(marks).to.have.lengthOf(1)
+      expect(marks[0].markId).to.equal('minimal2')
     })
   })
 })

--- a/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/reducedSubjectMocks.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/reducedSubjectMocks.js
@@ -118,3 +118,39 @@ export const reducedSubjectMocks = [
     y_center: 295
   }
 ]
+
+// Mark on a different step/task/tool to test multi-index routing
+export const multiIndexMock = {
+  stepKey: 'S1',
+  taskIndex: 1,
+  taskKey: 'T1',
+  taskType: 'drawing',
+  toolIndex: 2,
+  toolType: 'point',
+  frame: 0,
+  markId: 'multiIdx1',
+  x: 100,
+  y: 200
+}
+
+// Marks with no stepKey/taskIndex/toolIndex to test defaulting behavior
+export const minimalKeysMocks = [
+  // point with no routing keys at all
+  {
+    toolType: 'point',
+    frame: 0,
+    markId: 'minimal1',
+    x: 50,
+    y: 75
+  },
+  // circle with only stepKey, missing taskIndex and toolIndex
+  {
+    stepKey: 'S0',
+    toolType: 'circle',
+    frame: 0,
+    markId: 'minimal2',
+    r: 50,
+    x_center: 200,
+    y_center: 200
+  }
+]


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- https://github.com/zooniverse/front-end-monorepo/issues/7076
- https://github.com/zooniverse/caesar/pull/1612

## Describe your changes
Addresses all three suggested updates from #7076:

1. **Use `taskIndex` from Caesar data instead of hardcoded `tasks[0]`** ([useMachineLearntReductions.js#L36-L42](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/hooks/useMachineLearntReductions.js#L36-L42)): The hook was destructuring `taskIndex` out of the Caesar mark but never using it - marks always routed to `tasks[0]`. Now uses `tasks[taskIndex]` for correct multi-task routing. `toolIndex` is also properly extracted before being passed to `createMark`.

2. **Default `stepKey`, `taskIndex`, and `toolIndex` when absent** ([MachineLearntReductions.js](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.js)): As noted in [Cliff's comment](https://github.com/zooniverse/front-end-monorepo/issues/7076#issuecomment-3434484398), many correct-a-machine workflows have only one step, one task, and one tool. Rather than forcing every Caesar reduction to include `stepKey`, `taskIndex`, and `toolIndex`, these now default to `'S0'`, `0`, and `0` respectively when absent. This reduces the required keys in Caesar CSV uploads to just the tool-specific keys (e.g., `x`, `y` for points) plus `markId`, `toolType`, and `frame`.

3. **Updated tests** ([MachineLearntReductions.spec.js](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.spec.js)): Added test suites for multi-index routing (marks on different steps/tasks/tools) and default value behavior (marks with missing routing keys).

## How to Review
**Test project (staging):** Load the classifier with Cliff's staging point-mark workflow:
```
https://local.zooniverse.org:8080/?project=2007&workflow=3789&env=staging
```
Caesar Subject View: https://caesar-staging.zooniverse.org/workflows/3789/subjects/253445

**Test project (production, multi-tool):**
```
https://local.zooniverse.org:8080/?project=22358&env=production
```

**Steps:**
1. Load either project above — Caesar reduction marks should render on the subject
2. Verify marks appear on the correct tool
3. Run unit tests: `cd packages/lib-classifier && pnpm test -- --run src/store/subjects/Subject/MachineLearntReductions/MachineLearntReductions.spec.js`

No storybook stories affected. No follow-up PRs planned — this is a self-contained fix.

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser