### PR TITLE
lib-classifier: Refactor GeoMapViewer with shared hitTesting helper and pointermove throttle

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -31,10 +31,11 @@ import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 import asMSTFeature from './helpers/asMSTFeature'
 import createMeasureInteraction from './helpers/createMeasureInteraction'
-import createModifyUncertaintyInteraction, { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './helpers/createModifyUncertaintyInteraction'
+import createModifyUncertaintyInteraction from './helpers/createModifyUncertaintyInteraction'
 import createMoveToClickInteraction from './helpers/createMoveToClickInteraction'
 import getFeatureStyle from './helpers/getFeatureStyle'
 import getPixelDistance from './helpers/getPixelDistance'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './helpers/hitTesting'
 
 const StyledBox = styled(Box)`
   position: relative;
@@ -74,6 +75,8 @@ const MapContainer = styled.div`
 `
 
 const ZOOM_ANIMATION_DURATION_MS = 250
+const POINTER_MOVE_HIT_CHECK_INTERVAL_MS = 80
+const POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS = 4
 
 // Maps UnitSelect display options to OpenLayers ScaleLine unit strings
 const UNIT_OPTION_TO_SCALE_LINE_UNITS = {
@@ -169,6 +172,7 @@ function GeoMapViewer({
     // create a GeoJSON format reader
     const geoJSONFormat = new GeoJSON()
     geoJSONFormatRef.current = geoJSONFormat
+    let pointerMoveRafId = null
 
     const baseLayer = new TileLayer({
       // preload tiles for 1 level of zooming
@@ -284,10 +288,59 @@ function GeoMapViewer({
       map.addInteraction(modifyUncertainty)
       modifyUncertaintyRef.current = modifyUncertainty
 
-      // Track whether a point is actively being dragged to switch grab → grabbing.
+      // Track whether a point is actively being dragged to switch grab -> grabbing.
       // Center-point drags are captured by moveToClick (not Translate), so we use
       // onDragStart/onDragEnd callbacks to update the cursor immediately on press.
       let isDraggingPoint = false
+      let latestPointerMoveEvent = null
+      let lastAppliedCursor = ''
+      let lastHitCheckTs = 0
+      let lastHitCheckPixel = null
+      let lastHitCheckResult = false
+
+      function applyCursor(element, cursor) {
+        if (lastAppliedCursor === cursor) return
+        element.style.cursor = cursor
+        lastAppliedCursor = cursor
+      }
+
+      function isPointerOverFeature(pixel) {
+        let isOverFeature = false
+
+        featuresLayer.getSource().forEachFeature((feature) => {
+          if (isOverFeature) return
+
+          const coords = feature.getGeometry()?.getCoordinates?.()
+          if (!Array.isArray(coords)) return
+
+          const pointPixel = map.getPixelFromCoordinate(coords)
+          if (isPixelNearPointCenter({
+            pixel,
+            pointPixel,
+            radius: POINT_CENTER_HIT_RADIUS_PIXELS
+          })) {
+            isOverFeature = true
+            return
+          }
+
+          const mstFeature = asMSTFeature(feature)
+          const uncertaintyRadiusPixels = mstFeature?.getUncertaintyRadiusPixels?.({
+            feature,
+            geoDrawingTask,
+            resolution: map.getView().getResolution()
+          })
+
+          if (
+            typeof uncertaintyRadiusPixels === 'number'
+            && uncertaintyRadiusPixels > 0
+            && getPixelDistance(pixel, pointPixel) <= uncertaintyRadiusPixels
+          ) {
+            isOverFeature = true
+          }
+        })
+
+        return isOverFeature
+      }
 
       // Create and add move-to-click interaction
       const moveToClick = createMoveToClickInteraction({
@@ -313,96 +366,116 @@ function GeoMapViewer({
       // our inline style.cursor overrides OL's class-based cursor (ol-grab, ol-grabbing)
       // which Translate sets on the viewport via classList.
       const handlePointerMove = (event) => {
-        if (isMeasureModeActiveRef.current) {
-          const element = map.getTargetElement()
+        latestPointerMoveEvent = event
 
-          if (element) {
-            element.style.cursor = ''
+        if (pointerMoveRafId !== null) return
+
+        pointerMoveRafId = requestAnimationFrame(() => {
+          pointerMoveRafId = null
+
+          const latestEvent = latestPointerMoveEvent
+          if (!latestEvent) return
+
+          if (isMeasureModeActiveRef.current) {
+            const targetElement = map.getTargetElement()
+
+            if (targetElement) {
+              applyCursor(targetElement, '')
+            }
+
+            return
           }
 
-          return
-        }
+          const element = map.getViewport()
+          if (!element) return
 
-        const element = map.getViewport()
-        if (!element) return
+          let cursor = ''
+          const selectedFeature = select.getFeatures().item(0)
 
-        let cursor = ''
-        const selectedFeature = select.getFeatures().item(0)
+          if (selectedFeature) {
+            const mstFeature = asMSTFeature(selectedFeature)
+            const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
 
-        if (selectedFeature) {
-          const mstFeature = asMSTFeature(selectedFeature)
-          const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
-
-          if (mstFeature && Array.isArray(pointCoordinates)) {
-            const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
-            const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
-              feature: selectedFeature,
-              geoDrawingTask
-            })
-
-            // If we're near the feature center, grab/grabbing takes priority
-            if (isPixelNearPointCenter({
-              pixel: event.pixel,
-              pointPixel,
-              radius: POINT_CENTER_HIT_RADIUS_PIXELS
-            })) {
-              cursor = isDraggingPoint ? 'grabbing' : 'grab'
-            }
-
-            // If we're near the drag handle, show the resize cursor
-            if (!cursor && dragHandleCoordinates) {
-              const dragHandlePixel = map.getPixelFromCoordinate(dragHandleCoordinates)
-              if (isPixelNearDragHandle({
-                pixel: event.pixel,
-                handlePixel: dragHandlePixel,
-                tolerance: 15
-              })) {
-                cursor = 'ew-resize'
-              }
-            }
-
-            // If the feature has an uncertainty radius, show the default cursor when hovering over it
-            if (!cursor) {
-              const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
+            if (mstFeature && Array.isArray(pointCoordinates)) {
+              const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
+              const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
                 feature: selectedFeature,
-                geoDrawingTask,
-                resolution: map.getView().getResolution()
+                geoDrawingTask
               })
 
-              if (
-                typeof uncertaintyRadiusPixels === 'number'
-                && uncertaintyRadiusPixels > 0
-                && getPixelDistance(event.pixel, pointPixel) <= uncertaintyRadiusPixels
-              ) {
-                cursor = 'default'
+              if (isPixelNearPointCenter({
+                pixel: latestEvent.pixel,
+                pointPixel,
+                radius: POINT_CENTER_HIT_RADIUS_PIXELS
+              })) {
+                cursor = isDraggingPoint ? 'grabbing' : 'grab'
+              }
+
+              if (!cursor && dragHandleCoordinates) {
+                const dragHandlePixel = map.getPixelFromCoordinate(dragHandleCoordinates)
+                if (isPixelNearDragHandle({
+                  pixel: latestEvent.pixel,
+                  handlePixel: dragHandlePixel,
+                  tolerance: 15
+                })) {
+                  cursor = 'ew-resize'
+                }
+              }
+
+              if (!cursor) {
+                const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
+                  feature: selectedFeature,
+                  geoDrawingTask,
+                  resolution: map.getView().getResolution()
+                })
+
+                if (
+                  typeof uncertaintyRadiusPixels === 'number'
+                  && uncertaintyRadiusPixels > 0
+                  && getPixelDistance(latestEvent.pixel, pointPixel) <= uncertaintyRadiusPixels
+                ) {
+                  cursor = 'default'
+                }
               }
             }
           }
-        }
 
-        if (!cursor) {
-          if (selectedFeature) {
-            // When a feature is selected, only show pointer over another feature's center point (which is selectable)
-            let hoveringOtherCenter = false
-            featuresLayer.getSource().forEachFeature((feature) => {
-              if (feature === selectedFeature || hoveringOtherCenter) return
-              const coords = feature.getGeometry()?.getCoordinates?.()
-              if (!Array.isArray(coords)) return
-              const featurePixel = map.getPixelFromCoordinate(coords)
-              if (isPixelNearPointCenter({ pixel: event.pixel, pointPixel: featurePixel, radius: POINT_CENTER_HIT_RADIUS_PIXELS })) {
-                hoveringOtherCenter = true
+          if (!cursor) {
+            if (selectedFeature) {
+              // When a feature is selected, only show pointer over another feature's center point (which is selectable)
+              let hoveringOtherCenter = false
+              featuresLayer.getSource().forEachFeature((feature) => {
+                if (feature === selectedFeature || hoveringOtherCenter) return
+                const coords = feature.getGeometry()?.getCoordinates?.()
+                if (!Array.isArray(coords)) return
+                const featurePixel = map.getPixelFromCoordinate(coords)
+                if (isPixelNearPointCenter({
+                  pixel: latestEvent.pixel,
+                  pointPixel: featurePixel,
+                  radius: POINT_CENTER_HIT_RADIUS_PIXELS
+                })) {
+                  hoveringOtherCenter = true
+                }
+              })
+              cursor = hoveringOtherCenter ? 'pointer' : 'default'
+            } else {
+              const now = performance.now()
+              const movedEnough = !lastHitCheckPixel
+                || getPixelDistance(latestEvent.pixel, lastHitCheckPixel) >= POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS
+              const elapsedEnough = (now - lastHitCheckTs) >= POINTER_MOVE_HIT_CHECK_INTERVAL_MS
+
+              if (movedEnough || elapsedEnough) {
+                lastHitCheckResult = isPointerOverFeature(latestEvent.pixel)
+                lastHitCheckTs = now
+                lastHitCheckPixel = [...latestEvent.pixel]
               }
-            })
-            cursor = hoveringOtherCenter ? 'pointer' : 'default'
-          } else {
-            const hit = map.hasFeatureAtPixel(event.pixel, {
-              layerFilter: (layer) => layer === featuresLayer
-            })
-            cursor = hit ? 'pointer' : 'default'
-          }
-        }
 
-        element.style.cursor = cursor
+              cursor = lastHitCheckResult ? 'pointer' : 'default'
+            }
+          }
+
+          applyCursor(element, cursor)
+        })
       }
       map.on('pointermove', handlePointerMove)
       pointerMoveHandlerRef.current = handlePointerMove
@@ -429,6 +502,7 @@ function GeoMapViewer({
       if (moveToClickRef.current) map.removeInteraction(moveToClickRef.current)
       measureInteractionRef.current?.destroy()
       if (pointerMoveHandlerRef.current) map.un('pointermove', pointerMoveHandlerRef.current)
+      if (pointerMoveRafId !== null) cancelAnimationFrame(pointerMoveRafId)
       map.setTarget(undefined)
       mapRef.current = undefined
       featuresRef.current = undefined

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -74,8 +74,11 @@ const MapContainer = styled.div`
   width: 100%;
 `
 
+// Zoom animation duration in milliseconds
 const ZOOM_ANIMATION_DURATION_MS = 250
+// Minimum time between hit checks on pointermove, to throttle expensive hit testing
 const POINTER_MOVE_HIT_CHECK_INTERVAL_MS = 80
+// Minimum pixel distance the pointer must move to trigger a new hit test on pointermove, to throttle expensive hit testing
 const POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS = 4
 
 // Maps UnitSelect display options to OpenLayers ScaleLine unit strings
@@ -172,8 +175,7 @@ function GeoMapViewer({
     // create a GeoJSON format reader
     const geoJSONFormat = new GeoJSON()
     geoJSONFormatRef.current = geoJSONFormat
-    let pointerMoveRafId = null
-
+    
     const baseLayer = new TileLayer({
       // preload tiles for 1 level of zooming
       preload: 1,
@@ -204,6 +206,10 @@ function GeoMapViewer({
         (() => { const sl = new ScaleLine(); scaleLineRef.current = sl; return sl })()
       ])
     })
+
+    // track the latest pointermove event for hit testing, 
+    // and throttle hit testing to improve performance during fast mouse moves and zoom/pan animations
+    let pointerMoveRafId = null
 
     // Helper to compute style with current resolution
     function handleFeatureStyle({ feature, isSelected = false }) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
@@ -2,23 +2,9 @@ import PointerInteraction from 'ol/interaction/Pointer'
 import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import asMSTFeature from './asMSTFeature'
 import getPixelDistance from './getPixelDistance'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './hitTesting'
 
-export const POINT_CENTER_HIT_RADIUS_PIXELS = 10
-
-export function isPixelNearPointCenter({
-  pixel,
-  pointPixel,
-  radius = POINT_CENTER_HIT_RADIUS_PIXELS
-}) {
-  if (!Array.isArray(pixel) || !Array.isArray(pointPixel)) return false
-
-  const deltaX = pixel[0] - pointPixel[0]
-  const deltaY = pixel[1] - pointPixel[1]
-
-  return (deltaX * deltaX) + (deltaY * deltaY) <= radius * radius
-}
-
-export function shouldStartDragHandleInteraction({
+function shouldStartDragHandleInteraction({
   pixel,
   pointPixel,
   handlePixel,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
@@ -2,7 +2,7 @@ import PointerInteraction from 'ol/interaction/Pointer'
 import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import asMSTFeature from './asMSTFeature'
 import getPixelDistance from './getPixelDistance'
-import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './createModifyUncertaintyInteraction'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './hitTesting'
 
 export const MOVE_TO_CLICK_HOLD_DELAY = 250
 
@@ -37,6 +37,16 @@ function createMoveToClickInteraction({
   }
 
   function isPointerOnResizeHandle({ pixel, map, olFeature, mstFeature }) {
+    const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
+      feature: olFeature,
+      geoDrawingTask,
+      resolution: map.getView().getResolution()
+    })
+
+    if (!(typeof uncertaintyRadiusPixels === 'number' && uncertaintyRadiusPixels > 0)) {
+      return false
+    }
+
     const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
       feature: olFeature,
       geoDrawingTask
@@ -138,6 +148,26 @@ function createMoveToClickInteraction({
     state.draggingFeature = false
 
     const mstFeature = asMSTFeature(state.selectedFeature)
+    const clickedInsideSelectedFeature = mstFeature
+      ? isPointerInsideSelectedFeature({
+        pixel: event.pixel,
+        map,
+        olFeature: state.selectedFeature
+      })
+      : false
+
+    state.clickedOnFeature = clickedInsideSelectedFeature
+
+    // Prioritize center-point dragging over uncertainty-handle checks.
+    // At far zoom, tiny uncertainty circles can place the handle near center.
+    if (clickedInsideSelectedFeature) {
+      state.draggingFeature = true
+      state.disabledSelect = true
+      selectInteraction.setActive(false)
+      onDragStart?.()
+      return true
+    }
+
     const clickedOnResizeHandle = mstFeature
       ? isPointerOnResizeHandle({
         pixel: event.pixel,
@@ -169,24 +199,6 @@ function createMoveToClickInteraction({
       state.clickedInUncertaintyCircle = true
       state.disabledSelect = true
       selectInteraction.setActive(false)
-      return true
-    }
-
-    const clickedInsideSelectedFeature = mstFeature
-      ? isPointerInsideSelectedFeature({
-        pixel: event.pixel,
-        map,
-        olFeature: state.selectedFeature
-      })
-      : false
-
-    state.clickedOnFeature = clickedInsideSelectedFeature
-
-    if (clickedInsideSelectedFeature) {
-      state.draggingFeature = true
-      state.disabledSelect = true
-      selectInteraction.setActive(false)
-      onDragStart?.()
       return true
     }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
@@ -1,0 +1,14 @@
+export const POINT_CENTER_HIT_RADIUS_PIXELS = 10
+
+export function isPixelNearPointCenter({
+  pixel,
+  pointPixel,
+  radius = POINT_CENTER_HIT_RADIUS_PIXELS
+}) {
+  if (!Array.isArray(pixel) || !Array.isArray(pointPixel)) return false
+
+  const deltaX = pixel[0] - pointPixel[0]
+  const deltaY = pixel[1] - pointPixel[1]
+
+  return (deltaX * deltaX) + (deltaY * deltaY) <= radius * radius
+}


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- performance issues noted moving point, particularly zoomed in 
- cursor grabbing doesn't show as expected when zoomed out

## Describe your changes
- create shared `hitTesting` helper, refactor GeoMapViewer and custom interactions accordingly
- `createMoveToClickInteraction` - moved `clickedInsideSelectedFeature` above other, mostly uncertainty circle related, functions to give clicking and dragging point higher priority than uncertainty circle related actions, fixing cursor grabbing bug
- refactor GeoMapViewer with `pointerMoveRafId` and `requestAnimationFrame` to throttle pointermove events to once per animation frame
- add `applyCursor` function so cursor styling changes are only applied when changed

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - staging/testing: https://local.zooniverse.org:8080/?project=2030&demo=true&workflow=3882
- What user actions should my reviewer step through to review this PR?
  - it's a little difficult to recreate issues consistently, but generally try zooming in and interacting (dragging and moving, point to move) with a point
  - zoom out and note subtle cursor doesn't show as grabbing when expected with very small (or zero) uncertainty circle
- Which storybook stories should be reviewed?
  - http://localhost:6006/?path=/story/geodrawing-tools-point--multiple-points-uncertainty-circles
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected