### PR TITLE
lib-classifier: Preserve pan and Measure while drawing LineString

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -34,6 +34,7 @@ import createGeoLineStringInteraction from './helpers/createGeoLineStringInterac
 import createMeasureInteraction from './helpers/createMeasureInteraction'
 import createModifyUncertaintyInteraction from './helpers/createModifyUncertaintyInteraction'
 import createMoveToClickInteraction from './helpers/createMoveToClickInteraction'
+import getDrawingModeUpdates from './helpers/getDrawingModeUpdates'
 import getFeatureStyle from './helpers/getFeatureStyle'
 import getPixelDistance from './helpers/getPixelDistance'
 import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixelsAcrossWorldCopies } from './helpers/hitTesting'
@@ -147,6 +148,7 @@ function GeoMapViewer({
   const featuresRef = useRef()
   const geoJSONFormatRef = useRef()
   const isMeasureModeActiveRef = useRef(false)
+  const isDrawModeActiveRef = useRef(false)
   
   // Interaction refs: created once and reused to avoid re-stacking on data updates
   const scaleLineRef = useRef()
@@ -406,6 +408,11 @@ function GeoMapViewer({
           const element = map.getViewport()
           if (!element) return
 
+          if (isDrawModeActiveRef.current) {
+            element.style.cursor = latestEvent.dragging ? '' : 'crosshair'
+            return
+          }
+
           let cursor = ''
           const selectedFeature = select.getFeatures().item(0)
 
@@ -547,28 +554,33 @@ function GeoMapViewer({
   }, [selectedUnit, geoDrawingTask])
 
   const activeToolType = geoDrawingTask?.activeTool?.type
+  useEffect(function exitMeasureOnDrawingToolSelect() {
+    if (activeToolType === 'LineString' && isMeasureModeActiveRef.current) {
+      measureInteractionRef.current?.clear()
+      setIsMeasureModeActive(false)
+    }
+  }, [activeToolType])
+
   useEffect(function syncDrawingToolMode() {
-    const isLineStringDrawing = activeToolType === 'LineString'
+    const updates = getDrawingModeUpdates(activeToolType, isMeasureModeActive)
+    isDrawModeActiveRef.current = updates.lineStringDraw
 
-    lineStringDrawRef.current?.setActive(isLineStringDrawing)
+    lineStringDrawRef.current?.setActive(updates.lineStringDraw)
 
-    if (isLineStringDrawing) {
+    if (updates.clearSelection) {
       clearSelectedFeature(selectRef.current)
-      selectRef.current?.setActive(false)
-      translateRef.current?.setActive(false)
-      modifyUncertaintyRef.current?.setActive(false)
-      moveToClickRef.current?.setActive(false)
-    } else {
-      if (!isMeasureModeActiveRef.current) {
-        selectRef.current?.setActive(true)
-        translateRef.current?.setActive(true)
-        modifyUncertaintyRef.current?.setActive(true)
-        moveToClickRef.current?.setActive(true)
-      }
+    }
+
+    if (updates.featureInteractions !== 'skip') {
+      const isEnabled = updates.featureInteractions === 'enable'
+      selectRef.current?.setActive(isEnabled)
+      translateRef.current?.setActive(isEnabled)
+      modifyUncertaintyRef.current?.setActive(isEnabled)
+      moveToClickRef.current?.setActive(isEnabled)
     }
 
     return undefined
-  }, [activeToolType])
+  }, [activeToolType, isMeasureModeActive])
 
   useEffect(function syncMeasureMode() {
     isMeasureModeActiveRef.current = isMeasureModeActive
@@ -753,7 +765,13 @@ function GeoMapViewer({
   }
 
   function handleToggleMeasureMode() {
-    setIsMeasureModeActive((active) => !active)
+    setIsMeasureModeActive((active) => {
+      const next = !active
+      if (next) {
+        lineStringDrawRef.current?.abortDrawing()
+      }
+      return next
+    })
   }
 
   function handleUnitChange(unit) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
@@ -40,6 +40,9 @@ function createGeoLineStringInteraction({
   })
 
   return {
+    abortDrawing() {
+      draw.abortDrawing?.()
+    },
     setActive(active) {
       draw.setActive(active)
     },

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getDrawingModeUpdates.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getDrawingModeUpdates.js
@@ -1,0 +1,19 @@
+function getDrawingModeUpdates(activeToolType, isMeasureModeActive) {
+  const isDrawing = activeToolType === 'LineString' && !isMeasureModeActive
+
+  if (isDrawing) {
+    return {
+      lineStringDraw: true,
+      featureInteractions: 'disable',
+      clearSelection: true
+    }
+  }
+
+  return {
+    lineStringDraw: false,
+    featureInteractions: isMeasureModeActive ? 'skip' : 'enable',
+    clearSelection: false
+  }
+}
+
+export default getDrawingModeUpdates

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getDrawingModeUpdates.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getDrawingModeUpdates.spec.js
@@ -1,0 +1,49 @@
+import getDrawingModeUpdates from './getDrawingModeUpdates'
+
+describe('helpers > getDrawingModeUpdates', function () {
+  describe('when the active tool is LineString and measure mode is off', function () {
+    it('activates Draw, disables feature interactions, and clears selection', function () {
+      expect(getDrawingModeUpdates('LineString', false)).to.deep.equal({
+        lineStringDraw: true,
+        featureInteractions: 'disable',
+        clearSelection: true
+      })
+    })
+  })
+
+  describe('when the active tool is LineString and measure mode is on', function () {
+    it('deactivates Draw and lets syncMeasureMode retain ownership of feature interactions (measure wins)', function () {
+      expect(getDrawingModeUpdates('LineString', true)).to.deep.equal({
+        lineStringDraw: false,
+        featureInteractions: 'skip',
+        clearSelection: false
+      })
+    })
+  })
+
+  describe('when the active tool is not LineString', function () {
+    it('deactivates Draw, enables feature interactions, and does not clear selection (measure off)', function () {
+      expect(getDrawingModeUpdates('Point', false)).to.deep.equal({
+        lineStringDraw: false,
+        featureInteractions: 'enable',
+        clearSelection: false
+      })
+    })
+
+    it('deactivates Draw but skips feature interactions so syncMeasureMode retains ownership (measure on)', function () {
+      expect(getDrawingModeUpdates('Point', true)).to.deep.equal({
+        lineStringDraw: false,
+        featureInteractions: 'skip',
+        clearSelection: false
+      })
+    })
+
+    it('handles an undefined active tool type the same way as a non-LineString tool', function () {
+      expect(getDrawingModeUpdates(undefined, false)).to.deep.equal({
+        lineStringDraw: false,
+        featureInteractions: 'enable',
+        clearSelection: false
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Resolves #7364

## Describe your changes
- extract the per-tool interaction decision into a pure `getDrawingModeUpdates(activeToolType, isMeasureModeActive)` helper. It returns `{ lineStringDraw, featureInteractions, clearSelection }` where `featureInteractions` is `'enable' | 'disable' | 'skip'` (`'skip'` lets `syncMeasureMode` keep ownership when Measure is the active mode)
- in `syncDrawingToolMode` (now keyed on both `activeToolType` and `isMeasureModeActive`), apply the helper's output: activate the LineString `Draw` interaction when the active tool is `LineString` and Measure is off; deactivate it when either condition fails
- on Measure toggle ON, abort any in-progress LineString sketch via the new `lineStringDrawRef.current.abortDrawing()` so the partial line is discarded before Measure takes over. Persisted LineString features stay on the map
- add an `exitMeasureOnDrawingToolSelect` effect: when the user picks the LineString tool while Measure is active, exit Measure mode and clear its tooltips and temp line via `measureInteractionRef.current.clear()`. The two modes are mutually exclusive, enforced at the transition points
- in the existing `pointermove` cursor handler, show `crosshair` only while NOT dragging. During a drag, the cursor falls through to OpenLayers' grab/grabbing class so the press-and-drag pan affordance is visible
- DragPan stays active throughout. OpenLayers' built-in `clickTolerance` distinguishes a click (which adds a vertex through the LineString `Draw` interaction) from a drag (which pans the map through `DragPan`). The result: while a LineString tool is the active drawing tool, click adds a vertex, press-and-drag pans, and the two never fight for the same gesture

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - n/a for this PR. End-to-end UX (a LineString tool on a real workflow) lands when the Lab editor ships at the end of this milestone. Until then, the Storybook story below is the user-facing surface. The full LineString tool is exercisable on staging workflow 3919 (`kieftrav/geo-tools` project) once the Segmented Line milestone completes.
- What user actions should my reviewer step through to review this PR?
  - run `pnpm storybook` in `packages/lib-classifier`, open `Subject Viewers / GeoMapViewer` → `WithGeoDrawingLineStringTask`
  - hover the map: cursor should be `crosshair`
  - click without dragging (release within ~6px of where you pressed): a vertex should be added. Click more points, double-click to finish, and the new LineString should auto-select
  - press-and-drag (move beyond ~6px before releasing): the map should pan and NO vertex should be added. While dragging, the cursor should flip to the OpenLayers grabbing cursor
  - mid-sketch (one or two vertices placed but not yet finished), click the Measure button: the in-progress sketch should disappear (aborted) and Measure mode should take over. Persisted lines from prior sketches should remain
  - while in Measure mode (after measuring something), select the LineString tool from the task panel: Measure should exit automatically, its tooltips/temp line should clear, and you should be back in LineString draw mode
  - open `WithGeoDrawingTask` (existing Point-tool story) and confirm Point drawing + Select / Translate / Modify still work unchanged
  - run `pnpm test` in `packages/lib-classifier` and confirm `getDrawingModeUpdates.spec.js` (5 tests covering the activeToolType × isMeasureModeActive matrix) passes alongside the rest of the suite
- Which storybook stories should be reviewed?
  - `Subject Viewers / GeoMapViewer` → `WithGeoDrawingLineStringTask` (added in #7416): http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-geo-drawing-line-string-task
- Are there plans for follow up PR's to further fix this bug or develop this feature?
  - Yes. This is PR 4 of 9 in the **Segmented Line** milestone. Sequential PRs that follow this one (in merge order):
    1. #7365 lib-classifier: Add Modify interaction for LineString vertex editing
    2. #7366 lib-classifier: Add max_vertices and min_vertices to LineStringTool
    3. #7367 lib-classifier: Add min and max line count to LineStringTool
    4. #7368 lib-classifier: Add delete affordance for selected LineString feature
    5. [#7459 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7459): Add LineString tool to GeoDrawing task editor

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - reuses the `WithGeoDrawingLineStringTask` story added in #7416; no new story
