### PR TITLE
Add institute logos to ZooHeader

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade to Storybook v9
 - Remove `breakpoint` and `isNarrow` as props from ZooHeader in favor of defining `isNarrow` consistently in ZooHeader.
 - Add the institute logos to the ZooHeader (Adler, UMN, Oxford).
+- Use a color from lib-grommet-theme for ZooHeader's font color.
 
 ## Fixed
 

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Changed
 - Upgrade to Storybook v9
+- Remove `breakpoint` and `isNarrow` as props from ZooHeader in favor of defining `isNarrow` consistently in ZooHeader.
+- Add the institute logos to the ZooHeader (Adler, UMN, Oxford).
 
 ## Fixed
 

--- a/packages/lib-react-components/src/ZooHeader/README.md
+++ b/packages/lib-react-components/src/ZooHeader/README.md
@@ -4,6 +4,8 @@ The standard Zooniverse header to be used on Zooniverse sites. Built using:
 - [Grommet v2](https://v2.grommet.io/components)
 - [styled-components](https://www.styled-components.com/)
 
+The header does not contain a `<header>` tag. The parent must wrap ZooHeader and anything else into its own `<header>`.
+
 The header does not have light and dark theme variants. It remains black for both.
 
 The `signIn` (function), `signOut` (function), and `user` (object) props are required. These props can be defined using the API from @zooniverse/auth. See the development mini-app in the lib-auth folder for an example of using its API.

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
@@ -52,7 +52,7 @@ export const StyledLogoAnchor = styled(Anchor)`
 `
 
 const defaultHandler = () => true
-const navBreakpoint = 960 // legacy best guess for when the nav menus should collapse to hamburger style
+const navBreakpoint = 990 // best guess for when the nav menus should collapse to hamburger style
 const logosBreakpoint = 262 // 40px horizontal padding + 40px total gap + 182px total width of logos
 
 export default function ZooHeader({

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
@@ -15,7 +15,7 @@ import UserNavigation from './components/UserNavigation/UserNavigation'
 import ZooniverseLogo from '../ZooniverseLogo/ZooniverseLogo'
 
 export const StyledHeader = styled(Box)`
-  color: #b2b2b2;
+  color: #a6a7a9; // light-5
   font-size: 1em;
 
   // hide the header when printing, added for the user stats certificate, but applies generally
@@ -27,7 +27,7 @@ export const StyledHeader = styled(Box)`
 export const StyledLogoAnchor = styled(Anchor)`
   border-bottom: 2px solid transparent;
   border-top: 2px solid transparent; // to help align-items center in nav
-  color: #b2b2b2;
+  color: #a6a7a9; // light-5
   margin-right: 30px;
 
   &:hover,
@@ -68,9 +68,9 @@ export default function ZooHeader({
   // to define isNarrow as a props passed to the nav menus.
   const {
     width: headerWidth,
-    height: headerHeight,
     ref: headerRef
   } = useResizeDetector({
+    handleHeight: false,
     refreshMode: 'debounce',
     refreshRate: 100
   })
@@ -81,9 +81,9 @@ export default function ZooHeader({
   // the nav menus, and that's incompatible with a CSS container query.
   const {
     width: logosContainerWidth,
-    height: logosContainerHeight,
     ref: logosContainerRef
   } = useResizeDetector({
+    handleHeight: false,
     refreshMode: 'debounce',
     refreshRate: 100
   })

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
@@ -24,6 +24,16 @@ export const StyledHeader = styled(Box)`
   }
 `
 
+const Relative = styled(Box)`
+  position: relative;
+`
+
+const Absolute = styled(Box)`
+  position: absolute;
+  left: 0;
+  top: 0;
+`
+
 export const StyledLogoAnchor = styled(Anchor)`
   border-bottom: 2px solid transparent;
   border-top: 2px solid transparent; // to help align-items center in nav
@@ -66,10 +76,7 @@ export default function ZooHeader({
   // This resize detector could be refactored to use CSS container queries. The legacy
   // version of ZooHeader was intitially built with detecting client side viewport width
   // to define isNarrow as a props passed to the nav menus.
-  const {
-    width: headerWidth,
-    ref: headerRef
-  } = useResizeDetector({
+  const { width: headerWidth, ref: headerRef } = useResizeDetector({
     handleHeight: false,
     refreshMode: 'debounce',
     refreshRate: 100
@@ -79,16 +86,30 @@ export default function ZooHeader({
   // For the institutional logos. This resize cannot use CSS container queries because the container
   // in this case doesn't have a defined width. It adapts to however much space is left in between
   // the nav menus, and that's incompatible with a CSS container query.
-  const {
-    width: logosContainerWidth,
-    ref: logosContainerRef
-  } = useResizeDetector({
+  const { width: leftNavWidth, ref: leftNavRef } = useResizeDetector({
     handleHeight: false,
     refreshMode: 'debounce',
     refreshRate: 100
   })
-  const showLogosInline = logosContainerWidth > logosBreakpoint
 
+  const { width: logosContainerWidth, ref: logosContainerRef } =
+    useResizeDetector({
+      handleHeight: false,
+      refreshMode: 'debounce',
+      refreshRate: 100
+    })
+
+  // Show the institute logos inline with the navbar *if* the width of the left-hand nav does not
+  // cross into the justified-center <InstituteLogos /> which always have a width of 262px. The width
+  // of the left-hand nav varies with language or user preferences like browser font size, but we always
+  // want the logos centered relative to the user's screen width.
+  const minHeaderWidthAllowed = (leftNavWidth + 30) * 2 + logosBreakpoint
+  const showLogosInline =
+    headerWidth > navBreakpoint &&
+    headerWidth > minHeaderWidthAllowed &&
+    logosContainerWidth > logosBreakpoint
+
+  // Form the link URLs
   const host = getHost()
   const adminNavLinkLabel = 'Admin'
   const adminNavLinkURL = `${host}/admin`
@@ -116,12 +137,25 @@ export default function ZooHeader({
           <InstituteLogos />
         </Box>
       )}
-      <Box direction='row' pad={{ vertical: '10px', horizontal: 'medium' }}>
+      <Relative
+        direction='row'
+        pad={{
+          vertical: showLogosInline ? '20px' : '10px',
+          horizontal: 'medium'
+        }}
+      >
+        {showLogosInline && (
+          <Absolute fill align='center' direction='row' justify='center'>
+            <InstituteLogos />
+          </Absolute>
+        )}
         <Box
           as='nav'
           align='center'
           aria-label={t('ZooHeader.ariaLabel')}
           direction='row'
+          ref={leftNavRef}
+          style={{ zIndex: 1 }}
         >
           <StyledLogoAnchor href='http://www.zooniverse.org'>
             <ZooniverseLogo size='1.25em' id='HeaderZooniverseLogo' />
@@ -135,19 +169,13 @@ export default function ZooHeader({
             mainHeaderNavListURLs={mainHeaderNavListURLs}
           />
         </Box>
-        <Box
-          flex
-          direction='row'
-          justify='center'
-          ref={logosContainerRef}
-        >
-          {showLogosInline && <InstituteLogos />}
-        </Box>
+        <Box flex direction='row' justify='center' ref={logosContainerRef} />
         <Box
           aria-label={t('ZooHeader.SignedInUserNavigation.ariaLabel')}
           as='nav'
           direction='row'
           align='center'
+          style={{ zIndex: 1 }}
         >
           {hasMounted && (
             <UserNavigation
@@ -173,7 +201,7 @@ export default function ZooHeader({
             />
           )}
         </Box>
-      </Box>
+      </Relative>
     </StyledHeader>
   )
 }

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
@@ -3,10 +3,12 @@ import { Anchor, Box } from 'grommet'
 import { bool, func, number, shape, string } from 'prop-types'
 import { useResizeDetector } from 'react-resize-detector'
 import styled from 'styled-components'
+
 import { getHost } from './helpers'
 import { useTranslation } from '../translations/i18n'
 import { useHasMounted } from '../hooks'
 
+import InstituteLogos from './components/InstituteLogos/InstituteLogos'
 import MainNavList from './components/MainNavList/MainNavList'
 import NarrowMainNavMenu from './components/NarrowMainNavMenu/NarrowMainNavMenu'
 import UserNavigation from './components/UserNavigation/UserNavigation'
@@ -40,11 +42,11 @@ export const StyledLogoAnchor = styled(Anchor)`
 `
 
 const defaultHandler = () => true
+const navBreakpoint = 960 // legacy best guess for when the nav menus should collapse to hamburger style
+const logosBreakpoint = 262 // 40px horizontal padding + 40px total gap + 182px total width of logos
 
 export default function ZooHeader({
-  breakpoint = 960,
   adminMode = false,
-  isNarrow = false,
   onThemeChange = defaultHandler,
   register = defaultHandler,
   showThemeToggle = false,
@@ -56,13 +58,36 @@ export default function ZooHeader({
   user = {},
   ...props
 }) {
-  const hasMounted = useHasMounted()
   const { t } = useTranslation()
-  const { width, height, ref } = useResizeDetector({
+
+  // Hide the user nav menus until component is mounted and can detect a signed-in user
+  const hasMounted = useHasMounted()
+
+  // This resize detector could be refactored to use CSS container queries. The legacy
+  // version of ZooHeader was intitially built with detecting client side viewport width
+  // to define isNarrow as a props passed to the nav menus.
+  const {
+    width: headerWidth,
+    height: headerHeight,
+    ref: headerRef
+  } = useResizeDetector({
     refreshMode: 'debounce',
     refreshRate: 100
   })
-  isNarrow = isNarrow || width <= breakpoint
+  const isNarrow = headerWidth <= navBreakpoint
+
+  // For the institutional logos. This resize cannot use CSS container queries because the container
+  // in this case doesn't have a defined width. It adapts to however much space is left in between
+  // the nav menus, and that's incompatible with a CSS container query.
+  const {
+    width: logosContainerWidth,
+    height: logosContainerHeight,
+    ref: logosContainerRef
+  } = useResizeDetector({
+    refreshMode: 'debounce',
+    refreshRate: 100
+  })
+  const showLogosInline = logosContainerWidth > logosBreakpoint
 
   const host = getHost()
   const adminNavLinkLabel = 'Admin'
@@ -85,62 +110,69 @@ export default function ZooHeader({
   ]
 
   return (
-    <StyledHeader
-      ref={ref}
-      background='black'
-      direction='row'
-      justify='between'
-      pad={{ vertical: '20px', horizontal: 'medium' }}
-      responsive
-      {...props}
-    >
-      <Box
-        as='nav'
-        align='center'
-        aria-label={t('ZooHeader.ariaLabel')}
-        direction='row'
-      >
-        <StyledLogoAnchor href='http://www.zooniverse.org'>
-          <ZooniverseLogo size='1.25em' id='HeaderZooniverseLogo' />
-        </StyledLogoAnchor>
-        <MainNavList
-          adminNavLinkLabel={adminNavLinkLabel}
-          adminNavLinkURL={adminNavLinkURL}
-          adminMode={user?.admin && adminMode}
-          isNarrow={isNarrow}
-          mainHeaderNavListLabels={mainHeaderNavListLabels}
-          mainHeaderNavListURLs={mainHeaderNavListURLs}
-        />
-      </Box>
-      <Box
-        aria-label={t('ZooHeader.SignedInUserNavigation.ariaLabel')}
-        as='nav'
-        direction='row'
-        align='center'
-      >
-        {hasMounted && (
-          <UserNavigation
-            isNarrow={isNarrow}
-            onThemeChange={onThemeChange}
-            register={register}
-            showThemeToggle={showThemeToggle}
-            signIn={signIn}
-            signOut={signOut}
-            themeMode={themeMode}
-            unreadMessages={unreadMessages}
-            unreadNotifications={unreadNotifications}
-            user={user}
-          />
-        )}
-        {isNarrow && (
-          <NarrowMainNavMenu
+    <StyledHeader ref={headerRef} background='black' {...props}>
+      {!showLogosInline && (
+        <Box direction='row' justify='center' pad={{ top: '10px' }}>
+          <InstituteLogos />
+        </Box>
+      )}
+      <Box direction='row' pad={{ vertical: '10px', horizontal: 'medium' }}>
+        <Box
+          as='nav'
+          align='center'
+          aria-label={t('ZooHeader.ariaLabel')}
+          direction='row'
+        >
+          <StyledLogoAnchor href='http://www.zooniverse.org'>
+            <ZooniverseLogo size='1.25em' id='HeaderZooniverseLogo' />
+          </StyledLogoAnchor>
+          <MainNavList
             adminNavLinkLabel={adminNavLinkLabel}
             adminNavLinkURL={adminNavLinkURL}
             adminMode={user?.admin && adminMode}
+            isNarrow={isNarrow}
             mainHeaderNavListLabels={mainHeaderNavListLabels}
             mainHeaderNavListURLs={mainHeaderNavListURLs}
           />
-        )}
+        </Box>
+        <Box
+          flex
+          direction='row'
+          justify='center'
+          ref={logosContainerRef}
+        >
+          {showLogosInline && <InstituteLogos />}
+        </Box>
+        <Box
+          aria-label={t('ZooHeader.SignedInUserNavigation.ariaLabel')}
+          as='nav'
+          direction='row'
+          align='center'
+        >
+          {hasMounted && (
+            <UserNavigation
+              isNarrow={isNarrow}
+              onThemeChange={onThemeChange}
+              register={register}
+              showThemeToggle={showThemeToggle}
+              signIn={signIn}
+              signOut={signOut}
+              themeMode={themeMode}
+              unreadMessages={unreadMessages}
+              unreadNotifications={unreadNotifications}
+              user={user}
+            />
+          )}
+          {isNarrow && (
+            <NarrowMainNavMenu
+              adminNavLinkLabel={adminNavLinkLabel}
+              adminNavLinkURL={adminNavLinkURL}
+              adminMode={user?.admin && adminMode}
+              mainHeaderNavListLabels={mainHeaderNavListLabels}
+              mainHeaderNavListURLs={mainHeaderNavListURLs}
+            />
+          )}
+        </Box>
       </Box>
     </StyledHeader>
   )
@@ -148,7 +180,6 @@ export default function ZooHeader({
 
 ZooHeader.propTypes = {
   adminMode: bool,
-  isNarrow: bool,
   onThemeChange: func,
   register: func,
   showThemeToggle: bool,

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.jsx
@@ -74,8 +74,8 @@ export default function ZooHeader({
   const hasMounted = useHasMounted()
 
   // This resize detector could be refactored to use CSS container queries. The legacy
-  // version of ZooHeader was intitially built with detecting client side viewport width
-  // to define isNarrow as a props passed to the nav menus.
+  // version of ZooHeader was initially built with detecting client side viewport width
+  // to define isNarrow as a prop passed to the nav menus.
   const { width: headerWidth, ref: headerRef } = useResizeDetector({
     handleHeight: false,
     refreshMode: 'debounce',

--- a/packages/lib-react-components/src/ZooHeader/components/InstituteLogos/InstituteLogos.jsx
+++ b/packages/lib-react-components/src/ZooHeader/components/InstituteLogos/InstituteLogos.jsx
@@ -1,5 +1,4 @@
 import { Box } from 'grommet'
-import { string } from 'prop-types'
 import { useTheme } from 'styled-components'
 
 function InstituteLogos() {
@@ -29,10 +28,6 @@ function InstituteLogos() {
       />
     </Box>
   )
-}
-
-InstituteLogos.propTypes = {
-  size: string
 }
 
 export default InstituteLogos

--- a/packages/lib-react-components/src/ZooHeader/components/InstituteLogos/InstituteLogos.jsx
+++ b/packages/lib-react-components/src/ZooHeader/components/InstituteLogos/InstituteLogos.jsx
@@ -1,0 +1,38 @@
+import { Box } from 'grommet'
+import { string } from 'prop-types'
+import { useTheme } from 'styled-components'
+
+function InstituteLogos() {
+  const theme = useTheme()
+
+  const adlerSrc = theme.dark ? 'https://static.zooniverse.org/fem-assets/adler-dark.png': 'https://static.zooniverse.org/fem-assets/adler.png'
+  const minnSrc = theme.dark ? 'https://static.zooniverse.org/fem-assets/minnesota-dark.png' : 'https://static.zooniverse.org/fem-assets/minnesota.png'
+
+  return (
+    <Box
+      direction='row'
+      height='45px'
+      gap='20px'
+      margin={{ horizontal: '20px' }}
+    >
+      <img
+        alt='The Adler Planetarium'
+        src={adlerSrc}
+      />
+      <img
+        alt='University of Minnesota'
+        src={minnSrc}
+      />
+      <img
+        alt='University of Oxford'
+        src='https://static.zooniverse.org/fem-assets/oxford.jpg'
+      />
+    </Box>
+  )
+}
+
+InstituteLogos.propTypes = {
+  size: string
+}
+
+export default InstituteLogos

--- a/packages/lib-react-components/src/ZooHeader/components/NarrowMainNavMenu/NarrowMainNavMenu.jsx
+++ b/packages/lib-react-components/src/ZooHeader/components/NarrowMainNavMenu/NarrowMainNavMenu.jsx
@@ -36,7 +36,7 @@ export default function NarrowMainNavMenu({
     <NarrowMenu
       icon={false}
       items={menuListItems}
-      label={<StyledMenuIcon color='#B2B2B2' text='Main Navigation'/>}
+      label={<StyledMenuIcon color='light-5' text='Main Navigation'/>}
     />
   )
 }

--- a/packages/lib-react-components/src/ZooHeader/components/NavListItem/NavListItem.jsx
+++ b/packages/lib-react-components/src/ZooHeader/components/NavListItem/NavListItem.jsx
@@ -16,7 +16,7 @@ export const StyledNavListItem = styled(Anchor)`
   }
 `
 
-function NavListItem ({ className, color = '#B2B2B2', label, margin, url }) {
+function NavListItem ({ className, color = 'light-5', label, margin, url }) {
   return (
     <StyledNavListItem className={className} color={color} href={url} margin={margin} >
       <SpacedText

--- a/packages/lib-react-components/src/ZooHeader/components/ThemeModeToggle/ThemeModeToggle.jsx
+++ b/packages/lib-react-components/src/ZooHeader/components/ThemeModeToggle/ThemeModeToggle.jsx
@@ -30,9 +30,9 @@ export default function ThemeModeToggle({ themeMode, onThemeChange }) {
       aria-label={label}
       icon={
         themeMode === 'dark' ? (
-          <Moon color='#b2b2b2' />
+          <Moon color='light-5' />
         ) : (
-          <Sun color='#b2b2b2' />
+          <Sun color='light-5' />
         )
       }
       margin={{ right: 'small' }}

--- a/packages/lib-react-components/src/ZooHeader/components/UserMenu/UserMenu.jsx
+++ b/packages/lib-react-components/src/ZooHeader/components/UserMenu/UserMenu.jsx
@@ -42,7 +42,7 @@ export default function UserMenu({ signOut, user }) {
     <NarrowMenu aria-label={user.display_name} items={userMenuNavListItems}>
       <Box align='center' as='span' direction='row'>
         <SpacedText
-          color='#b2b2b2'
+          color='light-5'
           lang='en'
           margin={{ right: 'xsmall' }}
           size='xsmall'
@@ -50,7 +50,7 @@ export default function UserMenu({ signOut, user }) {
         >
           {user.display_name}
         </SpacedText>
-        <StyledFormDown color='#b2b2b2' />
+        <StyledFormDown color='light-5' />
       </Box>
     </NarrowMenu>
   )

--- a/packages/lib-react-components/src/ZooHeader/components/UserNavigation/UserNavigation.jsx
+++ b/packages/lib-react-components/src/ZooHeader/components/UserNavigation/UserNavigation.jsx
@@ -71,7 +71,7 @@ export default function UserNavigation({
 
   const notificationLabel = isNarrow ? (
     <Icon
-      icon={unreadNotifications ? <StyledNotificationIcon /> : <Notification />}
+      icon={unreadNotifications ? <StyledNotificationIcon /> : <Notification color='light-5' />}
       size='0.8rem'
       title={notificationLabelString}
     />
@@ -81,7 +81,7 @@ export default function UserNavigation({
 
   const messagesLabel = isNarrow ? (
     <Icon
-      icon={unreadMessages ? <StyledMailIcon /> : <MailOption />}
+      icon={unreadMessages ? <StyledMailIcon /> : <MailOption color='light-5' />}
       size={unreadMessages ? '0.9rem' : '0.8rem'}
       title={messagesLabelString}
     />
@@ -113,14 +113,14 @@ export default function UserNavigation({
       {Object.keys(user).length > 0 && signOut && (
         <>
           <NavListItem
-            color={unreadNotifications ? 'accent-1' : '#B2B2B2'}
+            color={unreadNotifications ? 'accent-1' : 'light-5'}
             label={notificationLabel}
             margin={{ right: 'small' }}
             unread={unreadNotifications}
             url={`${host}/notifications`}
           />
           <NavListItem
-            color={unreadMessages ? 'accent-1' : '#B2B2B2'}
+            color={unreadMessages ? 'accent-1' : 'light-5'}
             label={messagesLabel}
             margin={{ right: 'small' }}
             unread={unreadMessages}

--- a/packages/lib-react-components/src/ZooHeader/components/UserNavigation/components/NavButton/NavButton.jsx
+++ b/packages/lib-react-components/src/ZooHeader/components/UserNavigation/components/NavButton/NavButton.jsx
@@ -15,7 +15,7 @@ const StyledNavButton = styled(Button)`
 function NavButton ({ label = '', onClick, ...props }) {
   return (
     <StyledNavButton
-      label={<SpacedText color="#B2B2B2" weight="bold" size="xsmall">{label}</SpacedText>}
+      label={<SpacedText color="light-5" weight="bold" size="xsmall">{label}</SpacedText>}
       plain={true}
       onClick={onClick}
       {...props}


### PR DESCRIPTION
## Package
lib-react-components

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/7330
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5746

## Describe your changes
- Add the logos centered horizontally to the header based on the design in #7330 
     - See more discussion in that Issue about using a resize detector vs CSS to achieve the design
- Set the font color to `light-5` per #5746 

## How to Review
- Review all of the Stories associated with ZooHeader in lib-react-component's Storybook
- Run app-project locally and set the language to something like German and Japanese. Resize your browser to test the behavior of the header layout
    - https://localhost.zooniverse.org:3000/projects/de/brooke/i-fancy-cats
    - https://localhost.zooniverse.org:3000/projects/ja/brooke/i-fancy-cats

## Checklist

### General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/main/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

### Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
