### PR TITLE
lib-classifier: Refactor GeoMapViewer for moving and interacting with features across world extent

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -35,7 +35,7 @@ import createModifyUncertaintyInteraction from './helpers/createModifyUncertaint
 import createMoveToClickInteraction from './helpers/createMoveToClickInteraction'
 import getFeatureStyle from './helpers/getFeatureStyle'
 import getPixelDistance from './helpers/getPixelDistance'
-import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './helpers/hitTesting'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixelsAcrossWorldCopies } from './helpers/hitTesting'
 
 const StyledBox = styled(Box)`
   position: relative;
@@ -264,12 +264,13 @@ function GeoMapViewer({
           const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
           if (!Array.isArray(pointCoordinates)) return false
 
-          const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
-          return isPixelNearPointCenter({
-            pixel: mapBrowserEvent.pixel,
-            pointPixel,
-            radius: POINT_CENTER_HIT_RADIUS_PIXELS
-          })
+          return getFeaturePixelsAcrossWorldCopies(map, pointCoordinates).some(
+            pointPixel => isPixelNearPointCenter({
+              pixel: mapBrowserEvent.pixel,
+              pointPixel,
+              radius: POINT_CENTER_HIT_RADIUS_PIXELS
+            })
+          )
         }
       })
 
@@ -313,12 +314,13 @@ function GeoMapViewer({
           const coords = feature.getGeometry()?.getCoordinates?.()
           if (!Array.isArray(coords)) return
 
-          const pointPixel = map.getPixelFromCoordinate(coords)
-          if (isPixelNearPointCenter({
+          const pointPixels = getFeaturePixelsAcrossWorldCopies(map, coords)
+
+          if (pointPixels.some(pointPixel => isPixelNearPointCenter({
             pixel,
             pointPixel,
             radius: POINT_CENTER_HIT_RADIUS_PIXELS
-          })) {
+          }))) {
             isOverFeature = true
             return
           }
@@ -333,7 +335,7 @@ function GeoMapViewer({
           if (
             typeof uncertaintyRadiusPixels === 'number'
             && uncertaintyRadiusPixels > 0
-            && getPixelDistance(pixel, pointPixel) <= uncertaintyRadiusPixels
+            && pointPixels.some(pointPixel => getPixelDistance(pixel, pointPixel) <= uncertaintyRadiusPixels)
           ) {
             isOverFeature = true
           }
@@ -397,27 +399,27 @@ function GeoMapViewer({
             const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
 
             if (mstFeature && Array.isArray(pointCoordinates)) {
-              const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
+              const pointPixels = getFeaturePixelsAcrossWorldCopies(map, pointCoordinates)
               const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
                 feature: selectedFeature,
                 geoDrawingTask
               })
 
-              if (isPixelNearPointCenter({
+              if (pointPixels.some(pointPixel => isPixelNearPointCenter({
                 pixel: latestEvent.pixel,
                 pointPixel,
                 radius: POINT_CENTER_HIT_RADIUS_PIXELS
-              })) {
+              }))) {
                 cursor = isDraggingPoint ? 'grabbing' : 'grab'
               }
 
               if (!cursor && dragHandleCoordinates) {
-                const dragHandlePixel = map.getPixelFromCoordinate(dragHandleCoordinates)
-                if (isPixelNearDragHandle({
+                const dragHandlePixels = getFeaturePixelsAcrossWorldCopies(map, dragHandleCoordinates)
+                if (dragHandlePixels.some(handlePixel => isPixelNearDragHandle({
                   pixel: latestEvent.pixel,
-                  handlePixel: dragHandlePixel,
+                  handlePixel,
                   tolerance: 15
-                })) {
+                }))) {
                   cursor = 'ew-resize'
                 }
               }
@@ -432,7 +434,7 @@ function GeoMapViewer({
                 if (
                   typeof uncertaintyRadiusPixels === 'number'
                   && uncertaintyRadiusPixels > 0
-                  && getPixelDistance(latestEvent.pixel, pointPixel) <= uncertaintyRadiusPixels
+                  && pointPixels.some(pointPixel => getPixelDistance(latestEvent.pixel, pointPixel) <= uncertaintyRadiusPixels)
                 ) {
                   cursor = 'default'
                 }
@@ -448,12 +450,13 @@ function GeoMapViewer({
                 if (feature === selectedFeature || hoveringOtherCenter) return
                 const coords = feature.getGeometry()?.getCoordinates?.()
                 if (!Array.isArray(coords)) return
-                const featurePixel = map.getPixelFromCoordinate(coords)
-                if (isPixelNearPointCenter({
-                  pixel: latestEvent.pixel,
-                  pointPixel: featurePixel,
-                  radius: POINT_CENTER_HIT_RADIUS_PIXELS
-                })) {
+                if (getFeaturePixelsAcrossWorldCopies(map, coords).some(
+                  featurePixel => isPixelNearPointCenter({
+                    pixel: latestEvent.pixel,
+                    pointPixel: featurePixel,
+                    radius: POINT_CENTER_HIT_RADIUS_PIXELS
+                  })
+                )) {
                   hoveringOtherCenter = true
                 }
               })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -31,10 +31,11 @@ import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 import asMSTFeature from './helpers/asMSTFeature'
 import createMeasureInteraction from './helpers/createMeasureInteraction'
-import createModifyUncertaintyInteraction, { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './helpers/createModifyUncertaintyInteraction'
+import createModifyUncertaintyInteraction from './helpers/createModifyUncertaintyInteraction'
 import createMoveToClickInteraction from './helpers/createMoveToClickInteraction'
 import getFeatureStyle from './helpers/getFeatureStyle'
 import getPixelDistance from './helpers/getPixelDistance'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './helpers/hitTesting'
 
 const StyledBox = styled(Box)`
   position: relative;
