### PR TITLE
[DRAFT] lib-classifier: Refactor GeoDrawing Point uncertainty circle performance

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/Point/Point.js
@@ -1,5 +1,6 @@
 import { types } from 'mobx-state-tree'
 import { Point as OLPoint } from 'ol/geom'
+import { Circle as OLCircleGeometry } from 'ol/geom'
 import Style from 'ol/style/Style'
 import Fill from 'ol/style/Fill'
 import Stroke from 'ol/style/Stroke'
@@ -72,8 +73,8 @@ const Point = types
       return indexedTool || tools.find(tool => tool.type === 'Point')
     },
 
-    getUncertaintyCircleStyle({ color, radius }) {
-      if (!radius || radius <= 0) return undefined
+    getUncertaintyCircleStyle({ color, center, radius }) {
+      if (!radius || radius <= 0 || !Array.isArray(center) || center.length < 2) return undefined
 
       const lineOpacity = DEFAULT_UNCERTAINTY_OPACITY
       const backgroundOpacity = DEFAULT_UNCERTAINTY_BACKGROUND_OPACITY
@@ -122,11 +123,9 @@ const Point = types
       }
 
       return new Style({
-        image: new Circle({
-          radius,
-          fill: new Fill({ color: fillPattern }),
-          stroke: new Stroke({ color, width: 2, lineDash: [5, 10] })
-        })
+        geometry: new OLCircleGeometry(center, radius),
+        fill: new Fill({ color: fillPattern }),
+        stroke: new Stroke({ color, width: 2, lineDash: [5, 10] })
       })
     },
 
@@ -145,12 +144,18 @@ const Point = types
 
       const styles = []
 
+      const centerCoordinates = self.getCenterCoordinates({ feature })
+      const uncertaintyRadiusCoords = self.getUncertaintyRadius({ feature, geoDrawingTask })
       const uncertaintyRadiusPixels = self.getUncertaintyRadiusPixels({ feature, geoDrawingTask, resolution })
       const hasVisibleUncertaintyHandle = uncertaintyRadiusPixels !== undefined
 
       // Draw uncertainty circle if enabled and radius is greater than zero
-      if (hasVisibleUncertaintyHandle && uncertaintyRadiusPixels > 0) {
-        styles.push(self.getUncertaintyCircleStyle({ color, radius: uncertaintyRadiusPixels }))
+      if (typeof uncertaintyRadiusCoords === 'number' && uncertaintyRadiusCoords > 0) {
+        styles.push(self.getUncertaintyCircleStyle({
+          color,
+          center: centerCoordinates,
+          radius: uncertaintyRadiusCoords
+        }))
       }
 
       // Draw the drag handle if uncertainty circle is enabled, even if radius is zero


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post

## Describe your changes

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected