### PR TITLE
app-project: Revert rounded numbers in the Project Stats bar chart y-axis

### DIFF
--- a/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
@@ -148,7 +148,7 @@ function BarChart({
           property: 'count',
           label: typeLabel,
           render: number => {
-            return <Text data-testid='countLabel'>{Math.round(number.toLocaleString())}</Text>
+            return <Text data-testid='countLabel'>{number.toLocaleString()}</Text>
           }
         }
       ]}


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Internal review of the Project Stats page

## Describe your changes
- Remove `Math.round` from the y-axis. It results in axis ticks with duplicate numbers without further configuration. 
- Example if numbers are rounded:
<img width="200" alt="screenshot of y-axis" src="https://github.com/user-attachments/assets/32b6c5f7-8d83-4c72-a05d-deb157a97114" />

By comparison, the User Stats and Groups bar chart displays fractions:
<img width="200"  alt="Screenshot of y-axis" src="https://github.com/user-attachments/assets/fac7cf98-aa96-4bc4-9637-d9632748b883" />
