### PR TITLE
lib-classifier: Add Draw interaction for LineString tool to GeoMapViewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -30,6 +30,7 @@ import UnitSelect from './components/UnitSelect'
 import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 import asMSTFeature from './helpers/asMSTFeature'
+import createGeoLineStringInteraction from './helpers/createGeoLineStringInteraction'
 import createMeasureInteraction from './helpers/createMeasureInteraction'
 import createModifyUncertaintyInteraction from './helpers/createModifyUncertaintyInteraction'
 import createMoveToClickInteraction from './helpers/createMoveToClickInteraction'
@@ -154,6 +155,7 @@ function GeoMapViewer({
   const modifyUncertaintyRef = useRef()
   const moveToClickRef = useRef()
   const measureInteractionRef = useRef()
+  const lineStringDrawRef = useRef()
   const pointerMoveHandlerRef = useRef()
 
   // Shared options for reading GeoJSON and projecting to the map view
@@ -369,6 +371,13 @@ function GeoMapViewer({
       map.addInteraction(moveToClick)
       moveToClickRef.current = moveToClick
 
+      lineStringDrawRef.current = createGeoLineStringInteraction({
+        map,
+        source: featuresSource,
+        geoDrawingTask,
+        selectInteraction: select
+      })
+
       // Add cursor states that match the active interactions.
       // Note: we target the viewport element (not the outer target element) so that
       // our inline style.cursor overrides OL's class-based cursor (ol-grab, ol-grabbing)
@@ -509,6 +518,7 @@ function GeoMapViewer({
       if (translateRef.current) map.removeInteraction(translateRef.current)
       if (modifyUncertaintyRef.current) map.removeInteraction(modifyUncertaintyRef.current)
       if (moveToClickRef.current) map.removeInteraction(moveToClickRef.current)
+      lineStringDrawRef.current?.destroy()
       measureInteractionRef.current?.destroy()
       if (pointerMoveHandlerRef.current) map.un('pointermove', pointerMoveHandlerRef.current)
       if (pointerMoveRafId !== null) cancelAnimationFrame(pointerMoveRafId)
@@ -522,6 +532,7 @@ function GeoMapViewer({
       modifyUncertaintyRef.current = undefined
       moveToClickRef.current = undefined
       measureInteractionRef.current = undefined
+      lineStringDrawRef.current = undefined
       pointerMoveHandlerRef.current = undefined
     }
   }, [])
@@ -534,6 +545,30 @@ function GeoMapViewer({
       geoDrawingTask.setUnit(selectedUnit)
     }
   }, [selectedUnit, geoDrawingTask])
+
+  const activeToolType = geoDrawingTask?.activeTool?.type
+  useEffect(function syncDrawingToolMode() {
+    const isLineStringDrawing = activeToolType === 'LineString'
+
+    lineStringDrawRef.current?.setActive(isLineStringDrawing)
+
+    if (isLineStringDrawing) {
+      clearSelectedFeature(selectRef.current)
+      selectRef.current?.setActive(false)
+      translateRef.current?.setActive(false)
+      modifyUncertaintyRef.current?.setActive(false)
+      moveToClickRef.current?.setActive(false)
+    } else {
+      if (!isMeasureModeActiveRef.current) {
+        selectRef.current?.setActive(true)
+        translateRef.current?.setActive(true)
+        modifyUncertaintyRef.current?.setActive(true)
+        moveToClickRef.current?.setActive(true)
+      }
+    }
+
+    return undefined
+  }, [activeToolType])
 
   useEffect(function syncMeasureMode() {
     isMeasureModeActiveRef.current = isMeasureModeActive

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -39,6 +39,39 @@ export const WithGeoDrawingTask = {
   },
 }
 
+export const WithGeoDrawingLineStringTask = {
+  args: {
+    geoDrawingTask: GeoDrawingTask.create({
+      taskKey: 'T0',
+      activeToolIndex: 0,
+      tools: [
+        {
+          type: 'LineString',
+          label: 'Dam crest',
+          color: '#00aa55',
+        },
+      ],
+      type: 'geoDrawing',
+    }),
+    geoJSON: {
+      type: 'FeatureCollection',
+      bbox: [-91.05, 47.96, -90.97, 48.01],
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-91.0125, 47.9847]
+          },
+          properties: {
+            name: 'Knife Lake center pin (test seed)'
+          }
+        }
+      ]
+    },
+  },
+}
+
 export const WithoutGeoDrawingTask = {
   args: {
     geoJSON: {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
@@ -1,0 +1,55 @@
+import Draw from 'ol/interaction/Draw'
+
+function createGeoLineStringInteraction({
+  map,
+  source,
+  geoDrawingTask,
+  selectInteraction
+}) {
+  const draw = new Draw({
+    source,
+    type: 'LineString'
+  })
+
+  map.addInteraction(draw)
+  draw.setActive(false)
+
+  const drawEndKey = draw.on('drawend', function handleDrawEnd(event) {
+    const feature = event.feature
+    if (!feature) return
+
+    const toolIndex = geoDrawingTask?.activeToolIndex
+    if (typeof toolIndex === 'number') {
+      feature.set('toolIndex', toolIndex)
+    }
+
+    // Defer with a microtask so the source's addfeature event fires before
+    // Select reads the new feature.
+    if (selectInteraction) {
+      Promise.resolve().then(() => {
+        selectInteraction.getFeatures().clear()
+        selectInteraction.getFeatures().push(feature)
+        selectInteraction.dispatchEvent({
+          type: 'select',
+          selected: [feature],
+          deselected: []
+        })
+      })
+    }
+  })
+
+  return {
+    setActive(active) {
+      draw.setActive(active)
+    },
+    destroy() {
+      if (drawEndKey) {
+        draw.un('drawend', drawEndKey.listener)
+      }
+      draw.setActive(false)
+      map.removeInteraction(draw)
+    }
+  }
+}
+
+export default createGeoLineStringInteraction

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
@@ -1,3 +1,4 @@
+import { unByKey } from 'ol/Observable'
 import Draw from 'ol/interaction/Draw'
 
 function createGeoLineStringInteraction({
@@ -44,7 +45,7 @@ function createGeoLineStringInteraction({
     },
     destroy() {
       if (drawEndKey) {
-        draw.un('drawend', drawEndKey.listener)
+        unByKey(drawEndKey)
       }
       draw.setActive(false)
       map.removeInteraction(draw)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.spec.js
@@ -1,0 +1,92 @@
+import { Map, View, Feature } from 'ol'
+import LineStringGeom from 'ol/geom/LineString'
+import { Select } from 'ol/interaction'
+import VectorSource from 'ol/source/Vector'
+import VectorLayer from 'ol/layer/Vector'
+import createGeoLineStringInteraction from './createGeoLineStringInteraction'
+
+function buildMap(source) {
+  const layer = new VectorLayer({ source })
+  const map = new Map({
+    layers: [layer],
+    view: new View({ center: [0, 0], zoom: 1 })
+  })
+  return { map, layer }
+}
+
+describe('helpers > createGeoLineStringInteraction', function () {
+  let source, map, geoDrawingTask, selectInteraction
+
+  beforeEach(function () {
+    source = new VectorSource()
+    const built = buildMap(source)
+    map = built.map
+    geoDrawingTask = { activeToolIndex: 0 }
+    selectInteraction = new Select({ layers: [built.layer] })
+    map.addInteraction(selectInteraction)
+  })
+
+  afterEach(function () {
+    map.setTarget(undefined)
+  })
+
+  it('returns a closure with setActive and destroy', function () {
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask, selectInteraction })
+    expect(interaction).to.have.property('setActive').that.is.a('function')
+    expect(interaction).to.have.property('destroy').that.is.a('function')
+    interaction.destroy()
+  })
+
+  it('starts inactive', function () {
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask, selectInteraction })
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction).to.exist
+    expect(drawInteraction.getActive()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('setActive(true) activates the underlying Draw', function () {
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask, selectInteraction })
+    interaction.setActive(true)
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction.getActive()).to.equal(true)
+    interaction.destroy()
+  })
+
+  it('tags new features with toolIndex on drawend', function () {
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: { activeToolIndex: 2 }, selectInteraction })
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+
+    const feature = new Feature({ geometry: new LineStringGeom([[0, 0], [10, 10]]) })
+    drawInteraction.dispatchEvent({ type: 'drawend', feature })
+
+    expect(feature.get('toolIndex')).to.equal(2)
+    interaction.destroy()
+  })
+
+  it('dispatches select on the new feature after drawend (microtask)', async function () {
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask, selectInteraction })
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+
+    const feature = new Feature({ geometry: new LineStringGeom([[0, 0], [10, 10]]) })
+    source.addFeature(feature)
+
+    let selectedFeatures
+    selectInteraction.on('select', (event) => { selectedFeatures = event.selected })
+
+    drawInteraction.dispatchEvent({ type: 'drawend', feature })
+
+    await Promise.resolve()
+
+    expect(selectedFeatures).to.have.length(1)
+    expect(selectedFeatures[0]).to.equal(feature)
+    interaction.destroy()
+  })
+
+  it('destroy() removes the Draw from the map', function () {
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask, selectInteraction })
+    expect(map.getInteractions().getArray().some(i => i.constructor.name === 'Draw')).to.equal(true)
+    interaction.destroy()
+    expect(map.getInteractions().getArray().some(i => i.constructor.name === 'Draw')).to.equal(false)
+  })
+})


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Resolves #7363

## Describe your changes
- add a `createGeoLineStringInteraction` helper that wires an OpenLayers `Draw` interaction to the existing features `VectorSource`, so a drawn LineString flows through the same persistence path as Point features
- tag each newly drawn feature with the active `toolIndex` on `drawend` so `getStyles` dispatches to the correct `LineStringTool` config (color, label, future bounds)
- dispatch the new feature as the `Select` interaction's selection so the freshly drawn line is the selected feature without an extra click (deferred via a microtask so the source's `addfeature` event fires first)
- wire the new helper into `GeoMapViewer` via a `syncDrawingToolMode` effect that activates `Draw` and deactivates `Select` / `Translate` / `Modify` / `MoveToClick` when the active tool's `type` is `LineString`, restoring them when the active tool changes back (gated by measure-mode so `syncMeasureMode` retains ownership of the inverse)
- add a `WithGeoDrawingLineStringTask` Storybook story exercising the new path against a single Knife Lake seed point
- note: map navigation suppression while drawing lands in the next PR in this milestone

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - n/a for this PR. End-to-end UX (a LineString tool on a real workflow) is not exercisable until the Lab editor lands in this milestone's final PR. Until then, the Storybook story below is the user-facing surface. The full LineString tool is exercisable on staging workflow 3919 (`kieftrav/geo-tools` project) once the Segmented Line milestone completes.
- What user actions should my reviewer step through to review this PR?
  - run `pnpm storybook` in `packages/lib-classifier`, open `Subject Viewers / GeoMapViewer` → `WithGeoDrawingLineStringTask`
  - click on the map to place the first vertex, click again to add more, double-click to finish the line; expect a line feature to appear and be auto-selected (visible via the selection styling)
  - open `WithGeoDrawingTask` (existing Point-tool story) to confirm the Point flow is unaffected (Select / Translate / MoveToClick / Modify still work the way they did before)
  - run `pnpm test` in `packages/lib-classifier` and confirm `createGeoLineStringInteraction.spec.js` (6 tests) passes
- Which storybook stories should be reviewed?
  - `Subject Viewers / GeoMapViewer` → `WithGeoDrawingLineStringTask` (new in this PR): http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-geo-drawing-line-string-task
- Are there plans for follow up PR's to further fix this bug or develop this feature?
  - Yes. This is PR 3 of 9 in the **Segmented Line** milestone. Sequential PRs that follow this one (in merge order):
    1. #7364 lib-classifier: Suppress map navigation while drawing LineString
    2. #7365 lib-classifier: Add Modify interaction for LineString vertex editing
    3. #7366 lib-classifier: Add max_vertices and min_vertices to LineStringTool
    4. #7367 lib-classifier: Add min and max line count to LineStringTool
    5. #7368 lib-classifier: Add delete affordance for selected LineString feature
    6. [#7459 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7459): Add LineString tool to GeoDrawing task editor

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
