### PR TITLE
Add Catalan translations dictionaries for the project pages

### DIFF
--- a/packages/app-project/public/locales/ca/ca.json
+++ b/packages/app-project/public/locales/ca/ca.json
@@ -1,0 +1,5 @@
+{
+  "project": {
+    "disclaimer_copy": "Aquest projecte s’ha creat amb el Zooniverse Project Builder, però encara no és un projecte oficial de Zooniverse. Les consultes i incidències relacionades amb aquest projecte dirigides a l’equip de Zooniverse poden no rebre cap resposta."
+  }
+}

--- a/packages/app-project/public/locales/ca/components.json
+++ b/packages/app-project/public/locales/ca/components.json
@@ -1,0 +1,141 @@
+{
+  "404": {
+    "findNewProject": "Troba un nou projecte per explorar",
+    "heading": "No hi ha res aquí.",
+    "message": "La pàgina que busques ja no existeix.",
+    "returnHome": "Torna a la pàgina d'inici"
+  },
+  "Announcements": {
+    "AuthenticationInvitation": {
+      "announcement": "Si us plau, inicia sessió o registra’t per fer el seguiment de les teves contribucions.",
+      "register": "Registra’t",
+      "signIn": "iniciar sessió"
+    },
+    "FinishedAnnouncement": {
+      "announcement": "Acabat! Sembla que aquest projecte no té dades en aquest moment!",
+      "seeResults": "Veure resultats"
+    }
+  },
+  "CollectionsModal": {
+    "CreateCollection": {
+      "createButton": "Crea i afegeix",
+      "label": "Crea una col·lecció nova",
+      "private": "Col·lecció privada"
+    },
+    "SelectCollection": {
+      "addButton": "Afegeix",
+      "label": "Afegeix a una col·lecció existent"
+    },
+    "title": "Afegeix a la col·lecció"
+  },
+  "ConnectWithProject": {
+    "ProjectLink": {
+      "types": {
+        "bitbucket": "Bitbucket",
+        "bluesky": "BlueSky",
+        "facebook": "Facebook",
+        "github": "GitHub",
+        "instagram": "Instagram",
+        "mastodon": "Mastodon",
+        "medium": "Medium",
+        "pinterest": "Pinterest",
+        "reddit": "Reddit",
+        "tumblr": "Tumblr",
+        "twitter": "Twitter",
+        "website": "Lloc web",
+        "weibo": "Weibo",
+        "wordpress": "WordPress",
+        "youtube": "YouTube"
+      }
+    },
+    "title": "Connecta amb {{projectName}}"
+  },
+  "Head": {
+    "defaultDescription": "Zooniverse és la plataforma més gran i popular del món per a la recerca impulsada per persones.",
+    "defaultTitle": "Projectes",
+    "siteName": "Zooniverse - Recerca impulsada per persones"
+  },
+  "ProjectHeader": {
+    "ApprovedIcon": {
+      "title": "Aprovat per Zooniverse"
+    },
+    "Avatar": {
+      "alt": "Avatar del projecte per a {{project}}"
+    },
+    "LocaleSwitcher": {
+      "label": "Canvia l'idioma"
+    },
+    "ProjectNav": {
+      "ariaLabel": "Projecte"
+    },
+    "UnderReviewLabel": {
+      "underReview": "En revisió"
+    },
+    "about": "Quant a",
+    "admin": "Pàgina d'administració",
+    "classify": "Classificar",
+    "collect": "Recull",
+    "exploreProject": "Explora el projecte",
+    "organization": "Des de l'organització:",
+    "recents": "Recents",
+    "talk": "Parla"
+  },
+  "ProjectStatistics": {
+    "byTheNumbers": "Per xifres",
+    "classifications": "Classificacions",
+    "completedSubjects": "Objectes completats",
+    "percentComplete": "Percentatge complet",
+    "subjects": "Objectes",
+    "subtitle": "Fes un seguiment del progrés que tu i la resta de voluntaris heu fet en aquest projecte.",
+    "text": "Cada clic compta! Uneix-te a la comunitat de {{projectName}} per completar aquest projecte i ajudar els investigadors a obtenir resultats importants. Fes clic a “Veure més estadístiques” per veure encara més dades.",
+    "title": "{{projectName}} Estadístiques",
+    "viewMoreStats": "Veure més estadístiques",
+    "volunteers": "Voluntaris"
+  },
+  "RequireUser": {
+    "text": "Cal que inicieu la sessió!"
+  },
+  "StandardLayout": {
+    "headerLabel": "Capçalera del lloc de Zooniverse"
+  },
+  "SubjectPicker": {
+    "alreadySeen": "Ja vist",
+    "back": "Tria un conjunt d’objectes diferent",
+    "byline": "Ordena la llista fent clic als noms de les columnes. Veuràs els objectes seqüencialment, començant pel que triïs.",
+    "fetching": "Si us plau, espera...",
+    "heading": "Tria un objecte per començar",
+    "retired": "Retirat",
+    "unclassified": "Disponible"
+  },
+  "SubjectPreview": {
+    "CollectionsButton": {
+      "add": "Afegeix a col·leccions"
+    },
+    "TalkLink": {
+      "label": "Debateix a Talk"
+    }
+  },
+  "SubjectSetPicker": {
+    "SubjectSetCard": {
+      "isComplete": "Acabat"
+    },
+    "back": "Tria un flux de treball diferent",
+    "byline": "Tria un conjunt d’objectes per començar a transcriure.",
+    "heading": "Tria per on començar"
+  },
+  "WorkflowSelector": {
+    "WorkflowSelectButton": {
+      "complete": "{{completeness}}% completat",
+      "setSelection": "Trieu selecció",
+      "subjectSelection": "selecció d'objectes"
+    },
+    "WorkflowSelectButtons": {
+      "locked": "bloquejat",
+      "unlocked": "desbloquejat"
+    },
+    "error": "S’ha produït un error en obtenir els fluxos de treball :(",
+    "getStarted": "Comença!",
+    "message": "Pots fer una investigació real fent clic aquí per començar.",
+    "noWorkflows": "Res per classificar"
+  }
+}

