### PR TITLE
lib-classifier: Add LineString feature model

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/LineString/LineString.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/LineString/LineString.js
@@ -1,0 +1,90 @@
+import { types } from 'mobx-state-tree'
+import { Point as OLPoint } from 'ol/geom'
+import Style from 'ol/style/Style'
+import Fill from 'ol/style/Fill'
+import Stroke from 'ol/style/Stroke'
+import Circle from 'ol/style/Circle'
+
+const DEFAULT_COLOR = '#007bff'
+
+const LineString = types
+  .model('LineString', {
+    type: types.literal('Feature'),
+    geometry: types.model({
+      type: types.literal('LineString'),
+      coordinates: types.array(types.array(types.number))
+    }),
+    properties: types.optional(types.frozen(), {})
+  })
+  .preProcessSnapshot((snapshot) => {
+    const newSnapshot = Object.assign({}, snapshot, { type: 'Feature' })
+    const newGeometry = newSnapshot.geometry || {}
+
+    let coordinates = []
+    if (typeof newGeometry.getType === 'function') {
+      coordinates = newGeometry.getCoordinates?.() || []
+    } else {
+      coordinates = newGeometry.coordinates || []
+    }
+
+    newSnapshot.geometry = {
+      type: newGeometry.type || newGeometry.getType?.() || 'LineString',
+      coordinates: Array.isArray(coordinates) ? coordinates : []
+    }
+
+    return newSnapshot
+  })
+  .views(self => ({
+    getCoordinates({ feature }) {
+      const olCoordinates = feature?.getGeometry?.()?.getCoordinates?.()
+      if (Array.isArray(olCoordinates) && olCoordinates.length > 0) return olCoordinates
+
+      return self.geometry.coordinates
+    },
+
+    getTool({ feature, geoDrawingTask }) {
+      const tools = geoDrawingTask?.tools
+      if (!tools) return undefined
+      const toolIndex = feature?.get?.('toolIndex')
+      const indexedTool = typeof toolIndex === 'number' ? tools[toolIndex] : undefined
+      return indexedTool || tools.find(tool => tool.type === 'LineString')
+    },
+
+    getStyles({
+      feature,
+      geoDrawingTask,
+      isSelected = false
+    }) {
+      const tool = self.getTool({ feature, geoDrawingTask })
+      const color = tool?.color || DEFAULT_COLOR
+
+      const strokeWidth = isSelected ? 4 : 3
+      const styles = []
+
+      styles.push(
+        new Style({
+          stroke: new Stroke({ color, width: strokeWidth })
+        })
+      )
+
+      if (isSelected) {
+        const coordinates = self.getCoordinates({ feature })
+        coordinates.forEach((coord) => {
+          styles.push(
+            new Style({
+              geometry: new OLPoint(coord),
+              image: new Circle({
+                radius: 5,
+                fill: new Fill({ color: 'white' }),
+                stroke: new Stroke({ color, width: 2 })
+              })
+            })
+          )
+        })
+      }
+
+      return styles
+    }
+  }))
+
+export default LineString

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/LineString/LineString.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/LineString/LineString.spec.jsx
@@ -1,0 +1,157 @@
+import LineString from './LineString'
+import GeoDrawingTask from '../../../task/models/GeoDrawingTask'
+
+describe('Model > LineString', function () {
+  const basicSnapshot = {
+    type: 'Feature',
+    geometry: {
+      type: 'LineString',
+      coordinates: [[2.29, 48.85], [2.30, 48.86], [2.31, 48.87]]
+    },
+    properties: {}
+  }
+
+  it('should exist', function () {
+    const lineString = LineString.create(basicSnapshot)
+    expect(lineString).to.exist
+    expect(lineString).to.be.an('object')
+  })
+
+  describe('preProcessSnapshot', function () {
+    it('should handle plain GeoJSON object', function () {
+      const snapshot = {
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates: [[10, 20], [11, 21], [12, 22]]
+        },
+        properties: { name: 'Test line' }
+      }
+      const lineString = LineString.create(snapshot)
+      expect(lineString.geometry.type).to.equal('LineString')
+      expect(lineString.geometry.coordinates).to.deep.equal([[10, 20], [11, 21], [12, 22]])
+      expect(lineString.properties.name).to.equal('Test line')
+    })
+
+    it('should handle OpenLayers Geometry object', function () {
+      const mockOLGeometry = {
+        getType: () => 'LineString',
+        getCoordinates: () => [[5, 15], [6, 16]]
+      }
+      const snapshot = {
+        geometry: mockOLGeometry
+      }
+      const lineString = LineString.create(snapshot)
+      expect(lineString.geometry.type).to.equal('LineString')
+      expect(lineString.geometry.coordinates).to.deep.equal([[5, 15], [6, 16]])
+    })
+
+    it('should default to empty coordinates if missing', function () {
+      const snapshot = {
+        geometry: {}
+      }
+      const lineString = LineString.create(snapshot)
+      expect(lineString.geometry.coordinates).to.deep.equal([])
+    })
+
+    it('should default type to "LineString" if missing', function () {
+      const snapshot = {
+        geometry: {
+          coordinates: [[1, 2], [3, 4]]
+        }
+      }
+      const lineString = LineString.create(snapshot)
+      expect(lineString.geometry.type).to.equal('LineString')
+    })
+  })
+
+  describe('> Views', function () {
+    describe('getCoordinates', function () {
+      it('should return OL feature coordinates when available', function () {
+        const mockFeature = {
+          getGeometry: () => ({
+            getCoordinates: () => [[10, 20], [11, 21]]
+          })
+        }
+        const lineString = LineString.create(basicSnapshot)
+        const coords = lineString.getCoordinates({ feature: mockFeature })
+        expect(coords).to.deep.equal([[10, 20], [11, 21]])
+      })
+
+      it('should return model coordinates as fallback', function () {
+        const mockFeature = {}
+        const lineString = LineString.create(basicSnapshot)
+        const coords = lineString.getCoordinates({ feature: mockFeature })
+        expect(coords).to.deep.equal([[2.29, 48.85], [2.30, 48.86], [2.31, 48.87]])
+      })
+    })
+
+    describe('getTool', function () {
+      it('should return tool by toolIndex from feature', function () {
+        const mockFeature = {
+          get: (key) => key === 'toolIndex' ? 1 : null
+        }
+        const geoDrawingTask = GeoDrawingTask.create({
+          taskKey: 'T0',
+          type: 'geoDrawing',
+          tools: [
+            { type: 'Point', label: 'Point' },
+            { type: 'LineString', color: '#00ff00', label: 'Dam crest' }
+          ]
+        })
+        const lineString = LineString.create(basicSnapshot)
+        const tool = lineString.getTool({ feature: mockFeature, geoDrawingTask })
+        expect(tool?.type).to.equal('LineString')
+        expect(tool?.label).to.equal('Dam crest')
+      })
+
+      it('should fall back to first LineString tool when no toolIndex', function () {
+        const mockFeature = { get: () => null }
+        const geoDrawingTask = GeoDrawingTask.create({
+          taskKey: 'T0',
+          type: 'geoDrawing',
+          tools: [
+            { type: 'Point', label: 'Point' },
+            { type: 'LineString', color: '#00ff00', label: 'Dam crest' }
+          ]
+        })
+        const lineString = LineString.create(basicSnapshot)
+        const tool = lineString.getTool({ feature: mockFeature, geoDrawingTask })
+        expect(tool?.type).to.equal('LineString')
+      })
+    })
+
+    describe('getStyles', function () {
+      const mockFeature = {
+        get: (key) => key === 'toolIndex' ? 0 : null,
+        getGeometry: () => ({
+          getCoordinates: () => [[2.29, 48.85], [2.30, 48.86]]
+        })
+      }
+      const geoDrawingTask = GeoDrawingTask.create({
+        taskKey: 'T0',
+        type: 'geoDrawing',
+        tools: [
+          { type: 'LineString', color: '#00ff00', label: 'Dam crest' }
+        ]
+      })
+
+      it('should return at least one stroke style when not selected', function () {
+        const lineString = LineString.create(basicSnapshot)
+        const styles = lineString.getStyles({ feature: mockFeature, geoDrawingTask, isSelected: false })
+        expect(styles).to.be.an('array')
+        expect(styles.length).to.equal(1)
+        expect(styles[0].getStroke()).to.exist
+      })
+
+      it('should add per-vertex circle styles when selected', function () {
+        const lineString = LineString.create(basicSnapshot)
+        const styles = lineString.getStyles({ feature: mockFeature, geoDrawingTask, isSelected: true })
+        expect(styles.length).to.equal(3)
+        expect(styles[0].getStroke()).to.exist
+        expect(styles[1].getImage()).to.exist
+        expect(styles[2].getImage()).to.exist
+      })
+    })
+  })
+})

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/LineString/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/LineString/index.js
@@ -1,0 +1,1 @@
+export { default } from './LineString'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/index.js
@@ -1,1 +1,2 @@
+export { default as LineString } from './LineString'
 export { default as Point } from './Point'


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Resolves #7359

