### PR TITLE
Revert "Disable DoneButton and DoneAndTalkButton when Task component could not be rendered"

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.jsx
@@ -34,7 +34,7 @@ function Task ({
   task,
   ...props
 }) {
-  const TaskPlugin = task.type === 'dropdown-simple' ? tasks.dropdownSimple : tasks[task.type]
+  const TaskPlugin = task.type === 'dropdown-simple'? tasks.dropdownSimple : tasks[task.type]
   const TaskComponent = TaskPlugin?.TaskComponent
   let annotation
   let suggestions

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonConnector.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonConnector.jsx
@@ -11,7 +11,6 @@ function storeMapper(classifierStore) {
       active: subject
     },
     workflowSteps: {
-      hasUnsupportedTasks,
       shouldWeShowDoneAndTalkButton
     }
   } = classifierStore
@@ -27,7 +26,6 @@ function storeMapper(classifierStore) {
     }
 
     return {
-      hasUnsupportedTasks,
       onClick,
       talkURL: subject.talkURL,
       visible
@@ -38,10 +36,9 @@ function storeMapper(classifierStore) {
 }
 
 function DoneAndTalkConnector(props) {
-  const { hasUnsupportedTasks, onClick, talkURL, visible } = useStores(storeMapper)
-  const isDisabled = hasUnsupportedTasks || props.disabled
+  const { onClick, talkURL, visible } = useStores(storeMapper)
 
-  return visible ? <DoneAndTalkButton {...props} disabled={isDisabled} onClick={onClick} talkURL={talkURL} /> : null
+  return visible ? <DoneAndTalkButton onClick={onClick} {...props} talkURL={talkURL} /> : null
 }
 
 export default observer(DoneAndTalkConnector)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButtonConnector.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButtonConnector.jsx
@@ -12,8 +12,7 @@ function storeMapper(classifierStore) {
       completeClassification
     },
     workflowSteps: {
-      active: step,
-      hasUnsupportedTasks
+      active: step
     }
   } = classifierStore
 
@@ -38,7 +37,6 @@ function storeMapper(classifierStore) {
     }
 
     return {
-      hasUnsupportedTasks,
       hasNextStep,
       onClick
     }
@@ -48,10 +46,8 @@ function storeMapper(classifierStore) {
 }
 
 function DoneButtonConnector(props) {
-  const { hasUnsupportedTasks, hasNextStep, onClick } = useStores(storeMapper)
-  const isDisabled = hasUnsupportedTasks || props.disabled
-
-  return hasNextStep ? null : <DoneButton {...props} disabled={isDisabled} onClick={onClick} />
+  const { hasNextStep, onClick } = useStores(storeMapper)
+  return hasNextStep ? null : <DoneButton onClick={onClick} {...props} />
 }
 
 export default observer(DoneButtonConnector)

--- a/packages/lib-classifier/src/store/WorkflowStepStore/Step/Step.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/Step/Step.js
@@ -42,10 +42,6 @@ const baseStep = types
       return isValid
     },
 
-    get hasUnsupportedTasks() {
-      return self.taskKeys.length !== self.tasks.length
-    },
-
     get isThereBranching () {
       // We return the first single choice task
       // It doesn't make sense to have more than one single choice task in a step

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -48,10 +48,6 @@ const WorkflowStepStore = types
       return false
     },
 
-    get hasUnsupportedTasks() {
-      return Array.from(self.steps.values()).some(step => step.hasUnsupportedTasks)
-    },
-
     findTasksByType (type) {
       const tasksByType = Array.from(self.steps).map(([stepKey, step]) => {
         if (step?.tasks && step.tasks.length > 0) {


### PR DESCRIPTION
Reverts zooniverse/front-end-monorepo#7065

Bug found per Slack: https://zooniverse.slack.com/archives/CANKLB50E/p1777574399669049