--- a/packages/app-project/public/locales/ca/screens.json
+++ b/packages/app-project/public/locales/ca/screens.json
@@ -1,0 +1,79 @@
+{
+  "About": {
+    "PageHeading": {
+      "title": {
+        "education": "Educació",
+        "faq": "Preguntes freqüents",
+        "research": "Recerca",
+        "results": "Resultats",
+        "team": "L’equip"
+      }
+    },
+    "PageNav": {
+      "title": "Sobre el projecte"
+    },
+    "SidebarHeading": "Quant a",
+    "TeamMember": {
+      "collaborator": "Col·laborador",
+      "expert": "Expert",
+      "moderator": "Moderador",
+      "museum": "Museu",
+      "owner": "Propietari",
+      "researcher": "Investigador\/a",
+      "tester": "Provador",
+      "translator": "Traductor"
+    }
+  },
+  "Classify": {
+    "ClassifierWrapper": {
+      "ErrorMessage": {
+        "title": "S’ha produït un error en el classificador :("
+      }
+    },
+    "RecentSubjects": {
+      "text": "Debateix un objecte a Talk o afegeix-lo als teus favorits o a una col·lecció.",
+      "title": "Les teves classificacions recents"
+    },
+    "WorkflowAssignmentModal": {
+      "cancel": "No, gràcies",
+      "confirm": "Porta’m al següent flux de treball!",
+      "content": "Enhorabona! Com que ho estàs fent molt bé, ara pots accedir a un altre flux de treball. Si prefereixes continuar amb el flux de treball actual, pots triar quedar-t’hi.",
+      "dismiss": "No tornis a mostrar això en aquesta sessió",
+      "title": "Nou flux de treball disponible"
+    },
+    "YourStats": {
+      "allTime": "Tot el temps",
+      "lastSeven": "Darrers 7 dies",
+      "link": "Veure més",
+      "title": "Les teves estadístiques"
+    }
+  },
+  "Home": {
+    "AboutProject": {
+      "title": "Quant a {{projectName}}"
+    },
+    "Hero": {
+      "Introduction": {
+        "link": "Aprèn més"
+      },
+      "NotApproved": {
+        "paragraph": "Aquest projecte s’ha creat amb el Zooniverse Project Builder, però encara no és un projecte oficial de Zooniverse. Les consultes i incidències relacionades amb aquest projecte dirigides a l’equip de Zooniverse poden no rebre cap resposta."
+      }
+    },
+    "MessageFromResearcher": {
+      "noMessage": "Connecta amb l’equip de recerca a Parlem per saber més sobre aquest projecte.",
+      "noMessageButton": "Ves a Parlem",
+      "title": "Missatge de l'investigador"
+    },
+    "ZooniverseTalk": {
+      "RecentSubjects": {
+        "error": "S’ha produït un error en carregar els objectes :(",
+        "noSubjects": "Sembla que encara ningú no ha comentat cap objecte. Ves a Parlem i sigues el primer!",
+        "subjectLabel": "Objecte {{id}}"
+      },
+      "button": "Uneix-te",
+      "message": "Parla amb l’equip de recerca i amb altres voluntaris.",
+      "title": "Parlem"
+    }
+  }
+}