## Describe your changes
- add a `LineString` MobX-State-Tree feature model under `plugins/tasks/experimental/geoDrawing/features/models/`, mirroring the existing `Point` feature shape. The model normalizes input via `preProcessSnapshot` so it accepts both OpenLayers `Geometry` instances (via `getCoordinates`) and plain GeoJSON-style `{ type: 'Feature', geometry: { type: 'LineString', coordinates: [...] } }` snapshots
- register the new feature model in `features/models/index.js` so the GeoDrawing task and the OL Vector layer pipeline can resolve features by `geometry.type`
- add a spec covering construction from both OL geometries and plain snapshots, the default style, the `properties` passthrough, and round-tripping through the `frozen` MST type

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - n/a for this PR. This is a feature-model addition; no UI surfaces it yet. End-to-end UX lands across the follow-on PRs in this series (Draw interaction, Modify interaction, vertex/line bounds, delete affordance, lab editor). The full LineString tool is exercisable on staging workflow 3919 (`kieftrav/geo-tools` project) once those land.
- What user actions should my reviewer step through to review this PR?
  - code review only: `LineString.js` + `LineString.spec.jsx` + the `index.js` registration. Run `pnpm test` in `packages/lib-classifier` and confirm the new spec passes.
- Which storybook stories should be reviewed?
  - n/a (no UI surface added here)
- Are there plans for follow up PR's to further fix this bug or develop this feature?
  - Yes. This is PR 2 of 9 in the **Segmented Line** milestone. Sequential PRs that follow this one (in merge order):
    1. #7363 lib-classifier: Add Draw interaction for LineString tool to GeoMapViewer
    2. #7364 lib-classifier: Suppress map navigation while drawing LineString
    3. #7365 lib-classifier: Add Modify interaction for LineString vertex editing
    4. #7366 lib-classifier: Add max_vertices and min_vertices to LineStringTool
    5. #7367 lib-classifier: Add min and max line count to LineStringTool
    6. #7368 lib-classifier: Add delete affordance for selected LineString feature
    7. [#7459 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7459): Add LineString tool to GeoDrawing task editor

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - n/a for this feature-model PR; story coverage lands with the Draw / Modify follow-ons