### PR TITLE
Add zooniverse:deployed_app as custom metadata to the apps

### DIFF
--- a/packages/app-project/src/components/Head/Head.jsx
+++ b/packages/app-project/src/components/Head/Head.jsx
@@ -51,6 +51,7 @@ function Head (props) {
 
       <meta name='zooniverse:deployed_commit' content={process.env.COMMIT_ID} />
       <meta name='zooniverse:deployed_ref' content={process.env.GITHUB_REF_NAME} />
+      <meta name='zooniverse:deployed_app' content='fe-project' />
     </NextHead>
   )
 }

--- a/packages/app-root/src/app/layout.js
+++ b/packages/app-root/src/app/layout.js
@@ -21,7 +21,8 @@ export const metadata = {
     creator: '@the_zooniverse'
   },
   other: {
-    'zooniverse:deployed_commit': process.env.COMMIT_ID
+    'zooniverse:deployed_commit': process.env.COMMIT_ID,
+    'zooniverse:deployed_app': 'fe-root'
   }
 }
 


### PR DESCRIPTION
## Package
app-project
app-root

## Describe your changes
This is an enhancement to the Next.js apps' metadata to help with debugging CDN caching or preparing to switch routes from PFE to FEM via `curl`.

## How to Review
This PR has no effect on the functionality of either app. It adds `zooniverse:deployed_app` as a custom metadata property in the `<head>` of app-project (fe-project) and to the `<body>` of app-root (fe-root). The latter can't inject custom metadata into the `<head>` due to [Metadata Streaming](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#streaming-metadata) in Next.js's App Router since version 15+.

attn: @zwolf happy to discuss if this is actually helpful for sending requests to the deployed apps. See note ^ about `<head>` vs `<body>`.

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)