### PR TITLE
app-project: Fix EmptyPlaceholder's translation in the bar chart on Project Stats

### DIFF
--- a/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
@@ -148,7 +148,7 @@ function BarChart({
           property: 'count',
           label: typeLabel,
           render: number => {
-            return <Text data-testid='countLabel'>{number.toLocaleString()}</Text>
+            return <Text data-testid='countLabel'>{Math.round(number.toLocaleString())}</Text>
           }
         }
       ]}

--- a/packages/app-project/src/screens/ProjectStatsPage/components/Placeholders/EmptyPlaceholder.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/Placeholders/EmptyPlaceholder.jsx
@@ -1,6 +1,9 @@
 import { Box, Paragraph } from 'grommet'
+import { useTranslation } from 'next-i18next'
 
 function EmptyPlaceholder() {
+  const { t } = useTranslation('screens')
+
   return (
     <Box fill align='center' pad={{ vertical: 'large' }}>
       <Paragraph>{t('ProjectStats.BarChart.empty')}</Paragraph>


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Internal testing of the new Project Stats page

## Describe your changes
- Fix the missing import for the bar chart's empty state.
- Round the `count` on the chart's y-axis to display a integer for classifications and comments.