### PR TITLE
FlipbookViewer: fix broken Image Toolbar, when first item isn't an image

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButtonContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButtonContainer.jsx
@@ -18,14 +18,15 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ResetButtonContainer({ separateFrameResetView }) {
+function ResetButtonContainer({ overrideDisabled, separateFrameResetView }) {
   const { disabled, resetView } = useStores(storeMapper)
 
   const resetCallback = separateFrameResetView || resetView
+  const _disabled = overrideDisabled ?? disabled
 
   return (
     <ResetButton
-      disabled={disabled}
+      disabled={_disabled}
       onClick={resetCallback}
     />
   )
@@ -34,6 +35,8 @@ function ResetButtonContainer({ separateFrameResetView }) {
 export default observer(ResetButtonContainer)
 
 ResetButton.propTypes = {
+  /** Overrides the 'disabled' value, which is usually determined by the Subject Viewer Store's disableImageToolbar */
+  overrideDisabled: PropTypes.bool,
   /** Used when separate frames of a subject each have their own ImageToolbar */
   separateFrameResetView: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.jsx
@@ -21,10 +21,11 @@ function storeMapper (classifierStore) {
   }
 }
 
-function RotateButtonContainer({ separateFrameRotate }) {
+function RotateButtonContainer({ overrideDisabled, separateFrameRotate }) {
   const { disabled, rotate, show } = useStores(storeMapper)
 
   const rotateCallback = separateFrameRotate || rotate
+  const _disabled = overrideDisabled ?? disabled
 
   if (!show) {
     return null
@@ -32,13 +33,15 @@ function RotateButtonContainer({ separateFrameRotate }) {
 
   return (
     <RotateButton
-      disabled={disabled}
+      disabled={_disabled}
       onClick={rotateCallback}
     />
   )
 }
 
 RotateButtonContainer.propTypes = {
+  /** Overrides the 'disabled' value, which is usually determined by the Subject Viewer Store's disableImageToolbar */
+  overrideDisabled: PropTypes.bool,
   /** Used when separate frames of a subject each have their own ImageToolbar */
   separateFrameRotate: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.jsx
@@ -17,10 +17,11 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ZoomInButtonContainer({ separateFrameZoomIn }) {
+function ZoomInButtonContainer({ overrideDisabled, separateFrameZoomIn }) {
   const { disabled, zoomIn } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
   const zoomCallback = separateFrameZoomIn || zoomIn
+  const _disabled = overrideDisabled ?? disabled
 
   function onClick() {
     // Stop the zoom callback
@@ -47,7 +48,7 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
 
   return (
     <ZoomInButton
-      disabled={disabled}
+      disabled={_disabled}
       onClick={onClick}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
@@ -58,6 +59,8 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
 export default observer(ZoomInButtonContainer)
 
 ZoomInButtonContainer.propTypes = {
+  /** Overrides the 'disabled' value, which is usually determined by the Subject Viewer Store's disableImageToolbar */
+  overrideDisabled: PropTypes.bool,
   /** Used when separate frames of a subject each have their own ImageToolbar */
   separateFrameZoomIn: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.jsx
@@ -17,10 +17,11 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ZoomOutButtonContainer({ separateFrameZoomOut }) {
+function ZoomOutButtonContainer({ overrideDisabled, separateFrameZoomOut }) {
   const { disabled, zoomOut } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
   const zoomCallback = separateFrameZoomOut || zoomOut
+  const _disabled = overrideDisabled ?? disabled
 
   function onClick() {
     // stop the zoom callback
@@ -47,7 +48,7 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
 
   return (
     <ZoomOutButton
-      disabled={disabled}
+      disabled={_disabled}
       onClick={onClick}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
@@ -58,6 +59,8 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
 export default observer(ZoomOutButtonContainer)
 
 ZoomOutButtonContainer.propTypes = {
+  /** Overrides the 'disabled' value, which is usually determined by the Subject Viewer Store's disableImageToolbar */
+    overrideDisabled: PropTypes.bool,
   /** Used when separate frames of a subject each have their own ImageToolbar */
   separateFrameZoomOut: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -36,7 +36,19 @@ const FlipbookViewer = ({
   setOnZoom = DEFAULT_HANDLER,
   subject
 }) => {
-  // const [currentFrame, setCurrentFrame] = useState(defaultFrame)
+  // Prior to Apr 2026, FlipbookViewer used to store the "current frame" value
+  // in local state, but this caused issues with the image toolbar which
+  // expected synced with the Subject Viewer Store's "current frame".
+  
+  // Also, Subject Viewer Store's resetSubject() ensures that the first `frame`
+  // fed to the FlipbookViewer will either be 0, or the default_frame as set by
+  // subject.metadata. As a result, the defaultFrame prop of FlipbookViewer is
+  // now ONLY used to determine the dimensions of the "subject frame". (i.e. to
+  // keep all images & videos displayed in a consistent width & height)
+  // Future devs, it should be fairly safe to that defaultFrame prop to a say
+  // const REFERENCE_FRAME = 0 ; it only matters that all frames are displayed
+  // in a consistent size.
+
   const [playing, setPlaying] = useState(false)
 
   useEffect(() => {
@@ -130,7 +142,7 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
-  /** Fetched from metadata.default_frame or initialized to zero ⚠️ WARNING: not actually implemented as of Apr 2026 */
+  /** Fetched from metadata.default_frame or initialized to zero. ONLY used to determine size of "subject frame" */
   defaultFrame: PropTypes.number,
   /** Determined per mobx store WorkflowStepStore via SubjectViewer. */
   enableInteractionLayer: PropTypes.bool,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -18,6 +18,7 @@ const FlipbookViewer = ({
   enableInteractionLayer = false,
   enableRotation = DEFAULT_HANDLER,
   flipbookAutoplay = false,
+  frame = 0,
   invert = false,
   limitSubjectHeight = false,
   move = false,
@@ -25,11 +26,12 @@ const FlipbookViewer = ({
   onReady = DEFAULT_HANDLER,
   playIterations,
   rotation = 0,
+  setFrame = DEFAULT_HANDLER,
   setOnPan = DEFAULT_HANDLER,
   setOnZoom = DEFAULT_HANDLER,
   subject
 }) => {
-  const [currentFrame, setCurrentFrame] = useState(defaultFrame)
+  // const [currentFrame, setCurrentFrame] = useState(defaultFrame)
   const [playing, setPlaying] = useState(false)
 
   useEffect(() => {
@@ -64,8 +66,8 @@ const FlipbookViewer = ({
   // only for the sake of determining a consistent viewer width/height for
   // all media files. 
   // --------------------------------
-  const currentMediaType = subject?.locations[currentFrame]?.type
-  const currentMediaUrl = subject?.locations[currentFrame]?.url
+  const currentMediaType = subject?.locations[frame]?.type
+  const currentMediaUrl = subject?.locations[frame]?.url
   // --------------------------------
 
   const onPlayPause = () => {
@@ -80,7 +82,7 @@ const FlipbookViewer = ({
         <SingleImageViewer
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}
-          frame={currentFrame}
+          frame={frame}
           imgRef={mediaElementRef}
           invert={invert}
           limitSubjectHeight={limitSubjectHeight}
@@ -110,9 +112,9 @@ const FlipbookViewer = ({
         />
       )}
       <FlipbookControls
-        currentFrame={currentFrame}
+        currentFrame={frame}
         locations={subject.locations}
-        onFrameChange={setCurrentFrame}
+        onFrameChange={setFrame}
         onPlayPause={onPlayPause}
         playing={playing}
         playIterations={playIterations}
@@ -122,12 +124,14 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
-  /** Fetched from metadata.default_frame or initialized to zero */
+  /** Fetched from metadata.default_frame or initialized to zero ⚠️ WARNING: not actually implemented as of Apr 2026 */
   defaultFrame: PropTypes.number,
   /** Determined per mobx store WorkflowStepStore via SubjectViewer. */
   enableInteractionLayer: PropTypes.bool,
   /** Function passed from Subject Viewer Store */
   enableRotation: PropTypes.func,
+  /** Passed from the subject viewer store. Determins the current frame of the Subject */
+  frame: PropTypes.number,
   /** Fetched from workflow configuration. Determines whether to autoplay the loop on viewer load */
   flipbookAutoplay: PropTypes.bool,
   /** Passed from Subject Viewer Store */
@@ -144,6 +148,8 @@ FlipbookViewer.propTypes = {
   playIterations: PropTypes.number,
   /** Passed from the subject viewer store. Needed in SingleImageViewer to handle transforming (rotating) the image */
   rotation: PropTypes.number,
+  /** Passed from the Subject Viewer Store */
+  setFrame: PropTypes.func,
   /** Passed from the Subject Viewer Store */
   setOnPan: PropTypes.func,
   /** Passed from the Subject Viewer Store */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -1,6 +1,7 @@
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
 import { useEffect, useState } from 'react'
+import styled, { css } from 'styled-components'
 
 import { useKeyZoom, useSubjectImageOrVideo } from '@hooks'
 
@@ -12,6 +13,10 @@ import FlipbookControls from './components/FlipbookControls'
 const DEFAULT_HANDLER = () => true
 const DEFAULT_WIDTH = 800
 const DEFAULT_HEIGHT = 600
+
+const StyledVideo = styled.video`
+  ${props => props.invert && css`filter: invert(1)`}
+`
 
 const FlipbookViewer = ({
   defaultFrame = 0,
@@ -98,9 +103,10 @@ const FlipbookViewer = ({
         />
       )}
       {currentMediaType === 'video' && (
-        <video
+        <StyledVideo
           autoPlay={false}
           controls={true}
+          invert={invert}
           ref={mediaElementRef}
           src={currentMediaUrl}
           width={viewerWidth}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -120,6 +120,7 @@ const FlipbookViewer = ({
           autoPlay={false}
           controls={true}
           invert={invert}
+          preload='metadata'
           ref={mediaElementRef}
           src={currentMediaUrl}
           width={viewerWidth}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -38,7 +38,19 @@ const FlipbookViewer = ({
   zoomControlFn = undefined,
   zooming = true
 }) => {
-  // const [currentFrame, setCurrentFrame] = useState(defaultFrame)
+  // Prior to Apr 2026, FlipbookViewer used to store the "current frame" value
+  // in local state, but this caused issues with the image toolbar which
+  // expected synced with the Subject Viewer Store's "current frame".
+  
+  // Also, Subject Viewer Store's resetSubject() ensures that the first `frame`
+  // fed to the FlipbookViewer will either be 0, or the default_frame as set by
+  // subject.metadata. As a result, the defaultFrame prop of FlipbookViewer is
+  // now ONLY used to determine the dimensions of the "subject frame". (i.e. to
+  // keep all images & videos displayed in a consistent width & height)
+  // Future devs, it should be fairly safe to that defaultFrame prop to a say
+  // const REFERENCE_FRAME = 0 ; it only matters that all frames are displayed
+  // in a consistent size.
+
   const [playing, setPlaying] = useState(false)
 
   useEffect(() => {
@@ -134,7 +146,7 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
-  /** Fetched from metadata.default_frame or initialized to zero ⚠️ WARNING: not actually implemented as of Apr 2026 */
+  /** Fetched from metadata.default_frame or initialized to zero. ONLY used to determine size of "subject frame" */
   defaultFrame: PropTypes.number,
   /** Determined per mobx store WorkflowStepStore via SubjectViewer. */
   enableInteractionLayer: PropTypes.bool,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -1,6 +1,7 @@
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
 import { useEffect, useState } from 'react'
+import styled, { css } from 'styled-components'
 
 import { useKeyZoom, useSubjectImageOrVideo } from '@hooks'
 
@@ -12,6 +13,10 @@ import FlipbookControls from './components/FlipbookControls'
 const DEFAULT_HANDLER = () => true
 const DEFAULT_WIDTH = 800
 const DEFAULT_HEIGHT = 600
+
+const StyledVideo = styled.video`
+  ${props => props.invert && css`filter: invert(1)`}
+`
 
 const FlipbookViewer = ({
   defaultFrame = 0,
@@ -102,9 +107,10 @@ const FlipbookViewer = ({
         />
       )}
       {currentMediaType === 'video' && (
-        <video
+        <StyledVideo
           autoPlay={false}
           controls={true}
+          invert={invert}
           ref={mediaElementRef}
           src={currentMediaUrl}
           width={viewerWidth}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -18,6 +18,7 @@ const FlipbookViewer = ({
   enableInteractionLayer = false,
   enableRotation = DEFAULT_HANDLER,
   flipbookAutoplay = false,
+  frame = 0,
   invert = false,
   limitSubjectHeight = false,
   move = false,
@@ -25,13 +26,14 @@ const FlipbookViewer = ({
   onReady = DEFAULT_HANDLER,
   playIterations,
   rotation = 0,
+  setFrame = DEFAULT_HANDLER,
   setOnPan = DEFAULT_HANDLER,
   setOnZoom = DEFAULT_HANDLER,
   subject,
   zoomControlFn = undefined,
   zooming = true
 }) => {
-  const [currentFrame, setCurrentFrame] = useState(defaultFrame)
+  // const [currentFrame, setCurrentFrame] = useState(defaultFrame)
   const [playing, setPlaying] = useState(false)
 
   useEffect(() => {
@@ -66,8 +68,8 @@ const FlipbookViewer = ({
   // only for the sake of determining a consistent viewer width/height for
   // all media files. 
   // --------------------------------
-  const currentMediaType = subject?.locations[currentFrame]?.type
-  const currentMediaUrl = subject?.locations[currentFrame]?.url
+  const currentMediaType = subject?.locations[frame]?.type
+  const currentMediaUrl = subject?.locations[frame]?.url
   // --------------------------------
 
   const onPlayPause = () => {
@@ -82,7 +84,7 @@ const FlipbookViewer = ({
         <SingleImageViewer
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}
-          frame={currentFrame}
+          frame={frame}
           imgRef={mediaElementRef}
           invert={invert}
           limitSubjectHeight={limitSubjectHeight}
@@ -114,9 +116,9 @@ const FlipbookViewer = ({
         />
       )}
       <FlipbookControls
-        currentFrame={currentFrame}
+        currentFrame={frame}
         locations={subject.locations}
-        onFrameChange={setCurrentFrame}
+        onFrameChange={setFrame}
         onPlayPause={onPlayPause}
         playing={playing}
         playIterations={playIterations}
@@ -126,12 +128,14 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
-  /** Fetched from metadata.default_frame or initialized to zero */
+  /** Fetched from metadata.default_frame or initialized to zero ⚠️ WARNING: not actually implemented as of Apr 2026 */
   defaultFrame: PropTypes.number,
   /** Determined per mobx store WorkflowStepStore via SubjectViewer. */
   enableInteractionLayer: PropTypes.bool,
   /** Function passed from Subject Viewer Store */
   enableRotation: PropTypes.func,
+  /** Passed from the subject viewer store. Determins the current frame of the Subject */
+  frame: PropTypes.number,
   /** Fetched from workflow configuration. Determines whether to autoplay the loop on viewer load */
   flipbookAutoplay: PropTypes.bool,
   /** Passed from Subject Viewer Store */
@@ -149,6 +153,8 @@ FlipbookViewer.propTypes = {
   /** Passed from the subject viewer store. Needed in SingleImageViewer to handle transforming (rotating) the image */
   rotation: PropTypes.number,
   /** Usually passed from the Subject Viewer Store. Can be overridden, such as when the FlipbookViewer is used in the DataImageViewer.  */
+  setFrame: PropTypes.func,
+  /** Passed from the Subject Viewer Store */
   setOnPan: PropTypes.func,
   /** Usually passed from the Subject Viewer Store. Can be overridden, such as when the FlipbookViewer is used in the DataImageViewer. */
   setOnZoom: PropTypes.func,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -45,11 +45,8 @@ const FlipbookViewer = ({
   // Also, Subject Viewer Store's resetSubject() ensures that the first `frame`
   // fed to the FlipbookViewer will either be 0, or the default_frame as set by
   // subject.metadata. As a result, the defaultFrame prop of FlipbookViewer is
-  // now ONLY used to determine the dimensions of the "subject frame". (i.e. to
-  // keep all images & videos displayed in a consistent width & height)
-  // Future devs, it should be fairly safe to that defaultFrame prop to a say
-  // const REFERENCE_FRAME = 0 ; it only matters that all frames are displayed
-  // in a consistent size.
+  // now mainly used to determine the dimensions of the "subject frame". (i.e.
+  // to keep all images & videos displayed in a consistent width & height)
 
   const [playing, setPlaying] = useState(false)
 
@@ -146,7 +143,7 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
-  /** Fetched from metadata.default_frame or initialized to zero. ONLY used to determine size of "subject frame" */
+  /** Fetched from metadata.default_frame or initialized to zero. Mainly used to determine size of "subject frame" */
   defaultFrame: PropTypes.number,
   /** Determined per mobx store WorkflowStepStore via SubjectViewer. */
   enableInteractionLayer: PropTypes.bool,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -119,7 +119,7 @@ const FlipbookViewer = ({
         <StyledVideo
           autoPlay={false}
           controls={true}
-          invert={invert}
+          $invert={invert}
           preload='metadata'
           ref={mediaElementRef}
           src={currentMediaUrl}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.jsx
@@ -43,6 +43,12 @@ describe('Component > FlipbookViewer', function () {
 
       const newButtonStyle = window.getComputedStyle(thumbnailButtons[1])
       expect(newButtonStyle.border).to.equal('2px solid rgb(0, 93, 105)')
+
+      // Reset
+      await user.pointer({
+        keys: '[MouseLeft]',
+        target: thumbnailButtons[0]
+      })
     })
 
     it('should handle using arrow keys on the tablist', async function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -81,6 +81,15 @@ function FlipbookViewerContainer({
     return <div>Something went wrong.</div>
   }
 
+  // Figure out the default frame for this Subject, which is usually 0 but can
+  // be overridden by Subject metadata.
+  // This code matches SubjectViewerStore.js's resetSubject()
+  let defaultFrame = 0
+  if (subject?.metadata?.default_frame > 0) {
+    // To the research teams who set the default_frame value, the first item in a list is "1". Hence, we need to change that to Array index "0".
+    defaultFrame = parseInt(subject.metadata.default_frame - 1)
+  }
+
   return (
     <>
       {separateFramesView ? (
@@ -93,6 +102,7 @@ function FlipbookViewerContainer({
         />
       ) : (
         <FlipbookViewer
+          defaultFrame={defaultFrame}
           frame={frame}
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -11,11 +11,12 @@ import SeparateFramesViewer from '../SeparateFramesViewer/SeparateFramesViewer'
 function storeMapper(store) {
   const {
     enableRotation,
-    frame: defaultFrame,
+    frame,
     invert,
     move,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   } = store.subjectViewer
@@ -27,15 +28,16 @@ function storeMapper(store) {
   } = store.workflows?.active?.configuration
 
   return {
-    defaultFrame,
     enableRotation,
     flipbookAutoplay,
+    frame,
     invert,
     limitSubjectHeight,
     move,
     playIterations,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   }
@@ -51,15 +53,16 @@ function FlipbookViewerContainer({
   subject
 }) {
   const {
-    defaultFrame,
     enableRotation,
     flipbookAutoplay,
+    frame,
     invert,
     limitSubjectHeight,
     move,
     playIterations,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   } = useStores(storeMapper)
@@ -90,7 +93,7 @@ function FlipbookViewerContainer({
         />
       ) : (
         <FlipbookViewer
-          defaultFrame={defaultFrame}
+          frame={frame}
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}
           flipbookAutoplay={flipbookAutoplay}
@@ -101,6 +104,7 @@ function FlipbookViewerContainer({
           onReady={onReady}
           playIterations={playIterations}
           rotation={rotation}
+          setFrame={setFrame}
           setOnPan={setOnPan}
           setOnZoom={setOnZoom}
           subject={subject}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -67,8 +67,8 @@ function FlipbookViewerContainer({
     rotation,
     separateFramesView,
     setFrame,
-    setOnPan,
-    setOnZoom
+    setOnPan: storeSetOnPan,
+    setOnZoom: storeSetOnZoom
   } = useStores(storeMapper)
 
   const effectiveSetOnPan = propSetOnPan || storeSetOnPan

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -88,6 +88,15 @@ function FlipbookViewerContainer({
     return <div>Something went wrong.</div>
   }
 
+  // Figure out the default frame for this Subject, which is usually 0 but can
+  // be overridden by Subject metadata.
+  // This code matches SubjectViewerStore.js's resetSubject()
+  let defaultFrame = 0
+  if (subject?.metadata?.default_frame > 0) {
+    // To the research teams who set the default_frame value, the first item in a list is "1". Hence, we need to change that to Array index "0".
+    defaultFrame = parseInt(subject.metadata.default_frame - 1)
+  }
+
   return (
     <>
       {separateFramesView ? (
@@ -100,6 +109,7 @@ function FlipbookViewerContainer({
         />
       ) : (
         <FlipbookViewer
+          defaultFrame={defaultFrame}
           frame={frame}
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -11,11 +11,12 @@ import SeparateFramesViewer from '../SeparateFramesViewer/SeparateFramesViewer'
 function storeMapper(store) {
   const {
     enableRotation,
-    frame: defaultFrame,
+    frame,
     invert,
     move,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   } = store.subjectViewer
@@ -27,15 +28,16 @@ function storeMapper(store) {
   } = store.workflows?.active?.configuration
 
   return {
-    defaultFrame,
     enableRotation,
     flipbookAutoplay,
+    frame,
     invert,
     limitSubjectHeight,
     move,
     playIterations,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   }
@@ -55,17 +57,18 @@ function FlipbookViewerContainer({
   zooming = true
 }) {
   const {
-    defaultFrame,
     enableRotation,
     flipbookAutoplay,
+    frame,
     invert,
     limitSubjectHeight,
     move,
     playIterations,
     rotation,
     separateFramesView,
-    setOnZoom: storeSetOnZoom,
-    setOnPan: storeSetOnPan,
+    setFrame,
+    setOnPan,
+    setOnZoom
   } = useStores(storeMapper)
 
   const effectiveSetOnPan = propSetOnPan || storeSetOnPan
@@ -97,7 +100,7 @@ function FlipbookViewerContainer({
         />
       ) : (
         <FlipbookViewer
-          defaultFrame={defaultFrame}
+          frame={frame}
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}
           flipbookAutoplay={flipbookAutoplay}
@@ -110,6 +113,7 @@ function FlipbookViewerContainer({
           rotation={rotation}
           setOnPan={effectiveSetOnPan}
           setOnZoom={effectiveSetOnZoom}
+          setFrame={setFrame}
           subject={subject}
           zoomControlFn={zoomControlFn}
           zooming={zooming}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.jsx
@@ -183,10 +183,10 @@ const SeparateFrame = ({
             separateFrameMove={separateFrameMove}
             separateFrameEnableMove={separateFrameEnableMove}
           />
-          <ZoomInButton separateFrameZoomIn={separateFrameZoomIn} />
-          <ZoomOutButton separateFrameZoomOut={separateFrameZoomOut} />
-          <RotateButton separateFrameRotate={separateFrameRotate} />
-          <ResetButton separateFrameResetView={separateFrameResetView} />
+          <ZoomInButton overrideDisabled={false} separateFrameZoomIn={separateFrameZoomIn} />
+          <ZoomOutButton overrideDisabled={false} separateFrameZoomOut={separateFrameZoomOut} />
+          <RotateButton overrideDisabled={false} separateFrameRotate={separateFrameRotate} />
+          <ResetButton overrideDisabled={false} separateFrameResetView={separateFrameResetView} />
           <InvertButton separateFrameInvert={separateFrameInvert} />
         </Box>
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.jsx
@@ -199,6 +199,7 @@ const SeparateFrame = ({
         <video
           autoPlay={false}
           controls={true}
+          preload='metadata'
           ref={mediaElementRef}
           src={frameUrl}
           width={mediaWidth}


### PR DESCRIPTION
## PR Overview

Package: lib-classifier
Fixes #7325 
Affects: FlipbookViewer _(and possible SeparateFramesViewer)_

This PR attempts to fix the Image Toolbar's Move/Pan/etc buttons on the Flipbook Viewer, which are disabled when _the first frame of the Subject isn't an image file._

- The Image Toolbar button's on/off settings are determined _by the current frame of the Subject._
- The Flipbook Viewer meanwhile uses _local state_ to keep track of its own separate "current frame".
- The Separate Frames Viewer does its own thing.

🔶 Functional changes:

- FlipbookViewer:
  - (fix) The Image Toolbar now correctly recognises what's the current frame.
  - When the current frame is a video...
    - The zoom, move, rotate, reset buttons on the Image Toolbar are disabled.
    - (fix) Invert Colours button on the Image Toolbar now properly inverts videos.
- SeparateFramesViewer:
  - (no changes, should work as normal)

🔶 Code changes:

- FlipbookViewer:
  - "current frame" value is now set at the _global store_ level, not at the local state level.
  - New params: `frame`, `setFrame` (provided
  - Change of params: `defaultFrame` is kept, but only used to determine the "size of the subject viewer".
- ResetButton, RotateButton, ZoomInButton, ZoomOutButton:
  - New `overrideDisabled` param. Usually, these buttons are only disabled if the Subject Viewer Store says so (as a result of the detected Subject type), but this param allows us to go "nuh-uh, you're enabled/disabled whether you like it or not!"
- SeparateFramesViewer: sets overrideDisabled=false for all buttons, when the attached media item is an image.

<details>
<summary>(Prev notes)</summary>

This PR attempts to implement said fix by:

- Removing FlipbookViewer's _local state_ "current frame", and adding the "current frame" (and "set frame" function) from the Subject Viewer Store.
  - This puts it in line with other viewers like the MultiFrameViewer and ImageAndTextViewer.
- ~~⚠️ TODO: SeparateFramesViewer~~

</details>

Dev Questions:

- Is there a reason why the FlipbookViewer use local state for keeping track of current frame, instead of using the Subject Viewer Store?
  - _Update: local state was used to manage performance. [(comment)](https://github.com/zooniverse/front-end-monorepo/pull/7326#issuecomment-4284021414) Also, it was done to prevent multiple entries to classifications.metadata.subject_dimensions. [(comment)](https://github.com/zooniverse/front-end-monorepo/pull/7326#issuecomment-4284117275) Upon investigatin, performance may not be an issue [(comments 1](https://github.com/zooniverse/front-end-monorepo/pull/7326#issuecomment-4734164459), [2)](https://github.com/zooniverse/front-end-monorepo/pull/7326#issuecomment-4744206848)_
- Why does the Flipbook Viewer's `defaultFrame` prop have a comment that says _"Fetched from metadata.default_frame or initialized to zero"_ ? This clearly hasn't been the case. What metadata.default_frame?
  - _Update: project owners can set subject.metadata.default_frame to set any frame as the "first frame". [(comment)](https://github.com/zooniverse/front-end-monorepo/pull/7326#issuecomment-4284153580)_ 
- [bug] 🎥 When a frame contains a video, the "Invert Colours" button on the Image Toolbar is enabled but doesn't do anything. Should I implement colour inversion, or disable the "Invert Colours" button, or ignore?
  - _Update: yes I should [(comment)](https://github.com/zooniverse/front-end-monorepo/pull/7326#issuecomment-4284170134), and yes I've done. [(comment)](https://github.com/zooniverse/front-end-monorepo/pull/7326#issuecomment-4284721050)_

### Testing

🔶 Test on localhost on app-project.

**Test 1: Flipbook Viewer: subjects with multiple images**

_There should be no behavioural change here. This scenario should have always been working, and should continue to work normally._

- Select a project/wf that uses the Flipbook Viewer, with Subjects consisting of _multiple images_
  - Try Snapshot Wisconsin: https://local.zooniverse.org:3000/projects/zooniverse/snapshot-wisconsin/classify/workflow/32164?env=production&demo=true
- Switch between frames using the Flipbook Controls.
  - Use the Play/Pause button to automatically flip through the Flipbook Viewer.
  - 👁️‍🗨️ Check that the _performance_ "feels OK". (No significant stutter, lag, etc compared to baseline.)
- 🖼️  Ensure the _frames with images_ can be panned/zoomed _using the Ctrl + Mouse Drag action._ 
- 🖼️  Ensure the _frames with images_ can be zoomed, rotated, and reset **using the Image Toolbar buttons.** 

**Test 2: Flipbook Viewer: subjects with images + videos**

- Select a project/wf that uses the Flipbook Viewer, with Subjects consisting of a combination of _images and videos_
  - Try Chimp & See: https://local.zooniverse.org:3000/projects/sassydumbledore/chimp-and-see/classify/workflow/19267?env=production&demo=true
  - **Ensure at least some Subjects contain a video as their _first frame._ This is important.**
- Switch between frames using the Flipbook Controls.
  - Use the Play/Pause button to automatically flip through the Flipbook Viewer.
  - 👁️‍🗨️ Check that the _performance_ "feels OK". (No significant stutter, lag, etc compared to baseline.)
- 🖼️  Ensure the _frames with images_ can be panned/zoomed _using the Ctrl + Mouse Drag action._ 
- 🖼️ ⭐ 🆕 Ensure the _frames with images_ can be zoomed, rotated, and reset **using the Image Toolbar buttons.** 
- 🎥 Ensure the _frames with videos_ CAN'T be panned/zoomed using the Image Toolbar buttons. 
- 🎥 Ensure the _frames with videos_ can have their colours inverted.

**Test 3: Separate Frames Viewer: subjects with images + videos**

- Select the same project as "Flipbook Viewer: subjects with images + videos". (We want to ensure the same testing criteria.)
- Switch from Flipbook Viewer to Separate Frames Viewer by pressing the mysterious button in the flipbook controls.
- 🎥 For EACH _frame with a video,_ ensure that the Image Toolbar doesn't exist.[^1]
- 🖼️ For EACH _frame with an image,_ ensure that the Image Toolbar is enabled.
  - Pan and zoom using Ctrl + Mouse Drag action
  - Zoom/reset/rotate/etc using Image Toolbar buttons.

[^1]: This does mean that, strangely, you can't invert the colour of videos on the Separate Frames Viewer. This is consistent with existing behaviour, but I'm not sure if this is intended or not.[^2]
[^2]: Y'see, the "ImageToolbar" in the SeparateFrame component is actually _pseudo toolbar_ - it's a collection of buttons arranged to _look_ like the actual ImageToolbar component, and it's _only_ added when the media type is 'image'. That said, it's simple enough for me to spin up a new PR to make the pseudo toolbar consistent for _both_ image and video types, if we want.

### Status

~~WIP~~

Update 2026.06.19: this PR is now ready for review! This PR has been updated "release-ready" notes, marked with 🔶.
