### PR TITLE
Classifier: add translations strings for status message

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.jsx
@@ -5,7 +5,7 @@ import { Provider } from 'mobx-react'
 import { applySnapshot, getSnapshot } from 'mobx-state-tree'
 import PropTypes from 'prop-types'
 import { useEffect } from 'react';
-import i18n from '../../translations/i18n'
+import i18n, { useTranslation } from '../../translations/i18n'
 import {
   env,
   panoptes as panoptesClient,
@@ -60,6 +60,7 @@ export default function ClassifierContainer({
 }) {
   const storeEnvironment = { authClient, client }
   const { user, upp, projectRoles, userHasLoaded } = usePanoptesUserSession({ authClient, projectID: project?.id })
+  const { t } = useTranslation('components')
 
   /*
     A user must have one of the following roles to view an inactive workflow. Or have admin mode enabled.
@@ -230,10 +231,10 @@ export default function ClassifierContainer({
     return (
       <Provider classifierStore={classifierStore}>
         {!workflowID ? // If the workflow ID isn't specified, it's usually because the user is at the root /classify path.
-          <Paragraph>No workflow selected.</Paragraph>
+          <Paragraph>{t('Classifier.status.noWorkflowSelected')}</Paragraph>
 
         : !allowedWorkflowID && userHasLoaded ?
-          <Paragraph>This workflow does not exist or you do not have permission to view it.</Paragraph>
+          <Paragraph>{t('Classifier.status.workflowDoesNotExist')}</Paragraph>
 
         : classifierIsReady ?
           <Classifier
@@ -245,7 +246,7 @@ export default function ClassifierContainer({
           />
 
         :
-          <Paragraph>Loading the Classifier</Paragraph>
+          <Paragraph>{t('Classifier.status.loading')}</Paragraph>
         }
       </Provider>
     )

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -48,6 +48,13 @@
       ]
     }
   },
+  "Classifier": {
+    "status": {
+      "loading": "Loading the Classifier",
+      "noWorkflowSelected": "No workflow selected.",
+      "workflowDoesNotExist": "This workflow does not exist or you do not have permission to view it."
+    }
+  },
   "DrawingTools": {
     "RotateHandle": "Handle for rotating drawn annotation\/mark."
   },


### PR DESCRIPTION
## PR Overview

Package: lib-classifier
Follows #7345

This PR adds translation strings for the previously-hardcoded status messages on the ClassifierContainer: "No workflow selected", "Workflow does not exist", and "Classifier is loading".

### Testing

Test on localhost with lib-classifier.

- Choose a test project, e.g. https://local.zooniverse.org:8080/?project=darkeshard%2Ftest-project-2025
- ▶️ When the Classifier is loading, you should see the message "Loading the Classifier"[^1]
- ▶️ With no workflow selected, you should see the error message "No workflow selected."
- Choose a workflow, e.g. https://local.zooniverse.org:8080/?project=darkeshard%2Ftest-project-2025&workflow=3844
- You should see a functional workflow etc etc
- Choose a workflow that does NOT exist, e.g. https://local.zooniverse.org:8080/?project=darkeshard%2Ftest-project-2025&workflow=666666
- ▶️ You should see the message "This workflow does not exist or you do not have permission to view it."

[^1]: actually to be honest the only practical way you're going to test this is to run app-project via pnpm start, because otherwise there's a strong chance that your initial view of the page will be blocked by the goshdanged Next.JS error overlay.

### Status

Ready for review; once this is merged, Lokalise can be updated. 👌 