### PR TITLE
lib-classifier: Add LineStringTool model

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.js
@@ -1,0 +1,10 @@
+import { types } from 'mobx-state-tree'
+
+const LineStringTool = types
+  .model('LineStringTool', {
+    color: types.optional(types.string, ''),
+    label: types.optional(types.string, ''),
+    type: types.literal('LineString')
+  })
+
+export default LineStringTool

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.spec.jsx
@@ -1,0 +1,42 @@
+import LineStringTool from './LineStringTool'
+
+describe('Model > LineStringTool', function () {
+  it('should exist', function () {
+    const tool = LineStringTool.create({ type: 'LineString' })
+    expect(tool).to.exist
+    expect(tool).to.be.an('object')
+  })
+
+  it('should have a type of "LineString"', function () {
+    const tool = LineStringTool.create({ type: 'LineString' })
+    expect(tool.type).to.equal('LineString')
+  })
+
+  it('should default color to empty string', function () {
+    const tool = LineStringTool.create({ type: 'LineString' })
+    expect(tool.color).to.equal('')
+  })
+
+  it('should default label to empty string', function () {
+    const tool = LineStringTool.create({ type: 'LineString' })
+    expect(tool.label).to.equal('')
+  })
+
+  describe('with defined properties', function () {
+    const lineStringToolSnapshot = {
+      label: 'Dam crest',
+      type: 'LineString',
+      color: '#00ff00'
+    }
+
+    it('should have a color property', function () {
+      const tool = LineStringTool.create(lineStringToolSnapshot)
+      expect(tool.color).to.equal('#00ff00')
+    })
+
+    it('should have a label property', function () {
+      const tool = LineStringTool.create(lineStringToolSnapshot)
+      expect(tool.label).to.equal('Dam crest')
+    })
+  })
+})

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/index.js
@@ -1,0 +1,1 @@
+export { default } from './LineStringTool'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/index.js
@@ -1,1 +1,2 @@
+export { default as LineStringTool } from './LineStringTool'
 export { default as PointTool } from './PointTool'


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Resolves #7358

## Describe your changes
- add a `LineStringTool` MobX-State-Tree model under `plugins/tasks/experimental/geoDrawing/tools/models/`, with `color`, `label`, and a `type: 'LineString'` discriminator (parallels the existing `PointTool` shape so the GeoDrawing task can resolve drawing tools by `type`)
- register the new model in `tools/models/index.js` so the GeoDrawing task picks it up automatically
- add a spec covering default field values and the fixed type discriminator

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - n/a for this PR. This is a model-only addition; no UI surfaces it yet. End-to-end UX lands across the follow-on PRs in this series (Draw interaction, Modify interaction, vertex/line bounds, delete affordance, lab editor). The full LineString tool is exercisable on staging workflow 3919 (`kieftrav/geo-tools` project) once those land.
- What user actions should my reviewer step through to review this PR?
  - code review only: `LineStringTool.js` + `LineStringTool.spec.jsx` + the `index.js` registration. Run `pnpm test` in `packages/lib-classifier` and confirm the new spec passes.
- Which storybook stories should be reviewed?
  - n/a (no UI surface added here)
- Are there plans for follow up PR's to further fix this bug or develop this feature?
  - Yes. This is PR 1 of 9 in the **Segmented Line** milestone. Sequential PRs that follow this one (in merge order):
    1. #7359 lib-classifier: Add LineString feature model
    2. #7363 lib-classifier: Add Draw interaction for LineString tool to GeoMapViewer
    3. #7364 lib-classifier: Suppress map navigation while drawing LineString
    4. #7365 lib-classifier: Add Modify interaction for LineString vertex editing
    5. #7366 lib-classifier: Add max_vertices and min_vertices to LineStringTool
    6. #7367 lib-classifier: Add min and max line count to LineStringTool
    7. #7368 lib-classifier: Add delete affordance for selected LineString feature
    8. [#7459 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7459): Add LineString tool to GeoDrawing task editor

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - n/a for this model-only PR; story coverage lands with the Draw / Modify follow-ons