--- a/packages/lib-classifier/src/translations/ca/components.json
+++ b/packages/lib-classifier/src/translations/ca/components.json
@@ -1,0 +1,287 @@
+{
+  "Banners": {
+    "AlreadySeenBanner": {
+      "bannerText": "Ja has vist aquest objecte",
+      "tooltipText": [
+        "Ja has vist i classificat aquest objecte, de manera que les classificacions posteriors no s’utilitzaran en la seva anàlisi.",
+        "Si estàs buscant ajuda, prova de seleccionar un flux de treball diferent o contribuir en un projecte diferent."
+      ]
+    },
+    "Banner": {
+      "next": "Següent",
+      "previous": "Anterior",
+      "whyAmISeeingThis": "Per què veig això?"
+    },
+    "InProgressConfirmModal": {
+      "cancel": "Cancel·la",
+      "confirm": "D’acord",
+      "inProgress": "En tornar, s’esborrarà el teu treball de la tasca actual."
+    },
+    "RetiredBanner": {
+      "bannerText": "Acabat: aquest objecte s’ha retirat",
+      "tooltipText": [
+        "Aquest objecte ja té prou classificacions, de manera que les teves no s’utilitzaran en la seva anàlisi.",
+        "Si estàs buscant ajuda, prova de seleccionar un flux de treball diferent o contribuir en un projecte diferent."
+      ]
+    },
+    "SubjectSetProgressBanner": {
+      "alreadySeen": "Ja s'ha vist",
+      "bannerText": "{{setName}}: objecte {{number}}\/{{total}}",
+      "finished": "Acabat",
+      "tooltipText": [
+        "Aquest projecte permet als voluntaris veure els objectes en ordre seqüencial.",
+        "El número et mostra la posició de l’objecte dins del conjunt total."
+      ]
+    },
+    "UserHasFinishedWorkflowBanner": {
+      "bannerText": "Acabat: ho has vist tot",
+      "tooltipText": [
+        "Ja has classificat tot en aquest flux de treball, de manera que les classificacions posteriors no s’utilitzaran en la seva anàlisi.",
+        "Si estàs buscant ajuda, prova de seleccionar un flux de treball diferent o contribuir en un projecte diferent."
+      ]
+    },
+    "WorkflowIsFinishedBanner": {
+      "bannerText": "Aquest flux de treball s’ha acabat",
+      "tooltipText": [
+        "S’han completat tots els objectes en aquest flux de treball, de manera que les classificacions posteriors no s’utilitzaran en la seva anàlisi.",
+        "Si estàs buscant ajuda, prova de seleccionar un flux de treball diferent o contribuir en un projecte diferent."
+      ]
+    }
+  },
+  "DrawingTools": {
+    "RotateHandle": "Nansa per rotar l’anotació\/marca dibuixada."
+  },
+  "FeedbackModal": {
+    "keepClassifying": "Continua classificant",
+    "label": "Comentaris"
+  },
+  "FieldGuide": {
+    "FieldGuideButton": {
+      "buttonLabel": "Guia de camp"
+    },
+    "FieldGuideItem": {
+      "ariaTitle": "Torna a la llista d’elements de la guia de camp"
+    },
+    "FieldGuideItemAnchor": {
+      "ariaTitle": "Selecciona {{title}}"
+    },
+    "title": "Guia de camp"
+  },
+  "ImageToolbar": {
+    "AnnotateButton": {
+      "ariaLabel": "Anota"
+    },
+    "FullscreenButton": {
+      "ariaLabel": {
+        "actualSize": "Mostra l’objecte a mida normal",
+        "fullscreen": "Mostra l’objecte en mode de pantalla completa"
+      }
+    },
+    "InvertButton": {
+      "ariaLabel": "Inverteix el tema"
+    },
+    "MoveButton": {
+      "ariaLabel": "Mou l’objecte"
+    },
+    "ResetButton": {
+      "ariaLabel": "Restableix la vista de l’objecte"
+    },
+    "RotateButton": {
+      "ariaLabel": "Gira l’objecte"
+    },
+    "ZoomInButton": {
+      "ariaLabel": "Apropa el zoom a l’objecte"
+    },
+    "ZoomOutButton": {
+      "ariaLabel": "Allunya el zoom de l’objecte"
+    }
+  },
+  "MetaTools": {
+    "CollectionsButton": {
+      "add": "Afegeix a col·leccions"
+    },
+    "HidePreviousMarksDrawingButton": {
+      "hide": "Amaga les marques anteriors",
+      "show": "Mostra les marques anteriors"
+    },
+    "HidePreviousTranscriptionsButton": {
+      "hide": "Amaga totes les marques",
+      "show": "Mostra totes les marques",
+      "showUser": "Mostra les teves marques"
+    },
+    "MetadataButton": {
+      "label": "Informació del tema"
+    },
+    "MetadataModal": {
+      "table": {
+        "label": "Etiqueta",
+        "value": "Valor"
+      },
+      "title": "Metadades del tema"
+    }
+  },
+  "ModalTutorial": {
+    "title": "Tutorial"
+  },
+  "QuickTalk": {
+    "aria": {
+      "closeButton": "Tanca el panell de comentaris",
+      "goToTalk": "Tanca el panell de comentaris",
+      "mainPanel": "Panell de comentaris QuickTalk",
+      "openButton": "Aquest tema té {{count}} comentari(s). Feu clic per desplegar.",
+      "panelContent": "Comentaris del debat del tema",
+      "panelHeading": "Debat del tema"
+    },
+    "errors": {
+      "failPostComment": "No s’han pogut afegir comentaris a la discussió existent.",
+      "failPostDiscussion": "No s’han pogut afegir comentaris a la nova discussió.",
+      "noBoard": "Encara no s’ha configurat un tauler de comentaris per a aquest tema en aquest projecte.",
+      "noText": "No es pot publicar un comentari buit.",
+      "noUser": "Usuari no connectat."
+    },
+    "loginToPost": "Si us plau, inicieu la sessió per publicar un comentari.",
+    "status": {
+      "initialized": "Deixa una nota sobre aquest tema\\n",
+      "loading": "Publicant el comentari...",
+      "success": "Comentari publicat!"
+    },
+    "subjectHasNoComments": "Aquest tema encara no té cap comentari."
+  },
+  "SlideTutorial": {
+    "StepNavigation": {
+      "go": "Ves al pas {{index}}",
+      "next": "Ves al pas següent",
+      "previous": "Ves al pas anterior"
+    },
+    "alt": "Pas del tutorial {{activeStep}}",
+    "error": "No s’ha pogut carregar el pas del tutorial.",
+    "getStarted": "Comença",
+    "heading": "{{projectDisplayName}} Tutorial"
+  },
+  "StepNavigation": {
+    "go": "Ves al pas següent {{index}}",
+    "next": "Ves al pas anterior",
+    "previous": "Ves al pas anterior"
+  },
+  "SubjectViewer": {
+    "BarChartViewer": {
+      "chartLabel": "Gràfic de barres"
+    },
+    "ImageAndTextViewer": {
+      "textIconAltText": "Icona per al visor de text"
+    },
+    "InteractionLayer": {
+      "ConfirmModal": {
+        "close": "Tanca sense desar",
+        "keepWorking": "Continua treballant"
+      },
+      "SaveButton": {
+        "save": "Desa i tanca"
+      },
+      "SubTaskPopup": {
+        "notRender": "No s’ha pogut mostrar el component de la tasca.",
+        "required": "Aquesta tasca és obligatòria."
+      },
+      "TranscribedLines": {
+        "ConsensusPopup": {
+          "aggregatedTranscription": "transcripció agregada",
+          "explanation": "Aquestes {{count}} transcripcions han estat enviades per voluntaris anteriors i no es poden modificar.",
+          "noAggregation": "No hi ha agregació disponible",
+          "title": "Transcripcions anteriors",
+          "transcriptionsUnavailable": "Transcripcions no disponibles"
+        },
+        "complete": "Transcripció completada",
+        "transcribed": "Té transcripcions"
+      }
+    },
+    "MultiFrameViewer": {
+      "FrameCarousel": {
+        "nextFrameLabel": "Següent",
+        "previousFrameLabel": "Anterior",
+        "thumbnailAltText": "Miniatura de la imatge"
+      }
+    },
+    "ScatterPlotViewer": {
+      "Selection": {
+        "delete": "Elimina la selecció {{index}}"
+      }
+    },
+    "SeparateFramesViewer": {
+      "ViewModeButton": {
+        "switchToFlipbook": "Canvia a la vista de llibre fullejable",
+        "switchToSeparateFrames": "Canvia a la vista de fotogrames separats"
+      }
+    },
+    "SingleVideoViewerContainer": {
+      "error": "S’ha produït un error en carregar l’element."
+    },
+    "VariableStarViewer": {
+      "controls": "controls",
+      "figCaption": "Diagrama HR",
+      "flip": "Inverteix",
+      "focus": "Enfoca",
+      "highlight": "Ressalta",
+      "imageTitle": "Diagrama HR: lluminositat vs temperatura",
+      "label": "Filtre {{id}}",
+      "periodMultiple": "Múltiple del període",
+      "phase": "Fase",
+      "phaseFocus": "Focus de fase"
+    },
+    "VideoController": {
+      "closeVolume": "Tanca el control de volum",
+      "fullscreen": "Mostra el vídeo a pantalla completa",
+      "openVolume": "Obre el control de volum",
+      "pause": "Pausa el vídeo",
+      "play": "Reprodueix el vídeo",
+      "playbackSpeed": "Selecció de la velocitat de reproducció del vídeo",
+      "scrubber": "Control de desplaçament del reproductor de vídeo",
+      "volumeSlider": "Control de volum"
+    },
+    "ZoomControlButton": {
+      "disable": "desactiva el zoom",
+      "enable": "activa el zoom"
+    },
+    "loading": "Carregant un element",
+    "zoomHelp": "Fes servir CTRL + la roda del ratolí per fer zoom"
+  },
+  "TaskArea": {
+    "DisabledTaskPopup": {
+      "body": "Aquest tema ja té prou classificacions, així que qualsevol classificació addicional enviada no s’utilitzarà en la seva anàlisi. Encara podeu consultar aquest tema com a referència.",
+      "options": {
+        "dismiss": "Descarta",
+        "next": "Següent tema disponible",
+        "select": "Tria un tema nou"
+      },
+      "title": "Acabat"
+    },
+    "Tasks": {
+      "BackButton": {
+        "back": "Enrere"
+      },
+      "DoneAndTalkButton": {
+        "doneAndTalk": "Fet i comenta",
+        "newTab": "en una pestanya nova"
+      },
+      "DoneButton": {
+        "done": "Fet"
+      },
+      "ExpertOptions": {
+        "demoToggle": "Mode de demostració",
+        "label": "Opcions d'expert"
+      },
+      "NextButton": {
+        "next": "Següent"
+      },
+      "TaskHelp": {
+        "close": "Tanca",
+        "label": "Necessites ajuda amb aquesta tasca?"
+      },
+      "demoMode": "En mode de demostració, les classificacions no es desaran. Utilitzeu-ho per a demostracions ràpides i inexactes de la interfície de classificació.",
+      "error": "Alguna cosa ha fallat",
+      "loading": "Carregant",
+      "renderFallback": "No s’ha pogut mostrar el component de la tasca."
+    },
+    "task": "Tasca",
+    "tutorial": "Tutorial"
+  }
+}