@@ -74,6 +75,8 @@ const MapContainer = styled.div`
 `
 
 const ZOOM_ANIMATION_DURATION_MS = 250
+const POINTER_MOVE_HIT_CHECK_INTERVAL_MS = 80
+const POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS = 4
 
 // Maps UnitSelect display options to OpenLayers ScaleLine unit strings
 const UNIT_OPTION_TO_SCALE_LINE_UNITS = {
@@ -169,6 +172,7 @@ function GeoMapViewer({
     // create a GeoJSON format reader
     const geoJSONFormat = new GeoJSON()
     geoJSONFormatRef.current = geoJSONFormat
+    let pointerMoveRafId = null
 
     const baseLayer = new TileLayer({
       // preload tiles for 1 level of zooming
@@ -284,10 +288,59 @@ function GeoMapViewer({
       map.addInteraction(modifyUncertainty)
       modifyUncertaintyRef.current = modifyUncertainty
 
-      // Track whether a point is actively being dragged to switch grab → grabbing.
+      // Track whether a point is actively being dragged to switch grab -> grabbing.
       // Center-point drags are captured by moveToClick (not Translate), so we use
       // onDragStart/onDragEnd callbacks to update the cursor immediately on press.
       let isDraggingPoint = false
+      let latestPointerMoveEvent = null
+      let lastAppliedCursor = ''
+      let lastHitCheckTs = 0
+      let lastHitCheckPixel = null
+      let lastHitCheckResult = false
+
+      function applyCursor(element, cursor) {
+        if (lastAppliedCursor === cursor) return
+        element.style.cursor = cursor
+        lastAppliedCursor = cursor
+      }
+
+      function isPointerOverFeature(pixel) {
+        let isOverFeature = false
+
+        featuresLayer.getSource().forEachFeature((feature) => {
+          if (isOverFeature) return
+
+          const coords = feature.getGeometry()?.getCoordinates?.()
+          if (!Array.isArray(coords)) return
+
+          const pointPixel = map.getPixelFromCoordinate(coords)
+          if (isPixelNearPointCenter({
+            pixel,
+            pointPixel,
+            radius: POINT_CENTER_HIT_RADIUS_PIXELS
+          })) {
+            isOverFeature = true
+            return
+          }
+
+          const mstFeature = asMSTFeature(feature)
+          const uncertaintyRadiusPixels = mstFeature?.getUncertaintyRadiusPixels?.({
+            feature,
+            geoDrawingTask,
+            resolution: map.getView().getResolution()
+          })
+
+          if (
+            typeof uncertaintyRadiusPixels === 'number'
+            && uncertaintyRadiusPixels > 0
+            && getPixelDistance(pixel, pointPixel) <= uncertaintyRadiusPixels
+          ) {
+            isOverFeature = true
+          }
+        })
+
+        return isOverFeature
+      }
 
       // Create and add move-to-click interaction
       const moveToClick = createMoveToClickInteraction({
@@ -313,96 +366,116 @@ function GeoMapViewer({
       // our inline style.cursor overrides OL's class-based cursor (ol-grab, ol-grabbing)
       // which Translate sets on the viewport via classList.
       const handlePointerMove = (event) => {
-        if (isMeasureModeActiveRef.current) {
-          const element = map.getTargetElement()
+        latestPointerMoveEvent = event
 
-          if (element) {
-            element.style.cursor = ''
+        if (pointerMoveRafId !== null) return
+
+        pointerMoveRafId = requestAnimationFrame(() => {
+          pointerMoveRafId = null
+
+          const latestEvent = latestPointerMoveEvent
+          if (!latestEvent) return
+
+          if (isMeasureModeActiveRef.current) {
+            const targetElement = map.getTargetElement()
+
+            if (targetElement) {
+              applyCursor(targetElement, '')
+            }
+
+            return
           }
 
-          return
-        }
+          const element = map.getViewport()
+          if (!element) return
 
-        const element = map.getViewport()
-        if (!element) return
+          let cursor = ''
+          const selectedFeature = select.getFeatures().item(0)
 
-        let cursor = ''
-        const selectedFeature = select.getFeatures().item(0)
+          if (selectedFeature) {
+            const mstFeature = asMSTFeature(selectedFeature)
+            const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
 
-        if (selectedFeature) {
-          const mstFeature = asMSTFeature(selectedFeature)
-          const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
-
-          if (mstFeature && Array.isArray(pointCoordinates)) {
-            const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
-            const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
-              feature: selectedFeature,
-              geoDrawingTask
-            })
-
-            // If we're near the feature center, grab/grabbing takes priority
-            if (isPixelNearPointCenter({
-              pixel: event.pixel,
-              pointPixel,
-              radius: POINT_CENTER_HIT_RADIUS_PIXELS
-            })) {
-              cursor = isDraggingPoint ? 'grabbing' : 'grab'
-            }
-
-            // If we're near the drag handle, show the resize cursor
-            if (!cursor && dragHandleCoordinates) {
-              const dragHandlePixel = map.getPixelFromCoordinate(dragHandleCoordinates)
-              if (isPixelNearDragHandle({
-                pixel: event.pixel,
-                handlePixel: dragHandlePixel,
-                tolerance: 15
-              })) {
-                cursor = 'ew-resize'
-              }
-            }
-
-            // If the feature has an uncertainty radius, show the default cursor when hovering over it
-            if (!cursor) {
-              const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
+            if (mstFeature && Array.isArray(pointCoordinates)) {
+              const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
+              const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
                 feature: selectedFeature,
-                geoDrawingTask,
-                resolution: map.getView().getResolution()
+                geoDrawingTask
               })
 
-              if (
-                typeof uncertaintyRadiusPixels === 'number'
-                && uncertaintyRadiusPixels > 0
-                && getPixelDistance(event.pixel, pointPixel) <= uncertaintyRadiusPixels
-              ) {
-                cursor = 'default'
+              if (isPixelNearPointCenter({
+                pixel: latestEvent.pixel,
+                pointPixel,
+                radius: POINT_CENTER_HIT_RADIUS_PIXELS
+              })) {
+                cursor = isDraggingPoint ? 'grabbing' : 'grab'
+              }
+
+              if (!cursor && dragHandleCoordinates) {
+                const dragHandlePixel = map.getPixelFromCoordinate(dragHandleCoordinates)
+                if (isPixelNearDragHandle({
+                  pixel: latestEvent.pixel,
+                  handlePixel: dragHandlePixel,
+                  tolerance: 15
+                })) {
+                  cursor = 'ew-resize'
+                }
+              }
+
+              if (!cursor) {
+                const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
+                  feature: selectedFeature,
+                  geoDrawingTask,
+                  resolution: map.getView().getResolution()
+                })
+
+                if (
+                  typeof uncertaintyRadiusPixels === 'number'
+                  && uncertaintyRadiusPixels > 0
+                  && getPixelDistance(latestEvent.pixel, pointPixel) <= uncertaintyRadiusPixels
+                ) {
+                  cursor = 'default'
+                }
               }
             }
           }
-        }
 
-        if (!cursor) {
-          if (selectedFeature) {
-            // When a feature is selected, only show pointer over another feature's center point (which is selectable)
-            let hoveringOtherCenter = false
-            featuresLayer.getSource().forEachFeature((feature) => {
-              if (feature === selectedFeature || hoveringOtherCenter) return
-              const coords = feature.getGeometry()?.getCoordinates?.()
-              if (!Array.isArray(coords)) return
-              const featurePixel = map.getPixelFromCoordinate(coords)
-              if (isPixelNearPointCenter({ pixel: event.pixel, pointPixel: featurePixel, radius: POINT_CENTER_HIT_RADIUS_PIXELS })) {
-                hoveringOtherCenter = true
+          if (!cursor) {
+            if (selectedFeature) {
+              // When a feature is selected, only show pointer over another feature's center point (which is selectable)
+              let hoveringOtherCenter = false
+              featuresLayer.getSource().forEachFeature((feature) => {
+                if (feature === selectedFeature || hoveringOtherCenter) return
+                const coords = feature.getGeometry()?.getCoordinates?.()
+                if (!Array.isArray(coords)) return
+                const featurePixel = map.getPixelFromCoordinate(coords)
+                if (isPixelNearPointCenter({
+                  pixel: latestEvent.pixel,
+                  pointPixel: featurePixel,
+                  radius: POINT_CENTER_HIT_RADIUS_PIXELS
+                })) {
+                  hoveringOtherCenter = true
+                }
+              })
+              cursor = hoveringOtherCenter ? 'pointer' : 'default'
+            } else {
+              const now = performance.now()
+              const movedEnough = !lastHitCheckPixel
+                || getPixelDistance(latestEvent.pixel, lastHitCheckPixel) >= POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS
+              const elapsedEnough = (now - lastHitCheckTs) >= POINTER_MOVE_HIT_CHECK_INTERVAL_MS
+
+              if (movedEnough || elapsedEnough) {
+                lastHitCheckResult = isPointerOverFeature(latestEvent.pixel)
+                lastHitCheckTs = now
+                lastHitCheckPixel = [...latestEvent.pixel]
               }
-            })
-            cursor = hoveringOtherCenter ? 'pointer' : 'default'
-          } else {
-            const hit = map.hasFeatureAtPixel(event.pixel, {
-              layerFilter: (layer) => layer === featuresLayer
-            })
-            cursor = hit ? 'pointer' : 'default'
-          }
-        }
 
-        element.style.cursor = cursor
+              cursor = lastHitCheckResult ? 'pointer' : 'default'
+            }
+          }
+
+          applyCursor(element, cursor)
+        })
       }
       map.on('pointermove', handlePointerMove)
       pointerMoveHandlerRef.current = handlePointerMove
@@ -429,6 +502,7 @@ function GeoMapViewer({
       if (moveToClickRef.current) map.removeInteraction(moveToClickRef.current)
       measureInteractionRef.current?.destroy()
       if (pointerMoveHandlerRef.current) map.un('pointermove', pointerMoveHandlerRef.current)
+      if (pointerMoveRafId !== null) cancelAnimationFrame(pointerMoveRafId)
       map.setTarget(undefined)
       mapRef.current = undefined
       featuresRef.current = undefined

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -74,8 +74,11 @@ const MapContainer = styled.div`
   width: 100%;
 `
 
+// Zoom animation duration in milliseconds
 const ZOOM_ANIMATION_DURATION_MS = 250
+// Minimum time between hit checks on pointermove, to throttle expensive hit testing
 const POINTER_MOVE_HIT_CHECK_INTERVAL_MS = 80
+// Minimum pixel distance the pointer must move to trigger a new hit test on pointermove, to throttle expensive hit testing
 const POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS = 4
 
 // Maps UnitSelect display options to OpenLayers ScaleLine unit strings
@@ -172,8 +175,7 @@ function GeoMapViewer({
     // create a GeoJSON format reader
     const geoJSONFormat = new GeoJSON()
     geoJSONFormatRef.current = geoJSONFormat
-    let pointerMoveRafId = null
-
+    
     const baseLayer = new TileLayer({
       // preload tiles for 1 level of zooming
       preload: 1,
@@ -204,6 +206,10 @@ function GeoMapViewer({
         (() => { const sl = new ScaleLine(); scaleLineRef.current = sl; return sl })()
       ])
     })
+
+    // track the latest pointermove event for hit testing, 
+    // and throttle hit testing to improve performance during fast mouse moves and zoom/pan animations
+    let pointerMoveRafId = null
 
     // Helper to compute style with current resolution
     function handleFeatureStyle({ feature, isSelected = false }) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
@@ -139,9 +139,23 @@ function createModifyUncertaintyInteraction({
     const coordinate = map.getCoordinateFromPixel(event.pixel)
     const centerCoordinates = state.draggedFeature.getGeometry().getCoordinates()
 
+    // After a cross-dateline drag, centerCoordinates is in the canonical world range but
+    // getCoordinateFromPixel returns a coordinate in the world copy the user is viewing.
+    // Normalize the drag coordinate to the nearest world copy of the center so that
+    // getPixelDistance always computes the short (correct) distance, not the ~40M-m cross-world distance.
+    const extent = map.getView().getProjection().getExtent()
+    const worldWidth = extent ? extent[2] - extent[0] : 0
+    let dragX = coordinate[0]
+    if (worldWidth > 0) {
+      const rawDelta = coordinate[0] - centerCoordinates[0]
+      const wrappedDelta = ((rawDelta + worldWidth / 2) % worldWidth + worldWidth) % worldWidth - worldWidth / 2
+      dragX = centerCoordinates[0] + wrappedDelta
+    }
+    const normalizedCoordinate = [dragX, coordinate[1]]
+
     // Calculate new radius in meters
     const newRadius = Math.round(
-      Math.max(minRadius, getPixelDistance(centerCoordinates, coordinate))
+      Math.max(minRadius, getPixelDistance(centerCoordinates, normalizedCoordinate))
     )
 
     // Update uncertainty radius through GeoDrawingTask to keep MST activeFeature and slider in sync

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
@@ -2,23 +2,9 @@ import PointerInteraction from 'ol/interaction/Pointer'
 import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import asMSTFeature from './asMSTFeature'
 import getPixelDistance from './getPixelDistance'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './hitTesting'
 
-export const POINT_CENTER_HIT_RADIUS_PIXELS = 10
-
-export function isPixelNearPointCenter({
-  pixel,
-  pointPixel,
-  radius = POINT_CENTER_HIT_RADIUS_PIXELS
-}) {
-  if (!Array.isArray(pixel) || !Array.isArray(pointPixel)) return false
-
-  const deltaX = pixel[0] - pointPixel[0]
-  const deltaY = pixel[1] - pointPixel[1]
-
-  return (deltaX * deltaX) + (deltaY * deltaY) <= radius * radius
-}
-
-export function shouldStartDragHandleInteraction({
+function shouldStartDragHandleInteraction({
   pixel,
   pointPixel,
   handlePixel,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
@@ -2,7 +2,7 @@ import PointerInteraction from 'ol/interaction/Pointer'
 import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import asMSTFeature from './asMSTFeature'
 import getPixelDistance from './getPixelDistance'
-import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './hitTesting'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixelsAcrossWorldCopies } from './hitTesting'
 
 function shouldStartDragHandleInteraction({
   pixel,
@@ -64,29 +64,29 @@ function createModifyUncertaintyInteraction({
       if (radius === null) continue
 
       const pointCoordinates = olFeature.getGeometry()?.getCoordinates?.()
-      const pointPixel = Array.isArray(pointCoordinates)
-        ? map.getPixelFromCoordinate(pointCoordinates)
-        : null
+      const pointPixels = Array.isArray(pointCoordinates)
+        ? getFeaturePixelsAcrossWorldCopies(map, pointCoordinates)
+        : []
 
-      if (isPixelNearPointCenter({ pixel, pointPixel })) {
+      if (pointPixels.some(pointPixel => isPixelNearPointCenter({ pixel, pointPixel }))) {
         return null
       }
 
       // Get the drag handle coordinates
-      const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({ 
-        feature: olFeature, 
-        geoDrawingTask 
+      const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
+        feature: olFeature,
+        geoDrawingTask
       })
       if (!dragHandleCoordinates) continue
 
-      // Check if click is near the full resize handle, not just its anchor point.
-      const dragHandlePixel = map.getPixelFromCoordinate(dragHandleCoordinates)
-      if (shouldStartDragHandleInteraction({
+      // Check if click is near the full resize handle across all world copies.
+      const dragHandlePixels = getFeaturePixelsAcrossWorldCopies(map, dragHandleCoordinates)
+      if (dragHandlePixels.some(handlePixel => shouldStartDragHandleInteraction({
         pixel,
-        pointPixel,
-        handlePixel: dragHandlePixel,
+        pointPixel: pointPixels[0] ?? null,
+        handlePixel,
         dragHandleTolerance
-      })) {
+      }))) {
         return olFeature
       }
     }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
@@ -1,10 +1,27 @@
 import PointerInteraction from 'ol/interaction/Pointer'
+import { get as getProjection } from 'ol/proj'
 import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import asMSTFeature from './asMSTFeature'
 import getPixelDistance from './getPixelDistance'
-import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './hitTesting'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixelsAcrossWorldCopies } from './hitTesting'
 
 export const MOVE_TO_CLICK_HOLD_DELAY = 250
+
+/**
+ * Wrap an X coordinate back into the projection's world extent so that features
+ * dragged past the dateline remain visible and renderable by OpenLayers.
+ * Derives the extent from the projection's own definition, so it works correctly
+ * for any projection that declares a world extent (e.g. EPSG:3857, EPSG:4326).
+ * Returns x unchanged if the projection has no defined world extent.
+ */
+function normalizeCoordinateToWorld(x, projectionCode) {
+  const proj = getProjection(projectionCode)
+  const extent = proj?.getExtent()
+  if (!extent) return x
+  const minX = extent[0]
+  const worldWidth = extent[2] - extent[0]
+  return ((((x - minX) % worldWidth) + worldWidth) % worldWidth) + minX
+}
 
 function createMoveToClickInteraction({
   selectInteraction,
@@ -54,36 +71,27 @@ function createMoveToClickInteraction({
 
     if (!dragHandleCoordinates) return false
 
-    const dragHandlePixel = map.getPixelFromCoordinate(dragHandleCoordinates)
-    return isPixelNearDragHandle({
-      pixel,
-      handlePixel: dragHandlePixel,
-      tolerance: 15
-    })
+    return getFeaturePixelsAcrossWorldCopies(map, dragHandleCoordinates).some(
+      handlePixel => isPixelNearDragHandle({ pixel, handlePixel, tolerance: 15 })
+    )
   }
 
   function isPointerInsideSelectedFeature({ pixel, map, olFeature }) {
     const pointCoordinates = olFeature.getGeometry()?.getCoordinates?.()
     if (!Array.isArray(pointCoordinates)) return false
 
-    const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
-    return isPixelNearPointCenter({
-      pixel,
-      pointPixel,
-      radius: POINT_CENTER_HIT_RADIUS_PIXELS
-    })
+    return getFeaturePixelsAcrossWorldCopies(map, pointCoordinates).some(
+      pointPixel => isPixelNearPointCenter({ pixel, pointPixel, radius: POINT_CENTER_HIT_RADIUS_PIXELS })
+    )
   }
 
   function isPointerInUncertaintyCircleOnly({ pixel, map, olFeature, mstFeature }) {
     const pointCoordinates = olFeature.getGeometry()?.getCoordinates?.()
     if (!Array.isArray(pointCoordinates)) return false
 
-    const pointPixel = map.getPixelFromCoordinate(pointCoordinates)
-    if (isPixelNearPointCenter({
-      pixel,
-      pointPixel,
-      radius: POINT_CENTER_HIT_RADIUS_PIXELS
-    })) {
+    const pointPixels = getFeaturePixelsAcrossWorldCopies(map, pointCoordinates)
+
+    if (pointPixels.some(pointPixel => isPixelNearPointCenter({ pixel, pointPixel, radius: POINT_CENTER_HIT_RADIUS_PIXELS }))) {
       return false
     }
 
@@ -96,15 +104,16 @@ function createMoveToClickInteraction({
     return (
       typeof uncertaintyRadiusPixels === 'number'
       && uncertaintyRadiusPixels > 0
-      && getPixelDistance(pixel, pointPixel) <= uncertaintyRadiusPixels
+      && pointPixels.some(pointPixel => getPixelDistance(pixel, pointPixel) <= uncertaintyRadiusPixels)
     )
   }
 
-  function teleportFeatureTo(coordinate) {
+  function teleportFeatureTo(coordinate, projectionCode) {
     const geometry = state.selectedFeature.getGeometry()
     if (!geometry || typeof geometry.setCoordinates !== 'function') return
 
-    geometry.setCoordinates(coordinate)
+    const wrappedCoordinate = [normalizeCoordinateToWorld(coordinate[0], projectionCode), coordinate[1]]
+    geometry.setCoordinates(wrappedCoordinate)
     state.selectedFeature.changed()
 
     if (geoDrawingTask.setActiveFeatureGeometry) {
@@ -208,8 +217,9 @@ function createMoveToClickInteraction({
       if (feature === state.selectedFeature || clickedOtherFeatureCenter) return
       const coords = feature.getGeometry()?.getCoordinates?.()
       if (!Array.isArray(coords)) return
-      const featurePixel = map.getPixelFromCoordinate(coords)
-      if (isPixelNearPointCenter({ pixel: event.pixel, pointPixel: featurePixel, radius: POINT_CENTER_HIT_RADIUS_PIXELS })) {
+      if (getFeaturePixelsAcrossWorldCopies(map, coords).some(
+        featurePixel => isPixelNearPointCenter({ pixel: event.pixel, pointPixel: featurePixel, radius: POINT_CENTER_HIT_RADIUS_PIXELS })
+      )) {
         clickedOtherFeatureCenter = true
       }
     })
@@ -245,8 +255,9 @@ function createMoveToClickInteraction({
     const geometry = state.selectedFeature.getGeometry()
 
     if (geometry && typeof geometry.setCoordinates === 'function') {
+      const projectionCode = map.getView().getProjection().getCode()
       geometry.setCoordinates([
-        state.featureCoordinate[0] + deltaX,
+        normalizeCoordinateToWorld(state.featureCoordinate[0] + deltaX, projectionCode),
         state.featureCoordinate[1] + deltaY
       ])
       state.selectedFeature.changed()
@@ -277,7 +288,7 @@ function createMoveToClickInteraction({
     const heldLongEnough = holdDuration >= MOVE_TO_CLICK_HOLD_DELAY
 
     if (wasClick && (state.clickedInUncertaintyCircle || !state.clickedOnFeature) && heldLongEnough) {
-      teleportFeatureTo(map.getCoordinateFromPixel(upPixel))
+      teleportFeatureTo(map.getCoordinateFromPixel(upPixel), map.getView().getProjection().getCode())
     }
 
     const wasDragging = state.draggingFeature

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
@@ -2,7 +2,7 @@ import PointerInteraction from 'ol/interaction/Pointer'
 import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import asMSTFeature from './asMSTFeature'
 import getPixelDistance from './getPixelDistance'
-import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './createModifyUncertaintyInteraction'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS } from './hitTesting'
 
 export const MOVE_TO_CLICK_HOLD_DELAY = 250
 
@@ -37,6 +37,16 @@ function createMoveToClickInteraction({
   }
 
   function isPointerOnResizeHandle({ pixel, map, olFeature, mstFeature }) {
+    const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
+      feature: olFeature,
+      geoDrawingTask,
+      resolution: map.getView().getResolution()
+    })
+
+    if (!(typeof uncertaintyRadiusPixels === 'number' && uncertaintyRadiusPixels > 0)) {
+      return false
+    }
+
     const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
       feature: olFeature,
       geoDrawingTask
@@ -138,6 +148,26 @@ function createMoveToClickInteraction({
     state.draggingFeature = false
 
     const mstFeature = asMSTFeature(state.selectedFeature)
+    const clickedInsideSelectedFeature = mstFeature
+      ? isPointerInsideSelectedFeature({
+        pixel: event.pixel,
+        map,
+        olFeature: state.selectedFeature
+      })
+      : false
+
+    state.clickedOnFeature = clickedInsideSelectedFeature
+
+    // Prioritize center-point dragging over uncertainty-handle checks.
+    // At far zoom, tiny uncertainty circles can place the handle near center.
+    if (clickedInsideSelectedFeature) {
+      state.draggingFeature = true
+      state.disabledSelect = true
+      selectInteraction.setActive(false)
+      onDragStart?.()
+      return true
+    }
+
     const clickedOnResizeHandle = mstFeature
       ? isPointerOnResizeHandle({
         pixel: event.pixel,
@@ -169,24 +199,6 @@ function createMoveToClickInteraction({
       state.clickedInUncertaintyCircle = true
       state.disabledSelect = true
       selectInteraction.setActive(false)
-      return true
-    }
-
-    const clickedInsideSelectedFeature = mstFeature
-      ? isPointerInsideSelectedFeature({
-        pixel: event.pixel,
-        map,
-        olFeature: state.selectedFeature
-      })
-      : false
-
-    state.clickedOnFeature = clickedInsideSelectedFeature
-
-    if (clickedInsideSelectedFeature) {
-      state.draggingFeature = true
-      state.disabledSelect = true
-      selectInteraction.setActive(false)
-      onDragStart?.()
       return true
     }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
@@ -1,0 +1,14 @@
+export const POINT_CENTER_HIT_RADIUS_PIXELS = 10
+
+export function isPixelNearPointCenter({
+  pixel,
+  pointPixel,
+  radius = POINT_CENTER_HIT_RADIUS_PIXELS
+}) {
+  if (!Array.isArray(pixel) || !Array.isArray(pointPixel)) return false
+
+  const deltaX = pixel[0] - pointPixel[0]
+  const deltaY = pixel[1] - pointPixel[1]
+
+  return (deltaX * deltaX) + (deltaY * deltaY) <= radius * radius
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
@@ -12,3 +12,17 @@ export function isPixelNearPointCenter({
 
   return (deltaX * deltaX) + (deltaY * deltaY) <= radius * radius
 }
+
+/**
+ * Returns all pixel positions for a coordinate, including ±worldWidth offsets.
+ * After coordinate normalization a feature's canonical X may not match the world copy the user is viewing, 
+ * so every copy that could be on screen must be checked.
+ */
+export function getFeaturePixelsAcrossWorldCopies(map, coord) {
+  const extent = map.getView().getProjection().getExtent()
+  const worldWidth = extent ? extent[2] - extent[0] : 0
+  const offsets = worldWidth > 0 ? [-worldWidth, 0, worldWidth] : [0]
+  return offsets
+    .map(offset => map.getPixelFromCoordinate([coord[0] + offset, coord[1]]))
+    .filter(Boolean)
+}


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- zoom way out and drag a point from the Americas to Russia or China
- zoom in to the recently moved point, note that it (visually) disappears

## Describe your changes
- `createMoveToClickInteraction`: add `normalizeCoordinateToWorld` so points dragged past the projection’s world extent are wrapped back into a valid world copy
- `hitTesting`: add `getFeaturePixelsAcrossWorldCopies` so pixel-based interactions are checked against all visible world copies
- refactor GeoMapViewer and helper custom interactions accordingly ^

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - staging/testing: https://local.zooniverse.org:8080/?project=2030&demo=true&workflow=3882
- What user actions should my reviewer step through to review this PR?
  - with a point in the Americas
  - zoom way out
  - move the point to Russia
  - zoom in, note point remains visible
  - move point a little
  - adjust uncertainty circle
- Which storybook stories should be reviewed?
  - http://localhost:6006/?path=/story/geodrawing-tools-point--uncertainty-circle
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected