### PR TITLE
refactor(lib-classifier): Remove duplicate feedback viewer logic

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/components/RadialFeedback.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/components/RadialFeedback.jsx
@@ -175,10 +175,6 @@ export default function RadialFeedback() {
     loadingState,
   } = useStores(storeMapper);
 
-  if (applicableRules.some(rule => rule.hideSubjectViewer)) {
-    return null
-  }
-
   const annotatedMarks = getAnnotatedMarks(
     annotations,
     applicableRules


### PR DESCRIPTION
Remove conditional rendering for subject viewer based on applicable rules. This was just duplicating `hideSubjectViewer` in `FeedbackStore`.

https://github.com/zooniverse/front-end-monorepo/blob/a1876e9467df747ec35936de9700d6a395cd3000/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.jsx#L37

_Please request review from `@zooniverse/frontend` team or an individual member of that team._

## Package

## Linked Issue and/or Talk Post

## Describe your changes

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/main/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

### Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)

### Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).