--- a/packages/lib-classifier/src/translations/ca/plugins.json
+++ b/packages/lib-classifier/src/translations/ca/plugins.json
@@ -1,0 +1,75 @@
+{
+  "FreehandLine": {
+    "active": "Fes clic i arrossega des del punt inicial fins al punt final o fes doble clic a qualsevol punt de la línia per crear un punt de tall",
+    "closePoint": "Fes clic a qualsevol punt de la línia per establir el punt final",
+    "inactive": "Feu clic per editar aquesta línia",
+    "spliceDrag": "Fes clic i arrossega des del punt inicial fins al punt final",
+    "splicePoint": "Fes doble clic a qualsevol punt de la línia per crear un punt de tall"
+  },
+  "HighlighterTask": {
+    "delete": "Elimina",
+    "noLabels": "No hi ha etiquetes per a la tasca de ressaltador",
+    "status": "{{count}} Marcat"
+  },
+  "InputStatus": {
+    "drawn": "{{count}} dibuixats",
+    "max": "{{count}} de {{max}} dibuixats com a màxim",
+    "maxAndMin": "Calen {{count}} de {{min}} dibuixats, {{max}} com a màxim",
+    "min": "Calen {{count}} de {{min}} dibuixats"
+  },
+  "LineControls": {
+    "close": "Tanca",
+    "delete": "Elimina",
+    "deleteCancel": "Cancel·la l’eliminació",
+    "deleteConfirm": "Confirma l'eliminació",
+    "lineControls": "Controls de línia",
+    "move": "Mou",
+    "redo": "Refer",
+    "undo": "Desfer"
+  },
+  "SimpleDropdownTask": {
+    "customInputPlaceholder": "Introdueix alguna cosa",
+    "otherLabel": "Una altra...",
+    "selectPlaceholder": "Tria una resposta"
+  },
+  "SurveyTask": {
+    "CharacteristicsFilter": {
+      "clearFilters": "Esborra els filtres",
+      "closeFilters": "Tanca els filtres",
+      "filter": "Filtre",
+      "removeFilter": "Elimina {{valueLabel}} filtre",
+      "showing": "Mostrant {{showing}} de {{total}}"
+    },
+    "Choice": {
+      "cancel": "Cancel·la",
+      "identify": "Identifica",
+      "lessInfo": "Menys informació",
+      "moreInfo": "Més informació",
+      "notThis": "Això no"
+    },
+    "ChoiceButton": {
+      "identified": "identificat",
+      "openSubmenu": "Obre el submenú per a {{choiceLabel}}"
+    },
+    "ConfusedWith": {
+      "cancel": "Cancel·la",
+      "confused": "Sovint confós amb",
+      "itsThis": "Crec que és això"
+    },
+    "DeleteButton": {
+      "delete": "Elimina la selecció {{choiceLabel}}"
+    }
+  },
+  "TextFromSubjectTask": {
+    "reset": "Restableix"
+  },
+  "TextTask": {
+    "TextTagButtons": {
+      "modifiers": "Modificadors de text"
+    }
+  },
+  "TranscriptionLine": {
+    "created": "Transcripció creada",
+    "editing": "Edició de la transcripció"
+  }
+}

