### PR TITLE
Block cache purge until deployment rollouts are successful

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -60,6 +60,7 @@ jobs:
     - name: Block until rollout is complete
       run: |
         kubectl rollout status deployment/zooniverse-org-root-production --timeout=10m
+        kubectl rollout status deployment/zooniverse-org-project-production --timeout=10m
 
   purge_cache:
     name: Purge AFD cache

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -57,8 +57,12 @@ jobs:
       run: |
         sed 's/__IMAGE_TAG__/${{ github.sha }}/g' kubernetes/deployment-production.tmpl | kubectl apply -f -
 
+    - name: Block until rollout is complete
+      run: |
+        kubectl rollout status deployment/zooniverse-org-root-production --timeout=10m
+
   purge_cache:
-    name: Purge cached file
+    name: Purge AFD cache
     needs: [build_and_push_image, deploy_production]
     uses: zooniverse/ci-cd/.github/workflows/purge_cache.yaml@main
     with:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -60,6 +60,7 @@ jobs:
     - name: Block until rollout is complete
       run: |
         kubectl rollout status deployment/zooniverse-org-root-staging --timeout=10m
+        kubectl rollout status deployment/zooniverse-org-project-staging --timeout=10m
 
   purge_staging_cache:
     name: Purge cache path

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -57,6 +57,10 @@ jobs:
       run: |
         sed 's/__IMAGE_TAG__/${{ github.sha }}/g' kubernetes/deployment-staging.tmpl | kubectl apply -f -
 
+    - name: Block until rollout is complete
+      run: |
+        kubectl rollout status deployment/zooniverse-org-root-staging --timeout=10m
+
   purge_staging_cache:
     name: Purge cache path
     needs: [build_and_push_image, deploy_staging]


### PR DESCRIPTION
Commands executed by the deploy actions are roughly async: the template apply will complete successfully, indicating that the rollout has begun and the pods are rolling. The cache purge command will start the process, but propagation will take however long it takes. 

When a deploy action is triggered and the template apply is successful, the cache purge can be started before the new pods are ready. It's possible that the CDN's requests return old content which is then cached. 

This change blocks the deploy workflows from continuing to the cache purge step until the rollout is successful, with a 10 minute timeout. This will also serve as a check to ensure that the run fails if the deployments don't actually successfully result in new app pods. Both deployments get checked sequentially and the second command finishes executing instantly if the second rollout was finished during the wait for the first. This shouldn't add more than 30-60s to the run time.

## Package

## Linked Issue and/or Talk Post

## Describe your changes

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/main/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

### Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)

### Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).
