### PR TITLE
lib-classifier: Hide line controls while user is drawing

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.jsx
@@ -1,4 +1,5 @@
 import { forwardRef, useState } from 'react'
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import styled, { withTheme } from 'styled-components'
 import { Tooltip } from '@zooniverse/react-components'
@@ -199,6 +200,16 @@ const LineControls = forwardRef(function LineControls({
 
   const buttons = (showDeleteButtons) ? deleteButtons : defaultButtons
 
+  /*
+   * Hide the controls if the user is drawing.
+   * This is handled here rather than in LineControlsContainer to preserve
+   * the position of the controls.
+  */
+  
+  if (mark.isDragging) {
+    return null
+  }
+
   return (
     <StyledSVG 
       width={`${WIDTH}`} 
@@ -253,10 +264,11 @@ const LineControls = forwardRef(function LineControls({
 LineControls.propTypes = {
   mark: PropTypes.shape({
     close: PropTypes.func,
+    isDragging: PropTypes.bool,
     redo: PropTypes.func,
     undo: PropTypes.func
   }),
   onDelete: PropTypes.func
 }
 
-export default withTheme(LineControls)
+export default withTheme(observer(LineControls))

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.spec.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.spec.jsx
@@ -13,6 +13,7 @@ describe('LineControls', () => {
   beforeEach(() => {
     mark = {
       id: 'test',
+      isDragging: false,
       undo: sinon.stub(),
       redo: sinon.stub(),
       close: sinon.stub()
@@ -109,5 +110,30 @@ describe('LineControls', () => {
     fireEvent.pointerDown(button)
     
     expect(svg.className.baseVal).not.to.equal(className)
+  })
+})
+
+describe('LineControls with isDragging = true', () => {
+  it('should render nothing', () => {
+    const mark = {
+      id: 'test',
+      isDragging: true,
+      undo: sinon.stub(),
+      redo: sinon.stub(),
+      close: sinon.stub()
+    }    
+    const onDelete = sinon.stub()
+
+    render(
+      <Grommet theme={zooTheme}>
+        <LineControls 
+          mark={mark}
+          onDelete={onDelete}
+        />
+      </Grommet>
+    )
+
+    const svg = document.querySelector('svg')
+    expect(svg).not.to.be.ok
   })
 })

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.stories.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.stories.jsx
@@ -14,6 +14,7 @@ const StyledDiv = styled.div`
 
 const mark = {
   id: '',
+  isDragging: false,
   undo: () => true,
   redo: () => true,
   close: () => true


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._

## Package

- lib-classifier

## Context

Currently, the line controls are shown as soon as the user starts to draw. If the controls obscure the part of the subject that the user wants to mark, they have to stop drawing and move the controls before continuing. This PR changes the behaviour so that the controls are hidden whenever the user is drawing. The position of the controls is preserved between hide and show events.

This change is most beneficial for smaller screens / subjects, where it's more likely that the controls will interfere with drawing.

## Describe your changes

- Conditionally render the` LineControls` when `isDragging = false` on the `FreehandLine` mark model.
- Update tests.

## How to Review

### Project

https://localhost:8080/?project=eatyourgreens/-project-testing-ground&workflow=3370

1. Draw a freehand line. Check that the controls are not shown until the drag ends.
2. Extend the line. Check that the controls are hidden, and reappear when the drag ends.
3. Move the controls to the right. Extend the line. Check that the controls reappear on the right when the drag ends.

### Storybook

- http://localhost:6006/?path=/story/drawing-tools-freehand-line--drawing
- http://localhost:6006/?path=/story/subject-viewers-singlevideoviewer--with-drawing&args=toolType:freehandLine

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature