### PR TITLE
ZooHeader: restyle images in InstituteLogos with explicit height for Safari

### DIFF
--- a/packages/lib-react-components/src/ZooHeader/components/InstituteLogos/InstituteLogos.jsx
+++ b/packages/lib-react-components/src/ZooHeader/components/InstituteLogos/InstituteLogos.jsx
@@ -8,23 +8,13 @@ function InstituteLogos() {
   const minnSrc = theme.dark ? 'https://static.zooniverse.org/fem-assets/minnesota-dark.png' : 'https://static.zooniverse.org/fem-assets/minnesota.png'
 
   return (
-    <Box
-      direction='row'
-      height='45px'
-      gap='20px'
-      margin={{ horizontal: '20px' }}
-    >
-      <img
-        alt='The Adler Planetarium'
-        src={adlerSrc}
-      />
-      <img
-        alt='University of Minnesota'
-        src={minnSrc}
-      />
+    <Box direction='row' gap='20px'>
+      <img alt='The Adler Planetarium' src={adlerSrc} height='45px' />
+      <img alt='University of Minnesota' src={minnSrc} height='45px' />
       <img
         alt='University of Oxford'
         src='https://static.zooniverse.org/fem-assets/oxford.jpg'
+        height='45px'
       />
     </Box>
   )


### PR DESCRIPTION
## Package
lib-react-components

## Linked Issue and/or Talk Post
Follows: https://github.com/zooniverse/front-end-monorepo/pull/7350

## Describe your changes
- restyle images in InstituteLogos with explicit height for Safari

## How to Review
- Run lib-react-component's Storybook and check out the header Stories in multiple browsers

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser



### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
