### PR TITLE
Project Stats page: Style the layout and various screen sizes

### DIFF
--- a/packages/app-project/public/locales/en/screens.json
+++ b/packages/app-project/public/locales/en/screens.json
@@ -99,6 +99,7 @@
     "comments": "Comments",
     "heading": "{{projectName}} Statistics",
     "workflows": {
+      "empty": "No associated workflows",
       "percentComplete": "{{percent}}% complete",
       "subjectsRetired": "Subjects retired: {{retired}}/{{total}}",
       "retireLimit": "Retirement limit: {{number}}",

--- a/packages/app-project/src/screens/ProjectStatsPage/ProjectStatsPage.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/ProjectStatsPage.jsx
@@ -1,17 +1,30 @@
 import { arrayOf, shape, string } from 'prop-types'
+import { Box, ResponsiveContext } from 'grommet'
+import { useContext } from 'react'
 
 import ChartContainer from './components/ChartContainer/ChartContainer'
 import StandardLayout from '@shared/components/StandardLayout'
 import ProjectStatistics from '@shared/components/ProjectStatistics'
 import Workflows from './components/Workflows/Workflows'
+import ProjectAboutPageLayout from '../ProjectAboutPage/ProjectAboutPageLayout'
 
 function ProjectStatsPage({ workflows }) {
+  const size = useContext(ResponsiveContext)
 
   return (
     <StandardLayout>
-      <ChartContainer workflows={workflows} />
-      <ProjectStatistics />
-      <Workflows workflows={workflows} />
+      <ProjectAboutPageLayout>
+        <Box
+          pad={size === 'small' ? 'none' : 'medium'}
+          gap={size === 'small' ? 'none' : 'medium'}
+          margin={{ bottom: 'large' }}
+          width={{ max: '85rem' }}
+        >
+          <ChartContainer workflows={workflows} />
+          <ProjectStatistics hideLink titleLevel={3} />
+          <Workflows workflows={workflows} />
+        </Box>
+      </ProjectAboutPageLayout>
     </StandardLayout>
   )
 }

--- a/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
@@ -138,7 +138,7 @@ function BarChart({
                   data-testid='periodLabel'
                   textAlign='center'
                 >
-                  {date.toLocaleDateString('en-US', dateRangeLabel.tLDS)}
+                  {date.toLocaleDateString(locale, dateRangeLabel.tLDS)}
                 </Text>
               )
             } else if (
@@ -151,13 +151,13 @@ function BarChart({
                   data-testid='periodLabel'
                   textAlign='center'
                 >
-                  {date.toLocaleDateString('en-US', dateRangeLabel.tLDS)}
+                  {date.toLocaleDateString(locale, dateRangeLabel.tLDS)}
                 </Text>
               )
             } else {
               return (
                 <Text data-testid='periodLabel' textAlign='center'>
-                  {date.toLocaleDateString('en-US', dateRangeLabel.tLDS)}
+                  {date.toLocaleDateString(locale, dateRangeLabel.tLDS)}
                 </Text>
               )
             }

--- a/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
@@ -39,6 +39,18 @@ const Relative = styled(Box)`
   position: relative;
 `
 
+// for stacked or inline Selects
+const StyledBox = styled(Box)`
+  flex-direction: row;
+  column-gap: 20px;
+
+  @media (width < 500px) {
+    align-items: center;
+    flex-direction: column;
+    row-gap: 10px;
+  }
+`
+
 function useStores() {
   const stores = useContext(MobXProviderContext)
   const { project } = stores.store
@@ -128,7 +140,7 @@ function ChartContainer({ workflows }) {
   const dateInterval = getDateInterval({ endDate, startDate })
   const erasQuery = {
     end_date: endDate ? endDate : undefined,
-    period: dateInterval.period,
+    period: dateInterval?.period,
     project_id: workflow ? undefined : projectId,
     start_date: startDate ? startDate : undefined,
     workflow_id: workflow || undefined
@@ -141,6 +153,7 @@ function ChartContainer({ workflows }) {
 
   const { data, error, isLoading, isValidating } = useProjectStats(filteredQuery, type)
   const loadingOrValidating = isLoading || isValidating
+  const errorMessage = dateRangeMessage || error?.message
 
   /* Custom Calendar visibility */
   const [showCalendar, setShowCalendar] = useState(false)
@@ -168,6 +181,8 @@ function ChartContainer({ workflows }) {
     }
   }
 
+  const smallScreen = size === 'small'
+
   return (
     <>
       <CustomCalendar
@@ -178,7 +193,7 @@ function ChartContainer({ workflows }) {
         setShowCalendar={setShowCalendar}
         showCalendar={showCalendar}
       />
-      <ContentBox>
+      <ContentBox fill border={{ size: smallScreen ? '0' : 'thin' }}>
         <Box
           direction={size !== 'small' ? 'row' : 'column'}
           justify='between'
@@ -189,6 +204,7 @@ function ChartContainer({ workflows }) {
             level={2}
             color={{ light: 'neutral-1', dark: 'accent-1' }}
             size={size !== 'small' ? '2rem' : '1.5rem'}
+            margin='none'
           >
             <Avatar width='50px' height='50x' />
             {t('ProjectStats.heading', { projectName: projectDisplayName })}
@@ -207,7 +223,7 @@ function ChartContainer({ workflows }) {
               ) : dateRangeMessage || error?.message ? (
                 <Box height='2.5rem' />
               ) : (
-                <span>{data?.['total_count']}</span>
+                <span>{data?.['total_count'].toLocaleString(locale)}</span>
               )}
             </SpacedText>
           </Box>
@@ -241,11 +257,9 @@ function ChartContainer({ workflows }) {
             />
           </Box>
           <ThemeContext.Extend value={selectTheme}>
-            <Box
-              basis='1/2'
-              direction='row'
+            <StyledBox
+              basis='1/2' // required so it doesn't overlap the StyledTabs
               fill={size === 'small' ? 'horizontal' : false}
-              gap='20px'
               justify={size === 'small' ? 'evenly' : 'end'}
             >
               <StyledSelect
@@ -269,14 +283,13 @@ function ChartContainer({ workflows }) {
                 valueKey={{ key: 'label', reduce: true }}
                 size='medium'
               />
-            </Box>
+            </StyledBox>
           </ThemeContext.Extend>
         </Box>
-        <Relative height='medium' margin={{ bottom: 'medium' }}>
-          {loadingOrValidating ? (
-            <LoadingPlaceholder />
-          ) : dateRangeMessage || error?.message ? (
-            <ErrorPlaceholder message={dateRangeMessage || error?.message} />
+        <Relative height='medium' margin={{ vertical: 'medium' }}>
+          {loadingOrValidating ? <LoadingPlaceholder /> : null}
+          {!loadingOrValidating && errorMessage?.length ? (
+            <ErrorPlaceholder message={errorMessage} />
           ) : null}
           <BarChart data={data?.data} dateRange={{ startDate, endDate }} type={type} />
         </Relative>

--- a/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/selectTheme.js
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/selectTheme.js
@@ -1,3 +1,5 @@
+/* Similar to lib-user */
+
 const selectTheme = {
   global: {
     control: {
@@ -21,10 +23,14 @@ const selectTheme = {
         font-weight: 700;
         border: none;
         box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.25);
-        width: clamp(180px, 50%, 215px);
+        width: 215px;
 
         &:focus:not(:focus-visible) {
           box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.25);
+        }
+
+        @media (width < 500px) {
+          width: 100%; // when stacked instead of inline together
         }
       `,
       open: {
@@ -51,7 +57,7 @@ const selectTheme = {
     options: {
       container: {
         align: 'center',
-        width: '215px'
+        width: '100%'
       },
       text: {
         textAlign: 'center',

--- a/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.jsx
@@ -4,6 +4,7 @@ import { Box, Button, Heading, ResponsiveContext, Text, Tip } from 'grommet'
 import { useContext } from 'react'
 import styled from 'styled-components'
 import { CircleInformation } from 'grommet-icons'
+import { SpacedText } from '@zooniverse/react-components'
 
 import ContentBox from '@shared/components/ContentBox'
 
@@ -81,6 +82,9 @@ function Workflows({ workflows = [] }) {
       border={{ size: size === 'small' ? '0' : 'thin' }}
     >
       <Box gap='15px'>
+        {workflows.length === 0 ? <Box width='100%' pad={{ vertical: 'large'}}>
+          <SpacedText weight={700} width='100%' textAlign='center'>{t('ProjectStats.workflows.empty')}</SpacedText>
+        </Box>: null}
         {workflows?.map(workflow => (
           <Box border={{ color: 'light-5' }} key={workflow.id}>
             <Box height='10px' width='100%'>

--- a/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.jsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'next-i18next'
 import { arrayOf, number, shape, string } from 'prop-types'
-import { Box, Button, Heading, Text, Tip } from 'grommet'
-import { useRouter } from 'next/router'
+import { Box, Button, Heading, ResponsiveContext, Text, Tip } from 'grommet'
+import { useContext } from 'react'
 import styled from 'styled-components'
 import { CircleInformation } from 'grommet-icons'
 
@@ -13,7 +13,7 @@ const WorkflowContainer = styled(Box)`
   padding: 20px 20px 30px;
   align-items: center;
 
-  @media (width < 769px) {
+  @media (width < 64rem) {
     padding: 10px 15px 15px;
     gap: 10px;
   }
@@ -21,6 +21,14 @@ const WorkflowContainer = styled(Box)`
 
 const WorkflowNameContainer = styled(Box)`
   width: 50%;
+
+  @media (width < 64rem) {
+    width: 60%;
+  }
+
+  @media (width < 769px) {
+    width: 45%;
+  }
 
   & > h4 {
     font-size: 1rem;
@@ -39,22 +47,26 @@ const StatsContainerBox = styled(Box)`
   align-content: center;
   gap: 20px;
 
-  @media (width < 769px) {
+  @media (width < 64rem) {
+    width: 40%;
     flex-direction: column;
     gap: 0;
 
-    & > span {
+    .span {
       font-size: 0.75rem;
     }
+  }
+
+  @media (width < 769px) {
+    width: 55%;
   }
 `
 
 function Workflows({ workflows = [] }) {
-  const { t } = useTranslation('screens')
+  const { i18n, t } = useTranslation('screens')
+  const size = useContext(ResponsiveContext)
 
-  const router = useRouter()
-  const { locale } = router
-  const localeCode = locale === 'test' ? 'en' : locale
+  const localeCode = i18n.locale === 'test' ? 'en' : i18n.locale
   const nf = new Intl.NumberFormat(localeCode, {
     style: 'unit',
     unit: 'day',
@@ -62,16 +74,19 @@ function Workflows({ workflows = [] }) {
   })
 
   return (
-    <ContentBox title={t('ProjectStats.workflows.title')} titleLevel={3}>
+    <ContentBox
+      title={t('ProjectStats.workflows.title')}
+      titleLevel={3}
+      fill
+      border={{ size: size === 'small' ? '0' : 'thin' }}
+    >
       <Box gap='15px'>
         {workflows?.map(workflow => (
           <Box border={{ color: 'light-5' }} key={workflow.id}>
             <Box height='10px' width='100%'>
               <Box
                 height='10px'
-                background={
-                  workflow?.completeness === 1 ? '#D47811' : 'neutral-2'
-                }
+                background={workflow?.completeness === 1 ? '#D47811' : 'neutral-2'}
                 width={`${Math.round(workflow?.completeness * 100)}%`}
               />
             </Box>
@@ -96,15 +111,13 @@ function Workflows({ workflows = [] }) {
                 {workflow?.completeness === 1 ? null : (
                   <Box direction='row' gap='3px'>
                     <Tip
-                      content={
-                        <Text color='white'>{t('ProjectStats.workflows.tip')}</Text>
-                      }
+                      content={<Text color='white'>{t('ProjectStats.workflows.tip')}</Text>}
                       plain
                       dropProps={{
                         align: { top: 'bottom' },
                         background: 'dark-4',
                         round: '5px',
-                        pad: '5px',
+                        pad: '5px'
                       }}
                     >
                       <Button plain icon={<CircleInformation size='0.75rem' />} />

--- a/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.stories.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.stories.jsx
@@ -60,3 +60,8 @@ export const Default = {}
 Default.args = {
   workflows: mockWorkflows
 }
+
+export const Empty = {}
+Empty.args = {
+  workflows: []
+}

--- a/packages/app-project/src/screens/ProjectStatsPage/helpers/useProjectStats.js
+++ b/packages/app-project/src/screens/ProjectStatsPage/helpers/useProjectStats.js
@@ -2,10 +2,11 @@ import { env } from '@zooniverse/panoptes-js'
 import useSWR from 'swr'
 
 const SWROptions = {
+  keepPreviousData: true, // Show previous data with a placeholder overtop when isLoading or isValidating
   revalidateIfStale: true,
   revalidateOnMount: true,
   revalidateOnFocus: false,
-  revalidateOnReconnect: true,
+  revalidateOnReconnect: false,
   refreshInterval: 0
 }
 

--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.jsx
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.jsx
@@ -1,5 +1,5 @@
 import { Box, Paragraph, Text } from 'grommet'
-import { number, object, string } from 'prop-types'
+import { bool, number, object, string } from 'prop-types'
 import styled from 'styled-components'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
@@ -15,8 +15,8 @@ const MainGrid = styled.div`
   @media (min-width: 678px) {
     // Grommet small breakpoint
     grid-template-rows: 1fr;
-    grid-template-columns: 50% auto;
-    column-gap: 10px;
+    grid-template-columns: min(678px, 50%) min(550px, 50%);
+    justify-content: space-between;
   }
 `
 
@@ -24,18 +24,12 @@ const NumbersGrid = styled.div`
   display: grid;
   grid-template-rows: 1fr 1fr;
   grid-template-columns: 1fr 1fr;
-  grid-gap: 12px;
+  row-gap: 12px;
 
   @media (max-width: 679px) {
     // Grommet small breakpoint
     margin-top: 20px;
-    column-gap: 0;
   }
-`
-
-const StyledParagraph = styled(Paragraph)`
-  line-height: 22px;
-  max-width: 100%;
 `
 
 const dateStringOptions = {
@@ -49,10 +43,12 @@ function ProjectStatistics({
   classifications,
   completedSubjects,
   completeness,
+  hideLink = false,
   launchDate = null,
   linkProps,
   projectName,
   subjects,
+  titleLevel = 2,
   volunteers
 }) {
   const { t } = useTranslation('components')
@@ -67,15 +63,16 @@ function ProjectStatistics({
   return (
     <ContentBox
       className={className}
-      linkLabel={t('ProjectStatistics.viewMoreStats')}
-      linkProps={linkProps}
+      titleLevel={titleLevel}
+      linkLabel={hideLink ?  null: t('ProjectStatistics.viewMoreStats')}
+      linkProps={hideLink ? null : linkProps}
       title={t('ProjectStatistics.title', { projectName })}
     >
       <MainGrid>
         <Box>
-          <StyledParagraph size='medium'>
+          <Paragraph margin={{ top: 'none'}}>
             {t('ProjectStatistics.text', { projectName })}
-          </StyledParagraph>
+          </Paragraph>
           <CompletionBar completeness={completeness} />
           <Box
             direction='row'
@@ -115,10 +112,12 @@ ProjectStatistics.propTypes = {
   classifications: number.isRequired,
   completedSubjects: number.isRequired,
   completeness: number,
+  hideLink: bool,
   launchDate: string,
   linkProps: object.isRequired,
   projectName: string,
   subjects: number.isRequired,
+  titleLevel: number,
   volunteers: number.isRequired
 }
 

--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.jsx
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.jsx
@@ -17,7 +17,7 @@ function useStore() {
   }
 }
 
-const ProjectStatisticsContainer = ({ className, hideLink }) => {
+const ProjectStatisticsContainer = ({ className, hideLink = false, titleLevel = 2 }) => {
   const {
     classifications,
     completedSubjects,
@@ -31,7 +31,7 @@ const ProjectStatisticsContainer = ({ className, hideLink }) => {
   const router = useRouter()
   const owner = router?.query?.owner
   const project = router?.query?.project
-  const linkProps = hideLink ? null : {
+  const linkProps = {
     externalLink: true, // A project stats page uses PFE
     href: `/projects/${owner}/${project}/stats`
   }
@@ -42,10 +42,12 @@ const ProjectStatisticsContainer = ({ className, hideLink }) => {
       classifications={classifications}
       completedSubjects={completedSubjects}
       completeness={completeness}
+      hideLink={hideLink}
       launchDate={launchDate}
       linkProps={linkProps}
       projectName={projectName}
       subjects={subjects}
+      titleLevel={titleLevel}
       volunteers={volunteers}
     />
   )

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/Stat/Stat.jsx
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/Stat/Stat.jsx
@@ -3,19 +3,25 @@
 import { Box } from 'grommet'
 import { number, string } from 'prop-types'
 import { SpacedText } from '@zooniverse/react-components'
+import styled from 'styled-components'
+
+const StyledText = styled(SpacedText)`
+  text-wrap: nowrap;
+  text-align: center;
+`
 
 import AnimatedNumber from '@zooniverse/react-components/AnimatedNumber'
 
 function Stat({ label, value }) {
   return (
     <Box align='center'>
-      <SpacedText
+      <StyledText
         color={{ dark: 'neutral-6', light: 'dark-4' }}
         uppercase={false}
         size='1rem'
       >
         {label}
-      </SpacedText>
+      </StyledText>
       <SpacedText
         color={{ dark: 'accent-1', light: 'neutral-1' }}
         size='xxlarge'


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Builds on top of https://github.com/zooniverse/front-end-monorepo/pull/7281
Toward https://github.com/zooniverse/front-end-monorepo/issues/7080

## Describe your changes
- Edit the page layout and various styling for responsive screen sizes, dark mode, etc
- Add empty state to the Workflows component