### PR TITLE
Project Stats page: improvements to ChartContainer and BarChart for slow connections

### DIFF
--- a/packages/app-project/public/locales/en/screens.json
+++ b/packages/app-project/public/locales/en/screens.json
@@ -90,6 +90,7 @@
         "thisMonth": "This Month",
         "thisYear": "This Year"
       },
+      "empty": "No data. Change the workflow or the date range.",
       "selectDateRange": "Select date range",
       "selectWorkflow": "Select workflow"
     },

--- a/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
@@ -110,7 +110,7 @@ function BarChart({
       }}
       chart={chartOptions}
       data={completeData}
-      detail={!!completeData?.length > 0}
+      detail={!!completeData?.length > 0} // only show detail on hover if completeData if available
       guide={{
         y: {
           granularity: 'fine'
@@ -121,7 +121,6 @@ function BarChart({
           property: 'period',
           label: dateRangeLabel.countLabel,
           render: (period, datum, datumIndex) => {
-            if (!period) return '' // sometimes BarChart renders <Detail /> when `period` isn't defined. Haven't been able to replicate the bug consistently ¯\_(ツ)_/¯
             const date = new Date(period)
 
             if (xAxisFrequency === X_AXIS_FREQUENCY.everyOther && datum?.index % 2 !== 0) {

--- a/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
@@ -66,6 +66,7 @@ function BarChart({
   // set chart options based on data length and type
   const chartOptions = {
     color: gradient,
+    detail: false,
     property: 'count',
     type: 'bar'
   }
@@ -109,7 +110,7 @@ function BarChart({
       }}
       chart={chartOptions}
       data={completeData}
-      detail={!!completeData?.length}
+      detail={!!completeData?.length > 0}
       guide={{
         y: {
           granularity: 'fine'

--- a/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
@@ -147,7 +147,8 @@ function ChartContainer({ workflows }) {
     day: 'numeric',
     timeZone: 'UTC'
   }
-  if (!selectedDateRangeOption && !dateRangeMessage) {
+
+  if (!selectedDateRangeOption && !dateRangeMessage && endDate && startDate) {
     const formattedStartDate = new Intl.DateTimeFormat(locale, formatOptions).format(
       new Date(startDate)
     )
@@ -216,7 +217,8 @@ function ChartContainer({ workflows }) {
 
   return (
     <>
-      <CustomDateRange
+      {/* Only render these <input> if ChartContainer has mounted */}
+      {startDate && endDate ? <CustomDateRange
         endDate={endDate}
         launchDate={displayedLaunchDate}
         setStartDate={setStartDate}
@@ -224,7 +226,7 @@ function ChartContainer({ workflows }) {
         setShowCalendar={setShowCalendar}
         showCalendar={showCalendar}
         startDate={startDate}
-      />
+      /> : null}
       <ContentBox fill border={{ size: smallScreen ? '0' : 'thin' }}>
         <Box
           direction={size !== 'small' ? 'row' : 'column'}
@@ -242,13 +244,15 @@ function ChartContainer({ workflows }) {
             {t('ProjectStats.heading', { projectName: projectDisplayName })}
           </StyledHeading>
           <Box align='center'>
-            <SpacedText
-              color={{ dark: 'neutral-6', light: 'dark-4' }}
-              uppercase={false}
-              size='1rem'
-            >
-              {t(`ProjectStats.${type}`)}
-            </SpacedText>
+            {type ? (
+              <SpacedText
+                color={{ dark: 'neutral-6', light: 'dark-4' }}
+                uppercase={false}
+                size='1rem'
+              >
+                {t(`ProjectStats.${type}`)}
+              </SpacedText>
+            ) : null}
             <SpacedText color={{ dark: 'accent-1', light: 'neutral-1' }} size='xxlarge'>
               {loadingOrValidating ? (
                 <Loader height='2.5rem' width='2rem' />
@@ -318,18 +322,14 @@ function ChartContainer({ workflows }) {
             </StyledBox>
           </ThemeContext.Extend>
         </Box>
-        {loadingOrValidating ? <LoadingPlaceholder /> : null}
         {!loadingOrValidating && errorMessage?.length ? (
           <Box fill align='center' pad='medium'>
             <Text>{errorMessage}</Text>
           </Box>
         ) : null}
         <Relative height='medium' margin={{ vertical: 'medium' }}>
-          <BarChart
-            data={data?.data}
-            dateRange={{ startDate, endDate }}
-            type={type}
-          />
+          {loadingOrValidating ? <LoadingPlaceholder /> : null}
+          <BarChart data={data?.data} dateRange={{ startDate, endDate }} type={type} />
         </Relative>
       </ContentBox>
     </>

--- a/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
@@ -11,6 +11,7 @@ import { useSearchParams } from 'next/navigation'
 import ContentBox from '@shared/components/ContentBox'
 import BarChart from '../BarChart/BarChart'
 import CustomDateRange from './CustomDateRange'
+import EmptyPlaceholder from '../Placeholders/EmptyPlaceholder'
 import LoadingPlaceholder from '../Placeholders/LoadingPlaceholder'
 import StyledTab from './StyledTab'
 import selectTheme from './selectTheme'
@@ -218,15 +219,17 @@ function ChartContainer({ workflows }) {
   return (
     <>
       {/* Only render these <input> if ChartContainer has mounted */}
-      {startDate && endDate ? <CustomDateRange
-        endDate={endDate}
-        launchDate={displayedLaunchDate}
-        setStartDate={setStartDate}
-        setEndDate={setEndDate}
-        setShowCalendar={setShowCalendar}
-        showCalendar={showCalendar}
-        startDate={startDate}
-      /> : null}
+      {startDate && endDate ? (
+        <CustomDateRange
+          endDate={endDate}
+          launchDate={displayedLaunchDate}
+          setStartDate={setStartDate}
+          setEndDate={setEndDate}
+          setShowCalendar={setShowCalendar}
+          showCalendar={showCalendar}
+          startDate={startDate}
+        />
+      ) : null}
       <ContentBox fill border={{ size: smallScreen ? '0' : 'thin' }}>
         <Box
           direction={size !== 'small' ? 'row' : 'column'}
@@ -329,7 +332,16 @@ function ChartContainer({ workflows }) {
         ) : null}
         <Relative height='medium' margin={{ vertical: 'medium' }}>
           {loadingOrValidating ? <LoadingPlaceholder /> : null}
-          <BarChart data={data?.data} dateRange={{ startDate, endDate }} type={type} />
+          {/*
+            We want to show the previousData via useProjectStats() SWR while loading or validating,
+            but Grommet's DataChart > Detail component will randomly error sometimes when refreshing
+            the data because Grommet `detail` uses `series.render` method. Crashes the page if it can't
+            find the expected `period`.
+          */}
+          {data?.data.length > 0 ? (
+            <BarChart data={data?.data} dateRange={{ startDate, endDate }} type={type} />
+          ) : null}
+          {!loadingOrValidating && data?.data.length === 0 ? <EmptyPlaceholder /> : null}
         </Relative>
       </ContentBox>
     </>

--- a/packages/app-project/src/screens/ProjectStatsPage/components/Placeholders/EmptyPlaceholder.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/Placeholders/EmptyPlaceholder.jsx
@@ -1,0 +1,11 @@
+import { Box, Paragraph } from 'grommet'
+
+function EmptyPlaceholder() {
+  return (
+    <Box fill align='center' pad={{ vertical: 'large' }}>
+      <Paragraph>{t('ProjectStats.BarChart.empty')}</Paragraph>
+    </Box>
+  )
+}
+
+export default EmptyPlaceholder

--- a/packages/app-project/src/screens/ProjectStatsPage/helpers/useProjectStats.js
+++ b/packages/app-project/src/screens/ProjectStatsPage/helpers/useProjectStats.js
@@ -38,6 +38,6 @@ async function fetchStats({
 
 export default function useProjectStats(query, type) {
   const endpoint = type === 'count' ? '/classifications' : '/comments'
-  const key = { endpoint, query }
+  const key = type ? { endpoint, query } : null
   return useSWR(key, fetchStats, SWROptions)
 }

--- a/packages/app-project/src/screens/ProjectStatsPage/helpers/validateDateRangeParams.js
+++ b/packages/app-project/src/screens/ProjectStatsPage/helpers/validateDateRangeParams.js
@@ -22,6 +22,11 @@ function validateDate({ date, dateKey }) {
 }
 
 export default function validateDateRangeParams({ endDate, startDate }) {
+  // If chartContainer is rendered with query params already in the URL,
+  // we have to use those instead of defaults. endDate and startDate are null
+  // until the component mounts.
+  if (endDate === null && startDate === null) return ''
+
   const { date: validEndDate, message: endDateMessage } = validateDate({ date: endDate, dateKey: 'end_date' })
   const { date: validStartDate, message: startDateMessage } = validateDate({ date: startDate, dateKey: 'start_date' })
 


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Follows https://github.com/zooniverse/front-end-monorepo/pull/7281

## Describe your changes
- Improve handling of `startDate` and `endDate` during page loading for slow network connections
- `type` is null on page load, so don't fetch via `useProjectStats()` unless it is defined
- Add an EmptyPlaceholder component when no data is returned from the stats API