--- a/packages/lib-classifier/src/translations/i18n.jsx
+++ b/packages/lib-classifier/src/translations/i18n.jsx
@@ -10,6 +10,7 @@ const namespaces = ['components', 'plugins']
 const supportedLngs = [
   'ar', // Arabic
   'bn', // Bengali
+  'ca', // Catalan
   'cs', // Czech
   'da', // Danish
   'de', // German

--- a/packages/lib-react-components/src/translations/ca.json
+++ b/packages/lib-react-components/src/translations/ca.json
@@ -1,0 +1,171 @@
+{
+  "AdminCheckbox": {
+    "label": "Mode administrador"
+  },
+  "AuthModal": {
+    "LoginForm": {
+      "error": "El nom d'usuari o la contrasenya són incorrectes",
+      "forgot": "Has oblidat la contrasenya?",
+      "heading": "Benvingut\/da de nou!",
+      "instruction": "Ens alegra que hagis tornat! Inicia sessió per continuar on ho vas deixar.",
+      "login": "Nom d’usuari o adreça electrònica",
+      "password": "Contrasenya",
+      "placeholder": "p. ex. ZooniverseFan123",
+      "signIn": "Inicia sessió"
+    },
+    "RegisterForm": {
+      "betaListSignUp": "M’agradaria ajudar a provar nous projectes i rebre un correu electrònic quan estiguin disponibles (opcional)",
+      "email": "Adreça electrònica (obligatori)",
+      "emailConfirm": "Confirma l’adreça electrònica (obligatori)",
+      "emailConfirmError": "Les adreces electròniques no coincideixen. Torna-ho a provar.",
+      "emailConflict": "Ja existeix un compte amb aquesta adreça",
+      "emailListSignUp": "Accepto rebre correus electrònics de tant en tant (opcional)",
+      "emailPlaceholder": "p. ex. zoofan31@gmail.com",
+      "forgot": "Has oblidat la contrasenya?",
+      "heading": "Benvingut\/da de nou!",
+      "instruction": "Si us plau, crea un compte per començar a fer recerca real.",
+      "password": "Contrasenya (obligatori)",
+      "passwordConfirm": "Confirma la contrasenya (obligatori)",
+      "passwordConfirmError": "Les contrasenyes no coincideixen. Torna-ho a provar.",
+      "privacyAgreement": "Acceptes la nostra política de privacitat (obligatori)",
+      "privacyAgreementError": "És obligatori acceptar la política de privacitat.",
+      "privacyLink": "Llegeix la nostra política de privacitat",
+      "realName": "Nom real (opcional)",
+      "realNameHelp": "Ho utilitzarem per donar-te crèdit en articles científics, pòsters, etc.",
+      "realNamePatternHelp": "Introdueix un nom, no una adreça electrònica",
+      "realNamePlaceholder": "p. ex. Maggie Smith",
+      "register": "Registra't",
+      "registering": "Registrant…",
+      "underageConsent": "Confirmo que soc el pare, mare o tutor legal i dono permís perquè el meu fill o filla es registri proporcionant la meva adreça electrònica com a adreça de contacte principal. Tant jo com el meu fill o filla entenem i acceptem la política de privacitat (obligatori)",
+      "underageEmail": "Adreça electrònica del pare, mare o tutor legal (obligatori)",
+      "underageEmailSignUp": "Si hi estàs d’acord, t’enviarem periòdicament correus electrònics per promocionar nous projectes de recerca o altra informació relacionada amb la nostra recerca. No utilitzarem la teva informació de contacte amb finalitats comercials. (opcional)",
+      "underageNotRealName": "Utilitzaràs aquest nom per iniciar sessió. Es mostrarà públicament. No facis servir el teu nom real.",
+      "underageWithParent": "Si tens menys de 16 anys, marca aquesta casella per confirmar que has completat el formulari amb el teu pare, mare o tutor legal.",
+      "username": "Nom d'usuari (obligatori)",
+      "usernameConflict": "Aquest nom d’usuari ja està en ús",
+      "usernameHelp": "Això es mostrarà públicament als fòrums, etc.",
+      "usernamePatternHelp": "Els noms d'usuari només poden contenir lletres, números, '.', '-' i '_'",
+      "usernamePlaceholder": "p. ex. ZooniverseFan123"
+    },
+    "title": "Inicia sessió o crea un compte nou."
+  },
+  "CloseButton": {
+    "close": "Tanca"
+  },
+  "FavouritesButton": {
+    "add": "Afegeix als preferits",
+    "remove": "Afegit als preferits"
+  },
+  "Loader": {
+    "loading": "Carregant"
+  },
+  "ProjectCard": {
+    "classifications": "Classificacions",
+    "finished": "Finalitzat",
+    "paused": "En pausa",
+    "state": "Estat"
+  },
+  "ZooFooter": {
+    "aboutLabels": {
+      "about": "Sobre",
+      "acknowledgements": "Agraïments",
+      "contact": "Contacte",
+      "faq": "PMF",
+      "publications": "Publicacions",
+      "resources": "Recursos",
+      "team": "Equip"
+    },
+    "buildLabels": {
+      "bestPractices": "Bones pràctiques",
+      "buildAProject": "Crea un projecte",
+      "glossary": "Glossari",
+      "policies": "Polítiques",
+      "tutorial": "Tutorial"
+    },
+    "getInvolvedLabels": {
+      "callForProjects": "Crida de projectes",
+      "collaborate": "Col·laborar",
+      "collections": "Col·leccions",
+      "donate": "Donar",
+      "educate": "Educar",
+      "education": "Educació",
+      "getInvolved": "Implica't",
+      "volunteer": "Voluntari"
+    },
+    "newsLabels": {
+      "blog": "Bloc",
+      "dailyZooniverse": "Zooniverse diari",
+      "news": "Notícies"
+    },
+    "policyLabels": {
+      "jobs": "Feines",
+      "privacyPolicy": "Política de privacitat",
+      "security": "Seguretat",
+      "systemStatus": "Estat del sistema"
+    },
+    "projectLabels": {
+      "arts": "Arts",
+      "biology": "Biologia",
+      "climate": "Clima",
+      "history": "Història",
+      "language": "Llengua",
+      "literature": "Literatura",
+      "medicine": "Medicina",
+      "nature": "Natura",
+      "physics": "Física",
+      "projects": "Projectes",
+      "social": "Ciències socials",
+      "space": "Espai"
+    },
+    "tagLine": "Recerca impulsada per persones",
+    "talkLabels": {
+      "announcements": "Anuncis",
+      "data": "Processament de dades",
+      "projectBuilding": "Creació de projectes",
+      "talk": "Parlem",
+      "troubleshooting": "Resolució de problemes"
+    },
+    "zooniversePolicies": "Polítiques de Zooniverse"
+  },
+  "ZooHeader": {
+    "SignedInUserNavigation": {
+      "ariaLabel": "Compte d'usuari",
+      "navListLabels": {
+        "messages_one": "Missatges ({{count}})",
+        "messages_other": "Missatges ({{count}})",
+        "messages_zero": "Missatges",
+        "notifications_one": "Notificacions ({{count}})",
+        "notifications_other": "Notificacions ({{count}})",
+        "notifications_zero": "Notificacions"
+      }
+    },
+    "SignedOutUserNavigation": {
+      "register": "Registra't",
+      "signIn": "Inicia sessió"
+    },
+    "ThemeModeToggle": {
+      "switchToDark": "Canvia al tema fosc",
+      "switchToLight": "Canvia a tema clar"
+    },
+    "UserMenu": {
+      "userNavListLabels": {
+        "collections": "Col·leccions",
+        "favorites": "Preferits",
+        "profile": "Perfil",
+        "settings": "Configuració",
+        "signOut": "Tanca la sessió"
+      }
+    },
+    "ariaLabel": "Lloc web",
+    "mainHeaderNavListLabels": {
+      "about": "Quant a",
+      "build": "Construeix",
+      "getInvolved": "Implica't",
+      "projects": "Projectes",
+      "talk": "Parlem"
+    }
+  },
+  "ZooniverseLogo": {
+    "title": "Logotip de Zooniverse"
+  }
+}

--- a/packages/lib-react-components/src/translations/i18n.js
+++ b/packages/lib-react-components/src/translations/i18n.js
@@ -5,6 +5,7 @@ import { initReactI18next, useTranslation as useBaseTranslation } from 'react-i1
 const supportedLngs = [
   'ar', // Arabic
   'bn', // Bengali
+  'ca', // Catalan
   'cs', // Czech
   'da', // Danish
   'de', // German


### PR DESCRIPTION
- Adds complete Catalan (`ca`) dictionaries to app-project, lib-classifier, and lib-react-components
- Imports the dictionaries in lib-classifier and LRC's i18next config files