### PR TITLE
DataImageViewer: support multiple images

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
@@ -91,6 +91,11 @@ const DataImageViewer = forwardRef(function DataImageViewer({
     ? { locations: imageLocations } 
     : null
 
+  
+  // Also, if our subject contains multiple images, justify the position of the
+  // FlipbookViewer so it looks better.
+  const justifyImageSection = imageLocations?.length > 1 ? 'center' : undefined
+
   return (
     <Grid
       areas={areas}
@@ -124,6 +129,7 @@ const DataImageViewer = forwardRef(function DataImageViewer({
         background={imageViewerBackground}
         border={(zoomEnabled.image) && { color: 'brand', size: 'xsmall' }}
         gridArea='image'
+        justify={justifyImageSection}
       >
         {imageLocations?.length === 1 &&
           <SingleImageViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
@@ -6,6 +6,7 @@ import {
   Grid
 } from 'grommet'
 import { withParentSize } from '@visx/responsive'
+import FlipbookViewer from '../FlipbookViewer'
 import ScatterPlotViewer from '../ScatterPlotViewer'
 import SingleImageViewer from '../SingleImageViewer'
 import getZoomBackgroundColor from '@viewers/helpers/getZoomBackgroundColor'
@@ -84,6 +85,11 @@ const DataImageViewer = forwardRef(function DataImageViewer({
     SuperWASP Black Hole Hunters use jsonData.data.x and jsonData.data.y
   */
   const data = jsonData.data ? jsonData.data : jsonData
+
+  const pseudoSubjectForMultipleImages = imageLocations?.length > 1
+    ? { locations: imageLocations } 
+    : null
+
   return (
     <Grid
       areas={areas}
@@ -127,7 +133,15 @@ const DataImageViewer = forwardRef(function DataImageViewer({
             setOnZoom={zoomEnabled.image ? setOnZoom : DEFAULT_HANDLER}
             zoomControlFn={(zoomEnabled.image) ? () => disableImageZoom() : () => setAllowPanZoom('image')}
             zooming={zoomEnabled.image}
-          />}
+          />
+        }
+        {imageLocations?.length > 1 &&
+          <FlipbookViewer
+            enableInteractionLayer={false}
+            subject={pseudoSubjectForMultipleImages}
+            loadingState={loadingState}
+          />
+        }
       </Box>
     </Grid>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
@@ -80,12 +80,10 @@ const DataImageViewer = forwardRef(function DataImageViewer({
     setAllowPanZoom('')
   }
 
-  // Most of the time, we expect scatterplot JSON files to have a 'data' member
-  // which contains the chart data, e.g.:
-  // { data: [
-  //   { seriesData: [ { x: 66.8, y: 22.1, y_error: 0.16 }, ... ] }
-  // ]}
-  const data = jsonData.data
+  // Scatterplot-compatible JSON files come in few different formats. Some store
+  // their chart data in the 'data' member/node, others store their chart data
+  // at the root level.
+  const data = jsonData.data ? jsonData.data : jsonData
 
   // If our subject contains multiple images, we need to package them into a
   // pseudo Subject so the FlipbookViewer can load 'em.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
@@ -39,7 +39,7 @@ const DEFAULT_THEME = {
 }
 const DataImageViewer = forwardRef(function DataImageViewer({
   allowPanZoom = '',
-  imageLocation = null,
+  imageLocations = [],
   jsonData = JSON_DATA,
   loadingState,
   parentWidth,
@@ -118,10 +118,10 @@ const DataImageViewer = forwardRef(function DataImageViewer({
         border={(zoomEnabled.image) && { color: 'brand', size: 'xsmall' }}
         gridArea='image'
       >
-        {imageLocation &&
+        {imageLocations?.length === 1 &&
           <SingleImageViewer
             enableInteractionLayer={false}
-            imageLocation={imageLocation}
+            imageLocation={imageLocations[0]}
             loadingState={loadingState}
             setOnPan={zoomEnabled.image ? setOnPan : DEFAULT_HANDLER}
             setOnZoom={zoomEnabled.image ? setOnZoom : DEFAULT_HANDLER}
@@ -136,7 +136,7 @@ const DataImageViewer = forwardRef(function DataImageViewer({
 DataImageViewer.propTypes = {
   allowPanZoom: PropTypes.string,
   enableRotation: PropTypes.func,
-  imageLocation: PropTypes.object,
+  imageLocations: PropTypes.arrayOf(PropTypes.object),
   jsonData: PropTypes.shape({
     data: PropTypes.oneOfType([ PropTypes.array, PropTypes.object ]),
     chartOptions: PropTypes.object

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
@@ -80,13 +80,16 @@ const DataImageViewer = forwardRef(function DataImageViewer({
     setAllowPanZoom('')
   }
 
-  /*
-    PH-TESS light curves use jsonData.x and jsonData.y.
-    SuperWASP Black Hole Hunters use jsonData.data.x and jsonData.data.y
-  */
-  const data = jsonData.data ? jsonData.data : jsonData
+  // Most of the time, we expect scatterplot JSON files to have a 'data' member
+  // which contains the chart data, e.g.:
+  // { data: [
+  //   { seriesData: [ { x: 66.8, y: 22.1, y_error: 0.16 }, ... ] }
+  // ]}
+  const data = jsonData.data
 
-  const pseudoSubjectForMultipleImages = imageLocations?.length > 1
+  // If our subject contains multiple images, we need to package them into a
+  // pseudo Subject so the FlipbookViewer can load 'em.
+  const multiImagePseudoSubject = imageLocations?.length > 1
     ? { locations: imageLocations } 
     : null
 
@@ -138,7 +141,7 @@ const DataImageViewer = forwardRef(function DataImageViewer({
         {imageLocations?.length > 1 &&
           <FlipbookViewer
             enableInteractionLayer={false}
-            subject={pseudoSubjectForMultipleImages}
+            subject={multiImagePseudoSubject}
             loadingState={loadingState}
           />
         }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
@@ -147,6 +147,8 @@ const DataImageViewer = forwardRef(function DataImageViewer({
             enableInteractionLayer={false}
             subject={multiImagePseudoSubject}
             loadingState={loadingState}
+            setOnPan={zoomEnabled.image ? setOnPan : DEFAULT_HANDLER}
+            setOnZoom={zoomEnabled.image ? setOnZoom : DEFAULT_HANDLER}
             zoomControlFn={(zoomEnabled.image) ? () => disableImageZoom() : () => setAllowPanZoom('image')}
             zooming={zoomEnabled.image}
           />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.jsx
@@ -147,6 +147,8 @@ const DataImageViewer = forwardRef(function DataImageViewer({
             enableInteractionLayer={false}
             subject={multiImagePseudoSubject}
             loadingState={loadingState}
+            zoomControlFn={(zoomEnabled.image) ? () => disableImageZoom() : () => setAllowPanZoom('image')}
+            zooming={zoomEnabled.image}
           />
         }
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.jsx
@@ -18,23 +18,20 @@ const simpleSubject = Factory.build('subject', {
   ]
 })
 
-// Multi Image Subject contains 1 JSON file and 4 images file
+// Multi Image Subject contains 1 JSON file and 3 images file
 const multiImageSubject = Factory.build('subject', {
   locations: [
     {
-      'application/json': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/main/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/kepler.json'
+      'application/json': 'https://panoptes-uploads.zooniverse.org/subject_location/17a17a16-ed3d-40a8-b775-e65db6c4b852.json',
     },
     {
-      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/1e54b552-4608-4701-9db9-b8342b81278a.jpeg'
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/71cca7c9-4ba1-48c6-a2b1-4f32f9a89ec6.jpeg'
     },
     {
-      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/098f3fb6-5021-410a-82a2-477a28b2bcd6.jpeg'
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/0943b4a1-175f-4cf0-beaf-1a02cff05fed.jpeg'
     },
     {
-      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/8fcb18b0-de80-42cd-ba2a-4871da30c74f.jpeg'
-    },
-    {
-      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/85d8d82a-c88d-493c-b3db-7cd9f2ca5ad8.jpeg'
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/67b54e54-8ca9-4cb7-a4fb-2417b5bfc82a.jpeg'
     }
   ]
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.jsx
@@ -8,12 +8,34 @@ import ImageToolbar from '../../../ImageToolbar'
 import mockStore from '@test/mockStore'
 import readme from './README.md'
 
-const subject = Factory.build('subject', {
+// Simple Subject contains 1 JSON file and 1 image file
+const simpleSubject = Factory.build('subject', {
   locations: [
     {
       'application/json': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/main/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/kepler.json'
     },
     { 'image/png': 'https://panoptes-uploads.zooniverse.org/production/subject_location/6379335f-d893-445d-a25e-c14b83eabf63.png' }
+  ]
+})
+
+// Multi Image Subject contains 1 JSON file and 4 images file
+const multiImageSubject = Factory.build('subject', {
+  locations: [
+    {
+      'application/json': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/main/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/kepler.json'
+    },
+    {
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/1e54b552-4608-4701-9db9-b8342b81278a.jpeg'
+    },
+    {
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/098f3fb6-5021-410a-82a2-477a28b2bcd6.jpeg'
+    },
+    {
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/8fcb18b0-de80-42cd-ba2a-4871da30c74f.jpeg'
+    },
+    {
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/85d8d82a-c88d-493c-b3db-7cd9f2ca5ad8.jpeg'
+    }
   ]
 })
 
@@ -28,7 +50,7 @@ const lasairSubject = Factory.build('subject', {
 
 function ViewerContext ({
   children,
-  store = mockStore({ subject })
+  store = mockStore({ subject: simpleSubject })
 }) {
   return (
     <Provider classifierStore={store}>
@@ -97,6 +119,21 @@ export function InvertYAxis() {
 
   return (
     <ViewerContext store={lasairMock}>
+      <Box direction='row' width='large'>
+        <DataImageViewer
+          loadingState={asyncStates.success}
+        />
+        <ImageToolbar width='4rem' />
+      </Box>
+    </ViewerContext>
+  )
+}
+
+export function MultiImageSubjects() {
+  const multiImageMock = mockStore({ subject: multiImageSubject })
+
+  return (
+    <ViewerContext store={multiImageMock}>
       <Box direction='row' width='large'>
         <DataImageViewer
           loadingState={asyncStates.success}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.jsx
@@ -22,16 +22,16 @@ const simpleSubject = Factory.build('subject', {
 const multiImageSubject = Factory.build('subject', {
   locations: [
     {
-      'application/json': 'https://panoptes-uploads.zooniverse.org/subject_location/17a17a16-ed3d-40a8-b775-e65db6c4b852.json',
+      'application/json': 'https://panoptes-uploads.zooniverse.org/subject_location/0e939261-5e70-4be2-b168-8c4b34321fb3.json',
     },
     {
-      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/71cca7c9-4ba1-48c6-a2b1-4f32f9a89ec6.jpeg'
+      'image/png': 'https://panoptes-uploads.zooniverse.org/subject_location/a704707d-9afe-4451-b505-d99b5cd2e2dc.png'
     },
     {
-      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/0943b4a1-175f-4cf0-beaf-1a02cff05fed.jpeg'
+      'image/png': 'https://panoptes-uploads.zooniverse.org/subject_location/fbc390b4-054e-449f-b068-0aa54df9bb9d.png'
     },
     {
-      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/67b54e54-8ca9-4cb7-a4fb-2417b5bfc82a.jpeg'
+      'image/png': 'https://panoptes-uploads.zooniverse.org/subject_location/46d7d9ec-79ec-4ecc-8e71-9fa2a240a3b7.png'
     }
   ]
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewerContainer.jsx
@@ -18,7 +18,7 @@ export default function DataImageViewerContainer({
   ...rest
 }) {
   const [allowPanZoom, setAllowPanZoom] = useState('')
-  const { imageLocation, jsonData, loading, viewer } = useDataImageSubject({ onError, onReady, subject })
+  const { imageLocations, jsonData, loading, viewer } = useDataImageSubject({ onError, onReady, subject })
 
   if (!subject.id) {
     return null
@@ -29,7 +29,7 @@ export default function DataImageViewerContainer({
   return (
     <DataImageViewer
       allowPanZoom={allowPanZoom}
-      imageLocation={imageLocation}
+      imageLocations={imageLocations}
       ref={viewer}
       jsonData={jsonData}
       setAllowPanZoom={setAllowPanZoom}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/README.md
@@ -1,12 +1,22 @@
 # DataImageViewer
 
-The Data Image Viewer is a variant of the Subject Viewer that is a composite of the Scatter Plot Viewer and the Single Image Viewer rendered side-by-side with controls to enable or disable pan and zoom per viewer.
+The Data Image Viewer is a variant of the Subject Viewer that is a composite of the Scatter Plot Viewer and an image viewer, rendered side-by-side.
+
+- The Data Image Viewer has a very specific use case.
+  - **// TODO: link to an example project**
+- The Data Image Viewer _assumes_ any Subject fed into it will consists of:
+  - _exactly 1_ JSON file that can be displayed on a Scatter Plot Viewer.
+  - _1 or more_ image files.
+- The Data Image Viewer must be enabled via Workflow configuration; its use can't be inferred from the presence of a Data Image Subject...
+- ...because the Data Image Subject model doesn't exist.
+
+See "External Set" and "Dev Notes" for more info.
 
 ## Features
 
 The Data Image Viewer...
-- allows users to view coordinate data series in scatter plot
-- allows users to view an image
+- allows users to view coordinate data series in a scatter plot
+- allows users to view one or more images
 
 ## Props
 
@@ -22,6 +32,28 @@ The Workflow of the project should have a configuration specified that the Varia
 
 ### Subject
 
+Any Subject fed to the Data Image Viewer must have...
+
+- _exactly 1_ JSON file that can be displayed on a Scatter Plot Viewer.
+- _1 or more_ image files.
+
+Example:
+
+```js
+subject.locations = [
+  { "application/json": "data.json" },
+  { "image/png": "transient-photo-1.png" },
+  { "image/png": "transient-photo-2.png" }
+]
+```
+
+Note that there is no such thing as a "Data Image Subject" model per se; i.e. nothing akin to a "Single Image Subject". The use of the "Data Image (pseudo-)Subject" is inferred from the workflow explicitly saying it wants the Data Image Viewer. See [useDataImageSubject.js](hooks/useDataImageSubject.js).
+
+<details>
+<summary>Historically, the Data Image Viewer assumed its Subject contained an optional thumbnail image. This is no longer the case.</summary>
+
+_The following information was written prior to 2026, with the assumption that a thumbnail image was required to properly display "JSON Subjects" on Talk. This assumption was revised and removed on Apr 2026: https://github.com/zooniverse/front-end-monorepo/issues/7241_
+
 Each Subject has three files:
 - an image file (which works as a "thumbnail" to be seen on Talk, this must be first in the subject location's list)
 - a JSON file containing the data for the scatter plot
@@ -34,6 +66,8 @@ subject.locations = [
   { "image/png": "transient-object.png" }
 ]
 ```
+
+</details>
 
 ### JSON file
 
@@ -101,3 +135,19 @@ For the `data` array, this JSON takes the same shape as expected for the generic
 #### `chartOptions`
 
 A set of chart options can also be supplied that define the x-axis and y-axis labels as well as the custom margins to use. Margin is defined as the space outside axes lines. The scatter plot have a default margin of `{ bottom: 60, left: 60, right: 10, top: 10}`.
+
+## Dev Notes
+
+**No such thing as a Data Image Subject**
+
+Unlike most viewers, the use of the Data Image Viewer must be _explicitly set_ in the workflow config, instead of its use being inferred from the current Subject.
+
+This is because the definition of a "Data Image Subject" can get way too flexible or nebulous. If a Subject has 1 JSON file and 1 image file, is it meant to be displayed as a Scatterplot + Image? What if that JSON file is a GeoJSON file meant for a map viewer? What if that JSON file is a light curve and that image is a thumbnail, e.g. as used by early iterations of [Planet Hunters TESS](https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess)?
+
+We can't "guess" that a Subject is specifically a Data Image Subject just because it has 1 JSON and 1+ images. Hence, we need to explicitly set the Data Image Viewer, and then infer the Data Image Subject from the presence of the viewer.
+
+**Thoughts on scope expansion**
+
+There were some initial discussions on expanding the scope of the Data Image Viewer. e.g. "perhaps it can show Subjects with 1+ JSON file?"
+
+If we choose to go down this path, we need to accept that we're expanding the narrow design of the current Data Image Viewer and its specific use case. We'll then need to answer some questions, e.g.: what are the new layout rules? if a Data Image Subject contains 1+ JSON files and 1+ image files, do we add group all the JSON files into one "flipbook viewer" the same way all image files are grouped into a flipbook viewer?

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/hooks/useDataImageSubject.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/hooks/useDataImageSubject.js
@@ -10,19 +10,12 @@ export default function useDataImageSubject({
     data: [],
     chartOptions: {}
   }
-  let imageLocation = null
 
   if (data && !loading) {
     jsonData = data
   }
 
-  const locations = subject.locations.filter(location => location.type === 'image')
-  if (locations?.length > 0) {
-    // Presumably 2 image locations will be found
-    // The first will be the fallback to display something in Talk
-    // Even if there's only one, this is fine
-    imageLocation = locations.reverse()[0]
-  }
+  const imageLocations = subject.locations.filter(location => location.type === 'image')
 
-  return { imageLocation, jsonData, loading, viewer }
+  return { imageLocations, jsonData, loading, viewer }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -27,7 +27,9 @@ const FlipbookViewer = ({
   rotation = 0,
   setOnPan = DEFAULT_HANDLER,
   setOnZoom = DEFAULT_HANDLER,
-  subject
+  subject,
+  zoomControlFn = null,
+  zooming = true
 }) => {
   const [currentFrame, setCurrentFrame] = useState(defaultFrame)
   const [playing, setPlaying] = useState(false)
@@ -93,6 +95,8 @@ const FlipbookViewer = ({
           setOnZoom={setOnZoom}
           src={currentMediaUrl}
           subject={subject}
+          zoomControlFn={zoomControlFn}
+          zooming={zooming}
         />
       )}
       {currentMediaType === 'video' && (
@@ -151,7 +155,9 @@ FlipbookViewer.propTypes = {
   /** Required. Passed from SubjectViewer component */
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)
-  }).isRequired
+  }).isRequired,
+  zoomControlFn: PropTypes.func,
+  zooming: PropTypes.bool,
 }
 
 export default FlipbookViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -148,15 +148,17 @@ FlipbookViewer.propTypes = {
   playIterations: PropTypes.number,
   /** Passed from the subject viewer store. Needed in SingleImageViewer to handle transforming (rotating) the image */
   rotation: PropTypes.number,
-  /** Passed from the Subject Viewer Store */
+  /** Usually passed from the Subject Viewer Store. Can be overridden, such as when the FlipbookViewer is used in the DataImageViewer.  */
   setOnPan: PropTypes.func,
-  /** Passed from the Subject Viewer Store */
+  /** Usually passed from the Subject Viewer Store. Can be overridden, such as when the FlipbookViewer is used in the DataImageViewer. */
   setOnZoom: PropTypes.func,
   /** Required. Passed from SubjectViewer component */
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)
   }).isRequired,
+  /** OPTIONAL: only supply zoomControlFn and zooming if you want to allow users to manually enable/disable zoom & pan functionality. (As of Apr 2026, only used by DataImageViewer.) */
   zoomControlFn: PropTypes.func,
+  /** OPTIONAL: see zoomControlFn. */
   zooming: PropTypes.bool,
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -28,7 +28,7 @@ const FlipbookViewer = ({
   setOnPan = DEFAULT_HANDLER,
   setOnZoom = DEFAULT_HANDLER,
   subject,
-  zoomControlFn = null,
+  zoomControlFn = undefined,
   zooming = true
 }) => {
   const [currentFrame, setCurrentFrame] = useState(defaultFrame)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -48,6 +48,8 @@ function FlipbookViewerContainer({
   loadingState = asyncStates.initialized,
   onError = DEFAULT_HANDLER,
   onReady = DEFAULT_HANDLER,
+  setOnPan: propSetOnPan = null,
+  setOnZoom: propSetOnZoom = null,
   subject,
   zoomControlFn = null,
   zooming = true
@@ -62,9 +64,12 @@ function FlipbookViewerContainer({
     playIterations,
     rotation,
     separateFramesView,
-    setOnPan,
-    setOnZoom
+    setOnZoom: storeSetOnZoom,
+    setOnPan: storeSetOnPan,
   } = useStores(storeMapper)
+
+  const effectiveSetOnPan = propSetOnPan || storeSetOnPan
+  const effectiveSetOnZoom = propSetOnZoom || storeSetOnZoom
 
   useEffect(function preloadImages() {
     subject?.locations?.forEach(({ type, url }) => {
@@ -103,8 +108,8 @@ function FlipbookViewerContainer({
           onReady={onReady}
           playIterations={playIterations}
           rotation={rotation}
-          setOnPan={setOnPan}
-          setOnZoom={setOnZoom}
+          setOnPan={effectiveSetOnPan}
+          setOnZoom={effectiveSetOnZoom}
           subject={subject}
           zoomControlFn={zoomControlFn}
           zooming={zooming}
@@ -123,6 +128,8 @@ FlipbookViewerContainer.propTypes = {
   onError: PropTypes.func,
   /** Passed from SubjectViewer and dimensions are added to classification metadata. Called after svg layers successfully load with `defaultFrameSrc`. */
   onReady: PropTypes.func,
+  setOnPan: PropTypes.func,
+  setOnZoom: PropTypes.func,
   /** Required. Passed from mobx store via SubjectViewer. */
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -48,7 +48,9 @@ function FlipbookViewerContainer({
   loadingState = asyncStates.initialized,
   onError = DEFAULT_HANDLER,
   onReady = DEFAULT_HANDLER,
-  subject
+  subject,
+  zoomControlFn = null,
+  zooming = true
 }) {
   const {
     defaultFrame,
@@ -104,6 +106,8 @@ function FlipbookViewerContainer({
           setOnPan={setOnPan}
           setOnZoom={setOnZoom}
           subject={subject}
+          zoomControlFn={zoomControlFn}
+          zooming={zooming}
         />
       )}
     </>
@@ -122,7 +126,9 @@ FlipbookViewerContainer.propTypes = {
   /** Required. Passed from mobx store via SubjectViewer. */
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)
-  }).isRequired
+  }).isRequired,
+  zoomControlFn: PropTypes.func,
+  zooming: PropTypes.bool
 }
 
 export default observer(FlipbookViewerContainer)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -128,13 +128,17 @@ FlipbookViewerContainer.propTypes = {
   onError: PropTypes.func,
   /** Passed from SubjectViewer and dimensions are added to classification metadata. Called after svg layers successfully load with `defaultFrameSrc`. */
   onReady: PropTypes.func,
+  /** OPTIONAL: only supply this function if you want to override the setOnPan function from the store. (As of Apr 2026, only used by DataImageViewer.) */
   setOnPan: PropTypes.func,
+  /** OPTIONAL: only supply this function if you want to override the setOnZoom function from the store. (As of Apr 2026, only used by DataImageViewer.) */
   setOnZoom: PropTypes.func,
   /** Required. Passed from mobx store via SubjectViewer. */
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)
   }).isRequired,
+  /** OPTIONAL: only supply zoomControlFn and zooming if you want to allow users to manually enable/disable zoom & pan functionality. (As of Apr 2026, only used by DataImageViewer.) */
   zoomControlFn: PropTypes.func,
+  /** OPTIONAL: see zoomControlFn. */
   zooming: PropTypes.bool
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -48,10 +48,10 @@ function FlipbookViewerContainer({
   loadingState = asyncStates.initialized,
   onError = DEFAULT_HANDLER,
   onReady = DEFAULT_HANDLER,
-  setOnPan: propSetOnPan = null,
-  setOnZoom: propSetOnZoom = null,
+  setOnPan: propSetOnPan = undefined,
+  setOnZoom: propSetOnZoom = undefined,
   subject,
-  zoomControlFn = null,
+  zoomControlFn = undefined,
   zooming = true
 }) {
   const {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/README.md
@@ -37,9 +37,11 @@ FlipbookControls handles the following features:
 - `onReady`: (function) Function is passed from SubjectViewer and  dimensions are added to classification metadata.
 - `playIterations`: (string) Can be '', meaning infinite, or a number represented as a string. Set in the project builder and determines how many times to loop the flipbook.
 - `rotation`: (number) Passed from the subject viewer store. Needed in SingleImageViewer to handle transforming (rotating) the image.
-- `setOnPan`: (function) Passed from subject viewer store and used in VisXZoom.
-- `setOnZoom`: (function) Passed from subject viewer store and used in VisXZoom.
+- `setOnPan`: (function) Usually passed from subject viewer store, but can be overridden (e.g when used in DataImageViewer). Used in VisXZoom.
+- `setOnZoom`: (function) Usually passed from subject viewer store, but can be overridden (e.g when used in DataImageViewer). Used in VisXZoom.
 - `subject`: (object) Passed from mobx store via SubjectViewer.
+- `zoomControlFn`: (function) function for enabling/disabling zoom for images (Single Image Viewer). Optional. If set, it's usually paired with 'zooming', 'setOnPan', and 'setOnZoom' properties. (See DataImageViewer)
+- `zooming`: (function) determines if images (Single Image Viewer) can zoom. Defaults to true.
 
 ### State Variables
 - `currentFrame`: (number) Frame index that determines `viewerSrc`.


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Closes #7241

This PR allows the DataImageViewer to show multiple images.

<img width="770" height="516" alt="image" src="https://github.com/user-attachments/assets/ae4cc1a0-5b53-4495-86d1-c5a26546596a" />

Feature updates:

- DataImageViewer:[^1] if a Subject has 1 JSON and 1+ images, then those images will be displayed in the FlipbookViewer format. 🆕 
  - if a Subject has 1 JSON and 1 image, then that image will be displayed in the standard SingleImageViewer. (no change.)

[^1]: reminder - DataImageViewer is enabled by setting `workflow.configuration.subject_viewer = 'dataImage'`. The use of this viewer can't be inferred by the presence of a 'Data Image Subject', because there's no such thing as a 'Data Image Subject'.

Code changes:

- Data Image Viewer now expects all Subjects fed to it to have _exactly 1_ JSON file and _1 or more_ image files.
- **useDataImageSubject() now assumes that Subjects will NOT have a thumbnail image.**
- useDataImageSubject() now returns imageLocations (plural) instead of imageLocation.

Documentation updates:

- DataImageViewer's README (and by extension the "Data Image Subject"'s documentation) changed.
  - Clarified expected Subject structure.
  - Added additional dev notes on DataImageViewer's current narrow use case, and possible future scope expansion.

### Testing

Basic testing:

- Run Storybook for lib-classifier
- Confirm that the new Storybook Story (Subject Viewers -> DataImageViewer -> _Multi Image Subjects_ ) works correctly.
  - This new Story should allow you to see 1 JSON data on a scatterplot, and 3 images presented in a flipbook viewer.
- Confirm that the other Storybook Stories for the DataImageViewer work correctly too.
  - Other Stories should look/work the same as before this PR.

Note: the layout looks a bit funny on a narrow view, because the image toolbar hangs on the top-right while the actual image drops to the bottom, but this seems consistent with the current 1 JSON + 1 image design. 🤷 

<img width="313" height="650" alt="image" src="https://github.com/user-attachments/assets/b193f202-f9e5-4ec1-af4f-6196cc689bc5" />



Advanced testing:

- Run app-project
- Load  the test project/workflow, which is Cliff's "Data As Subject Testing" workflow on "LCJ Test" on _production._
  - https://local.zooniverse.org:3000/projects/lcjohnso/lcj-test/classify/workflow/23354?env=production&demo=true 
  - This project has 1 Subject (id 117885353) which contains `[ JSON, image, image, image ]`
- You should see a single scatterplot, next to a flipbook viewer showing 3 images.
    <img width="400" alt="image" src="https://github.com/user-attachments/assets/f45f50db-5192-484f-b8f3-0e875735f00f" />
- Interact with the viewer to confirm you can view/explore/etc all 4 media items.
- Submit the classification (in demo mode) 

### Status

Ready for review! ~~If you'd rather wait until I create that full test project so you can test on app-project, that's fine too - just let me know.~~