### PR TITLE
[DRAFT] lib-classifier: refactor GeoMapViewer and Point uncertainty circle per performance issues

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -74,6 +74,8 @@ const MapContainer = styled.div`
 `
 
 const ZOOM_ANIMATION_DURATION_MS = 250
+const POINTER_MOVE_HIT_CHECK_INTERVAL_MS = 80
+const POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS = 4
 
 // Maps UnitSelect display options to OpenLayers ScaleLine unit strings
 const UNIT_OPTION_TO_SCALE_LINE_UNITS = {
@@ -169,6 +171,7 @@ function GeoMapViewer({
     // create a GeoJSON format reader
     const geoJSONFormat = new GeoJSON()
     geoJSONFormatRef.current = geoJSONFormat
+    let pointerMoveRafId = null
 
     const baseLayer = new TileLayer({
       // preload tiles for 1 level of zooming
@@ -312,97 +315,129 @@ function GeoMapViewer({
       // Note: we target the viewport element (not the outer target element) so that
       // our inline style.cursor overrides OL's class-based cursor (ol-grab, ol-grabbing)
       // which Translate sets on the viewport via classList.
-      const handlePointerMove = (event) => {
-        if (isMeasureModeActiveRef.current) {
-          const element = map.getTargetElement()
+      let latestPointerMoveEvent = null
+      let lastAppliedCursor = ''
+      let lastHitCheckTs = 0
+      let lastHitCheckPixel = null
+      let lastHitCheckResult = false
 
-          if (element) {
-            element.style.cursor = ''
+      function applyCursor(element, cursor) {
+        if (lastAppliedCursor === cursor) return
+        element.style.cursor = cursor
+        lastAppliedCursor = cursor
+      }
+
+      const handlePointerMove = (event) => {
+        latestPointerMoveEvent = event
+
+        if (pointerMoveRafId !== null) return
+
+        pointerMoveRafId = requestAnimationFrame(() => {
+          pointerMoveRafId = null
+          const latestEvent = latestPointerMoveEvent
+          if (!latestEvent) return
+
+          if (isMeasureModeActiveRef.current) {
+            const element = map.getTargetElement()
+
+            if (element) {
+              applyCursor(element, '')
+            }
+
+            return
           }
 
-          return
-        }
+          const element = map.getViewport()
+          if (!element) return
 
-        const element = map.getViewport()
-        if (!element) return
+          let cursor = ''
+          const selectedFeature = select.getFeatures().item(0)
 
-        let cursor = ''
-        const selectedFeature = select.getFeatures().item(0)
+          if (selectedFeature) {
+            const mstFeature = asMSTFeature(selectedFeature)
+            const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
 
-        if (selectedFeature) {
-          const mstFeature = asMSTFeature(selectedFeature)
-          const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
-
-          if (mstFeature && Array.isArray(pointCoordinates)) {
-            const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
-            const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
-              feature: selectedFeature,
-              geoDrawingTask
-            })
-
-            // If we're near the feature center, grab/grabbing takes priority
-            if (isPixelNearPointCenter({
-              pixel: event.pixel,
-              pointPixel,
-              radius: POINT_CENTER_HIT_RADIUS_PIXELS
-            })) {
-              cursor = isDraggingPoint ? 'grabbing' : 'grab'
-            }
-
-            // If we're near the drag handle, show the resize cursor
-            if (!cursor && dragHandleCoordinates) {
-              const dragHandlePixel = map.getPixelFromCoordinate(dragHandleCoordinates)
-              if (isPixelNearDragHandle({
-                pixel: event.pixel,
-                handlePixel: dragHandlePixel,
-                tolerance: 15
-              })) {
-                cursor = 'ew-resize'
-              }
-            }
-
-            // If the feature has an uncertainty radius, show the default cursor when hovering over it
-            if (!cursor) {
-              const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
+            if (mstFeature && Array.isArray(pointCoordinates)) {
+              const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
+              const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
                 feature: selectedFeature,
-                geoDrawingTask,
-                resolution: map.getView().getResolution()
+                geoDrawingTask
               })
 
-              if (
-                typeof uncertaintyRadiusPixels === 'number'
-                && uncertaintyRadiusPixels > 0
-                && getPixelDistance(event.pixel, pointPixel) <= uncertaintyRadiusPixels
-              ) {
-                cursor = 'default'
+              // If we're near the feature center, grab/grabbing takes priority
+              if (isPixelNearPointCenter({
+                pixel: latestEvent.pixel,
+                pointPixel,
+                radius: POINT_CENTER_HIT_RADIUS_PIXELS
+              })) {
+                cursor = isDraggingPoint ? 'grabbing' : 'grab'
+              }
+
+              // If we're near the drag handle, show the resize cursor
+              if (!cursor && dragHandleCoordinates) {
+                const dragHandlePixel = map.getPixelFromCoordinate(dragHandleCoordinates)
+                if (isPixelNearDragHandle({
+                  pixel: latestEvent.pixel,
+                  handlePixel: dragHandlePixel,
+                  tolerance: 15
+                })) {
+                  cursor = 'ew-resize'
+                }
+              }
+
+              // If the feature has an uncertainty radius, show the default cursor when hovering over it
+              if (!cursor) {
+                const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
+                  feature: selectedFeature,
+                  geoDrawingTask,
+                  resolution: map.getView().getResolution()
+                })
+
+                if (
+                  typeof uncertaintyRadiusPixels === 'number'
+                  && uncertaintyRadiusPixels > 0
+                  && getPixelDistance(latestEvent.pixel, pointPixel) <= uncertaintyRadiusPixels
+                ) {
+                  cursor = 'default'
+                }
               }
             }
           }
-        }
 
-        if (!cursor) {
-          if (selectedFeature) {
-            // When a feature is selected, only show pointer over another feature's center point (which is selectable)
-            let hoveringOtherCenter = false
-            featuresLayer.getSource().forEachFeature((feature) => {
-              if (feature === selectedFeature || hoveringOtherCenter) return
-              const coords = feature.getGeometry()?.getCoordinates?.()
-              if (!Array.isArray(coords)) return
-              const featurePixel = map.getPixelFromCoordinate(coords)
-              if (isPixelNearPointCenter({ pixel: event.pixel, pointPixel: featurePixel, radius: POINT_CENTER_HIT_RADIUS_PIXELS })) {
-                hoveringOtherCenter = true
+          if (!cursor) {
+            if (selectedFeature) {
+              // When a feature is selected, only show pointer over another feature's center point (which is selectable)
+              let hoveringOtherCenter = false
+              featuresLayer.getSource().forEachFeature((feature) => {
+                if (feature === selectedFeature || hoveringOtherCenter) return
+                const coords = feature.getGeometry()?.getCoordinates?.()
+                if (!Array.isArray(coords)) return
+                const featurePixel = map.getPixelFromCoordinate(coords)
+                if (isPixelNearPointCenter({ pixel: latestEvent.pixel, pointPixel: featurePixel, radius: POINT_CENTER_HIT_RADIUS_PIXELS })) {
+                  hoveringOtherCenter = true
+                }
+              })
+              cursor = hoveringOtherCenter ? 'pointer' : 'default'
+            } else {
+              const now = performance.now()
+              const movedEnough = !lastHitCheckPixel
+                || getPixelDistance(latestEvent.pixel, lastHitCheckPixel) >= POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS
+              const elapsedEnough = (now - lastHitCheckTs) >= POINTER_MOVE_HIT_CHECK_INTERVAL_MS
+
+              if (movedEnough || elapsedEnough) {
+                lastHitCheckResult = map.hasFeatureAtPixel(latestEvent.pixel, {
+                  layerFilter: (layer) => layer === featuresLayer
+                })
+                lastHitCheckTs = now
+                lastHitCheckPixel = [...latestEvent.pixel]
               }
-            })
-            cursor = hoveringOtherCenter ? 'pointer' : 'default'
-          } else {
-            const hit = map.hasFeatureAtPixel(event.pixel, {
-              layerFilter: (layer) => layer === featuresLayer
-            })
-            cursor = hit ? 'pointer' : 'default'
-          }
-        }
 
-        element.style.cursor = cursor
+              cursor = lastHitCheckResult ? 'pointer' : 'default'
+            }
+          }
+
+          applyCursor(element, cursor)
+        })
       }
       map.on('pointermove', handlePointerMove)
       pointerMoveHandlerRef.current = handlePointerMove
@@ -429,6 +464,7 @@ function GeoMapViewer({
       if (moveToClickRef.current) map.removeInteraction(moveToClickRef.current)
       measureInteractionRef.current?.destroy()
       if (pointerMoveHandlerRef.current) map.un('pointermove', pointerMoveHandlerRef.current)
+      if (pointerMoveRafId !== null) cancelAnimationFrame(pointerMoveRafId)
       map.setTarget(undefined)
       mapRef.current = undefined
       featuresRef.current = undefined

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -31,10 +31,11 @@ import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 import asMSTFeature from './helpers/asMSTFeature'
 import createMeasureInteraction from './helpers/createMeasureInteraction'
-import createModifyUncertaintyInteraction, { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './helpers/createModifyUncertaintyInteraction'
+import createModifyUncertaintyInteraction from './helpers/createModifyUncertaintyInteraction'
 import createMoveToClickInteraction from './helpers/createMoveToClickInteraction'
 import getFeatureStyle from './helpers/getFeatureStyle'
 import getPixelDistance from './helpers/getPixelDistance'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './helpers/hitTesting'
 
 const StyledBox = styled(Box)`
   position: relative;
@@ -321,6 +322,44 @@ function GeoMapViewer({
       let lastHitCheckPixel = null
       let lastHitCheckResult = false
 
+      function isPointerOverFeature(pixel) {
+        let isOverFeature = false
+
+        featuresLayer.getSource().forEachFeature((feature) => {
+          if (isOverFeature) return
+
+          const coords = feature.getGeometry()?.getCoordinates?.()
+          if (!Array.isArray(coords)) return
+
+          const pointPixel = map.getPixelFromCoordinate(coords)
+          if (isPixelNearPointCenter({
+            pixel,
+            pointPixel,
+            radius: POINT_CENTER_HIT_RADIUS_PIXELS
+          })) {
+            isOverFeature = true
+            return
+          }
+
+          const mstFeature = asMSTFeature(feature)
+          const uncertaintyRadiusPixels = mstFeature?.getUncertaintyRadiusPixels?.({
+            feature,
+            geoDrawingTask,
+            resolution: map.getView().getResolution()
+          })
+
+          if (
+            typeof uncertaintyRadiusPixels === 'number'
+            && uncertaintyRadiusPixels > 0
+            && getPixelDistance(pixel, pointPixel) <= uncertaintyRadiusPixels
+          ) {
+            isOverFeature = true
+          }
+        })
+
+        return isOverFeature
+      }
+
       function applyCursor(element, cursor) {
         if (lastAppliedCursor === cursor) return
         element.style.cursor = cursor
@@ -425,9 +464,7 @@ function GeoMapViewer({
               const elapsedEnough = (now - lastHitCheckTs) >= POINTER_MOVE_HIT_CHECK_INTERVAL_MS
 
               if (movedEnough || elapsedEnough) {
-                lastHitCheckResult = map.hasFeatureAtPixel(latestEvent.pixel, {
-                  layerFilter: (layer) => layer === featuresLayer
-                })
+                lastHitCheckResult = isPointerOverFeature(latestEvent.pixel)
                 lastHitCheckTs = now
                 lastHitCheckPixel = [...latestEvent.pixel]
               }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -11,7 +11,7 @@ import { defaults as defaultControls } from 'ol/control/defaults'
 import ScaleLine from 'ol/control/ScaleLine'
 import { click } from 'ol/events/condition'
 import GeoJSON from 'ol/format/GeoJSON'
-import { Translate, Select } from 'ol/interaction'
+import { Select } from 'ol/interaction'
 import TileLayer from 'ol/layer/Tile'
 import VectorLayer from 'ol/layer/Vector'
 import OSM from 'ol/source/OSM'
@@ -147,7 +147,6 @@ function GeoMapViewer({
   // Interaction refs: created once and reused to avoid re-stacking on data updates
   const scaleLineRef = useRef()
   const selectRef = useRef()
-  const translateRef = useRef()
   const modifyUncertaintyRef = useRef()
   const moveToClickRef = useRef()
   const measureInteractionRef = useRef()
@@ -248,49 +247,19 @@ function GeoMapViewer({
         isSelected: select.getFeatures().getArray().includes(feature)
       }))
 
-      // Create translate interaction restricted to the center point hit area.
-      // Without a condition, OL's Translate uses its own hit detection against the
-      // feature's rendered style (which includes the uncertainty circle), causing
-      // drags anywhere inside the circle to move the feature. The condition limits
-      // translation to pointerdown events within POINT_CENTER_HIT_RADIUS_PIXELS of
-      // the feature center.
-      const translate = new Translate({
-        features: select.getFeatures(),
-        condition: (mapBrowserEvent) => {
-          const selectedFeatures = select.getFeatures().getArray()
-          if (selectedFeatures.length === 0) return false
-
-          const selectedFeature = selectedFeatures[0]
-          const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
-          if (!Array.isArray(pointCoordinates)) return false
-
-          const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
-          return isPixelNearPointCenter({
-            pixel: mapBrowserEvent.pixel,
-            pointPixel,
-            radius: POINT_CENTER_HIT_RADIUS_PIXELS
-          })
-        }
-      })
-
-      // Add select and translate interactions to the map
+      // Add select interaction to the map.
       map.addInteraction(select)
-      map.addInteraction(translate)
       selectRef.current = select
-      translateRef.current = translate
 
       // Create and add uncertainty circle modification interaction
       const modifyUncertainty = createModifyUncertaintyInteraction({
         geoDrawingTask,
-        selectInteraction: select,
-        translateInteraction: translate
+        selectInteraction: select
       })
       map.addInteraction(modifyUncertainty)
       modifyUncertaintyRef.current = modifyUncertainty
 
-      // Track whether a point is actively being dragged to switch grab → grabbing.
-      // Center-point drags are captured by moveToClick (not Translate), so we use
-      // onDragStart/onDragEnd callbacks to update the cursor immediately on press.
+      // Track whether a point is actively being dragged to switch grab -> grabbing.
       let isDraggingPoint = false
 
       // Create and add move-to-click interaction
@@ -313,9 +282,7 @@ function GeoMapViewer({
       moveToClickRef.current = moveToClick
 
       // Add cursor states that match the active interactions.
-      // Note: we target the viewport element (not the outer target element) so that
-      // our inline style.cursor overrides OL's class-based cursor (ol-grab, ol-grabbing)
-      // which Translate sets on the viewport via classList.
+      // Note: we target the viewport element (not the outer target element).
       let latestPointerMoveEvent = null
       let lastAppliedCursor = ''
       let lastHitCheckTs = 0
@@ -496,7 +463,6 @@ function GeoMapViewer({
 
     return () => {
       if (selectRef.current) map.removeInteraction(selectRef.current)
-      if (translateRef.current) map.removeInteraction(translateRef.current)
       if (modifyUncertaintyRef.current) map.removeInteraction(modifyUncertaintyRef.current)
       if (moveToClickRef.current) map.removeInteraction(moveToClickRef.current)
       measureInteractionRef.current?.destroy()
@@ -508,7 +474,6 @@ function GeoMapViewer({
       geoJSONFormatRef.current = undefined
       scaleLineRef.current = undefined
       selectRef.current = undefined
-      translateRef.current = undefined
       modifyUncertaintyRef.current = undefined
       moveToClickRef.current = undefined
       measureInteractionRef.current = undefined
@@ -535,7 +500,6 @@ function GeoMapViewer({
     }
 
     selectRef.current?.setActive(!isMeasureModeActive)
-    translateRef.current?.setActive(!isMeasureModeActive)
     modifyUncertaintyRef.current?.setActive(!isMeasureModeActive)
     moveToClickRef.current?.setActive(!isMeasureModeActive)
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
@@ -25,7 +25,6 @@ function shouldStartDragHandleInteraction({
 function createModifyUncertaintyInteraction({
   geoDrawingTask,
   selectInteraction,
-  translateInteraction,
   dragHandleTolerance = 15, // pixels
   minRadius = 0 // meters
 }) {
@@ -107,11 +106,6 @@ function createModifyUncertaintyInteraction({
       state.draggedFeature = selectedFeature
       state.isDragging = true
 
-      // Disable Translate interaction while dragging uncertainty drag handle
-      if (translateInteraction) {
-        translateInteraction.setActive(false)
-      }
-
       // Update cursor
       const viewport = map.getViewport()
       if (viewport) {
@@ -160,11 +154,6 @@ function createModifyUncertaintyInteraction({
     if (state.isDragging) {
       state.isDragging = false
       state.draggedFeature = null
-
-      // Re-enable Translate interaction
-      if (translateInteraction) {
-        translateInteraction.setActive(true)
-      }
 
       // Reset cursor
       const map = this.getMap()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
@@ -2,23 +2,9 @@ import PointerInteraction from 'ol/interaction/Pointer'
 import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import asMSTFeature from './asMSTFeature'
 import getPixelDistance from './getPixelDistance'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './hitTesting'
 
-export const POINT_CENTER_HIT_RADIUS_PIXELS = 10
-
-export function isPixelNearPointCenter({
-  pixel,
-  pointPixel,
-  radius = POINT_CENTER_HIT_RADIUS_PIXELS
-}) {
-  if (!Array.isArray(pixel) || !Array.isArray(pointPixel)) return false
-
-  const deltaX = pixel[0] - pointPixel[0]
-  const deltaY = pixel[1] - pointPixel[1]
-
-  return (deltaX * deltaX) + (deltaY * deltaY) <= radius * radius
-}
-
-export function shouldStartDragHandleInteraction({
+function shouldStartDragHandleInteraction({
   pixel,
   pointPixel,
   handlePixel,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
@@ -37,6 +37,16 @@ function createMoveToClickInteraction({
   }
 
   function isPointerOnResizeHandle({ pixel, map, olFeature, mstFeature }) {
+    const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
+      feature: olFeature,
+      geoDrawingTask,
+      resolution: map.getView().getResolution()
+    })
+
+    if (!(typeof uncertaintyRadiusPixels === 'number' && uncertaintyRadiusPixels > 0)) {
+      return false
+    }
+
     const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
       feature: olFeature,
       geoDrawingTask
@@ -138,6 +148,26 @@ function createMoveToClickInteraction({
     state.draggingFeature = false
 
     const mstFeature = asMSTFeature(state.selectedFeature)
+    const clickedInsideSelectedFeature = mstFeature
+      ? isPointerInsideSelectedFeature({
+        pixel: event.pixel,
+        map,
+        olFeature: state.selectedFeature
+      })
+      : false
+
+    state.clickedOnFeature = clickedInsideSelectedFeature
+
+    // Prioritize center-point dragging over uncertainty-handle checks.
+    // At far zoom, tiny uncertainty circles can place the handle near center.
+    if (clickedInsideSelectedFeature) {
+      state.draggingFeature = true
+      state.disabledSelect = true
+      selectInteraction.setActive(false)
+      onDragStart?.()
+      return true
+    }
+
     const clickedOnResizeHandle = mstFeature
       ? isPointerOnResizeHandle({
         pixel: event.pixel,
@@ -169,24 +199,6 @@ function createMoveToClickInteraction({
       state.clickedInUncertaintyCircle = true
       state.disabledSelect = true
       selectInteraction.setActive(false)
-      return true
-    }
-
-    const clickedInsideSelectedFeature = mstFeature
-      ? isPointerInsideSelectedFeature({
-        pixel: event.pixel,
-        map,
-        olFeature: state.selectedFeature
-      })
-      : false
-
-    state.clickedOnFeature = clickedInsideSelectedFeature
-
-    if (clickedInsideSelectedFeature) {
-      state.draggingFeature = true
-      state.disabledSelect = true
-      selectInteraction.setActive(false)
-      onDragStart?.()
       return true
     }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
@@ -2,7 +2,7 @@ import PointerInteraction from 'ol/interaction/Pointer'
 import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import asMSTFeature from './asMSTFeature'
 import getPixelDistance from './getPixelDistance'
-import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './createModifyUncertaintyInteraction'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './hitTesting'
 
 export const MOVE_TO_CLICK_HOLD_DELAY = 250
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
@@ -1,0 +1,14 @@
+export const POINT_CENTER_HIT_RADIUS_PIXELS = 10
+
+export function isPixelNearPointCenter({
+  pixel,
+  pointPixel,
+  radius = POINT_CENTER_HIT_RADIUS_PIXELS
+}) {
+  if (!Array.isArray(pixel) || !Array.isArray(pointPixel)) return false
+
+  const deltaX = pixel[0] - pointPixel[0]
+  const deltaY = pixel[1] - pointPixel[1]
+
+  return (deltaX * deltaX) + (deltaY * deltaY) <= radius * radius
+}

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/Point/Point.js
@@ -88,7 +88,7 @@ const Point = types
       if (!fillPattern) {
         const canvas = document.createElement('canvas')
         const tileSize = Math.max(spacing * 2, 12)
-        const context = canvas.getContext('2d')
+        const context = canvas.getContext('2d', { willReadFrequently: true })
 
         canvas.width = tileSize
         canvas.height = tileSize

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/Point/Point.js
@@ -1,5 +1,6 @@
 import { types } from 'mobx-state-tree'
 import { Point as OLPoint } from 'ol/geom'
+import { Circle as OLCircleGeometry } from 'ol/geom'
 import Style from 'ol/style/Style'
 import Fill from 'ol/style/Fill'
 import Stroke from 'ol/style/Stroke'
@@ -72,8 +73,8 @@ const Point = types
       return indexedTool || tools.find(tool => tool.type === 'Point')
     },
 
-    getUncertaintyCircleStyle({ color, radius }) {
-      if (!radius || radius <= 0) return undefined
+    getUncertaintyCircleStyle({ color, center, radius }) {
+      if (!radius || radius <= 0 || !Array.isArray(center) || center.length < 2) return undefined
 
       const lineOpacity = DEFAULT_UNCERTAINTY_OPACITY
       const backgroundOpacity = DEFAULT_UNCERTAINTY_BACKGROUND_OPACITY
@@ -122,11 +123,9 @@ const Point = types
       }
 
       return new Style({
-        image: new Circle({
-          radius,
-          fill: new Fill({ color: fillPattern }),
-          stroke: new Stroke({ color, width: 2, lineDash: [5, 10] })
-        })
+        geometry: new OLCircleGeometry(center, radius),
+        fill: new Fill({ color: fillPattern }),
+        stroke: new Stroke({ color, width: 2, lineDash: [5, 10] })
       })
     },
 
@@ -145,12 +144,18 @@ const Point = types
 
       const styles = []
 
+      const centerCoordinates = self.getCenterCoordinates({ feature })
+      const uncertaintyRadiusCoords = self.getUncertaintyRadius({ feature, geoDrawingTask })
       const uncertaintyRadiusPixels = self.getUncertaintyRadiusPixels({ feature, geoDrawingTask, resolution })
       const hasVisibleUncertaintyHandle = uncertaintyRadiusPixels !== undefined
 
       // Draw uncertainty circle if enabled and radius is greater than zero
-      if (hasVisibleUncertaintyHandle && uncertaintyRadiusPixels > 0) {
-        styles.push(self.getUncertaintyCircleStyle({ color, radius: uncertaintyRadiusPixels }))
+      if (typeof uncertaintyRadiusCoords === 'number' && uncertaintyRadiusCoords > 0) {
+        styles.push(self.getUncertaintyCircleStyle({
+          color,
+          center: centerCoordinates,
+          radius: uncertaintyRadiusCoords
+        }))
       }
 
       // Draw the drag handle if uncertainty circle is enabled, even if radius is zero


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post

## Describe your changes

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected