### PR TITLE
Classifier: add "No Workflow Selected" message

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
@@ -229,16 +229,22 @@ export default function ClassifierContainer({
   try {
     return (
       <Provider classifierStore={classifierStore}>
-      {!allowedWorkflowID && userHasLoaded ?
-        <Paragraph>This workflow does not exist or you do not have permission to view it.</Paragraph>
+        {!workflowID ? // If the workflow ID isn't specified, it's usually because the user is at the root /classify path.
+          <Paragraph>No workflow selected.</Paragraph>
+
+        : !allowedWorkflowID && userHasLoaded ?
+          <Paragraph>This workflow does not exist or you do not have permission to view it.</Paragraph>
+
         : classifierIsReady ?
-           <Classifier
-              onError={onError}
-              showTutorial={showTutorial}
-              subjectSetID={subjectSetID}
-              subjectID={subjectID}
-              workflowSnapshot={workflowSnapshot}
-            /> :
+          <Classifier
+            onError={onError}
+            showTutorial={showTutorial}
+            subjectSetID={subjectSetID}
+            subjectID={subjectID}
+            workflowSnapshot={workflowSnapshot}
+          />
+
+        :
           <Paragraph>Loading the Classifier</Paragraph>
         }
       </Provider>


### PR DESCRIPTION
## PR Overview

Package: lib-classifier (but test with app-project)
Improves on #7194

This is a small UI enhancement to the Classifier, which adds a better status message when no workflow is selected.

Currently, when you visit the root /classify page of a project (with either 0 or 2+ active workflows), you will see the error message/status message _"This workflow does not exist or you do not have permission to view it."_ Which is kinda wrong, since there's no _"this workflow"_ to begin with.

With this PR, the status message is a bit more accurate to the situation:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/23599026-9f3a-4614-ae84-b6567287e01a" />

Behaviour:
- When visiting the root /classify page as a normal (non-owner) volunteer... (e.g. https://local.zooniverse.org:3000/projects/darkeshard/test-project-2026/classify?env=staging)
  - 🆕 ...if a project has 2 or more active workflows, the status message is "No workflow selected", and a Select Workflow popup will appear.
  - 🟰 ...if a project has exactly 1 active workflow, user will be redirected to that workflow.
  - 🆕 ...if a project has 0 active workflows, the status message is "No workflow selected", and a Select Workflow popup will appear (albeit with the message "nothing to Classify").
- 🟰 When visiting the /classify path of a workflow that doesn't exist[^1] OR the user doesn't have access to[^2], error message will be "This workflow does not exist or you do not have permission to view it."[^3]
- When visiting the /classify path of a valid, active workflow, Classifier will function as normal.

(🆕 indicates new behaviour introduced with this PR. 🟰 indicates no change in behaviour.)

[^1]: in practice, if you visit a workflow that doesn't exist - e.g. https://frontend.preview.zooniverse.org/projects/darkeshard/test-project-2022/classify/workflow/123456789 - then you'll just get a 404 page, since app-project will perform the redirect before lib-classifier can even load to show the error message.
[^2]: to be specific, this means that the workflow exists BUT is not active, and the user isn't logged in as a project owner or collaborator or tester. In practice, this is usually the only way you'll see the "workflow doesn't exist" error message.
[^3]: OK, one more caveat - if you visit a workflow that DOES exist but belongs to a DIFFERENT project, you'll also get a 404. This is a weird edge case though.

### Testing 

Test on localhost with **app-project.**

- Select a test project: https://www.zooniverse.org/lab/2026/workflows?env=staging
  - (For your testing convenience, please feel free to edit this Test Project 2026. Activate/deactivate workflows any which way you like.)
- Edit the test project so it has (say) **3 active workflows.**
  - Visit the root /classify page: https://local.zooniverse.org:3000/projects/darkeshard/test-project-2026/classify?env=staging
  - Ensure that you see 1. the "No workflow selected" message (in the back) and 2. the Select Workflow popup with 3 workflows.
      <img width="400" alt="image" src="https://github.com/user-attachments/assets/1fd7cff5-6173-4f7d-a1c1-53eb37e37f1d" />
  - BONUS: choose any one workflow and try classifying on it.
- Edit the test project so it has **exactly 1 active workflow.**
  - Visit the root /classify page.
  - Ensure that you're redirected to that active workflow.
      <img width="400" alt="image" src="https://github.com/user-attachments/assets/e3549043-8710-4e6b-9b23-025ec1d54e24" />
- Edit the test project so it has **0 active workflows.**
  - Visit the root /classify page.
  - Ensure that you see 1. the "No workflow selected" message (in the back) and 2. the Select Workflow popup with "Nothing to Clasify".
      <img width="400" alt="image" src="https://github.com/user-attachments/assets/9e9bbd27-0935-4fb9-a518-b144b253eb5f" />
  - BONUS: try classifying on this workflow.
- Visit a workflow that EXISTS but is NOT active. (And make sure you're not logged in as a project owner!)
  - e.g. https://local.zooniverse.org:3000/projects/darkeshard/test-project-2026/classify/workflow/3913
  - Ensure that you see the "This workflow does not exist or you do not have permission to view it." error message
      <img width="400" alt="image" src="https://github.com/user-attachments/assets/f2a2549c-117d-4e8a-853c-d02e425c45f6" />

NOTE: if you visit a workflow that actually DOES NOT EXIST, then you'll immediately go to a 404 page. You won't get a chance to see the "This Workflow doesn't exist" error message, ironically enough.

### Status

Ready for review. Super low priority, though.