### PR TITLE
lib-classifier: Add configurable vertex bounds to LineStringTool

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -40,19 +40,19 @@ export const WithGeoDrawingTask = {
 }
 
 export const WithGeoDrawingLineStringTask = {
+  argTypes: {
+    min_vertices: {
+      control: { type: 'number', min: 0, step: 1 },
+      description: 'Minimum vertices required before the line can be finished. Leave blank for OL\'s default (2).'
+    },
+    max_vertices: {
+      control: { type: 'number', min: 0, step: 1 },
+      description: 'Maximum vertices allowed. Once reached, the line auto-finishes. Leave blank for no limit.'
+    }
+  },
   args: {
-    geoDrawingTask: GeoDrawingTask.create({
-      taskKey: 'T0',
-      activeToolIndex: 0,
-      tools: [
-        {
-          type: 'LineString',
-          label: 'Dam crest',
-          color: '#00aa55',
-        },
-      ],
-      type: 'geoDrawing',
-    }),
+    min_vertices: undefined,
+    max_vertices: undefined,
     geoJSON: {
       type: 'FeatureCollection',
       bbox: [-91.05, 47.96, -90.97, 48.01],
@@ -75,6 +75,23 @@ export const WithGeoDrawingLineStringTask = {
       }
     }
   },
+  render: ({ min_vertices, max_vertices, ...rest }) => {
+    const tool = {
+      type: 'LineString',
+      label: 'Dam crest',
+      color: '#00aa55'
+    }
+    if (min_vertices !== undefined && min_vertices !== '') tool.min_vertices = min_vertices
+    if (max_vertices !== undefined && max_vertices !== '') tool.max_vertices = max_vertices
+
+    const geoDrawingTask = GeoDrawingTask.create({
+      taskKey: 'T0',
+      activeToolIndex: 0,
+      tools: [tool],
+      type: 'geoDrawing'
+    })
+    return <GeoMapViewer {...rest} geoDrawingTask={geoDrawingTask} />
+  }
 }
 
 export const WithoutGeoDrawingTask = {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
@@ -37,19 +37,41 @@ function createGeoLineStringInteraction({
 }) {
   let isDrawing = false
 
+  const activeTool = geoDrawingTask?.activeTool
+  const minPoints = activeTool?.type === 'LineString' ? activeTool.min_vertices : undefined
+  const maxPoints = activeTool?.type === 'LineString' ? activeTool.max_vertices : undefined
+  const effectiveMin = typeof minPoints === 'number' ? minPoints : 2
+
+  // Block clicks that land on an already-placed vertex until min_vertices is
+  // reached, so double/triple-clicking can't stack duplicates. After min,
+  // allow them so OL's native double-click-to-finish can still close the line.
+  function isDuplicateVertexClick(event) {
+    const sketch = draw.getOverlay().getSource().getFeatures()
+      .find(f => f.getGeometry()?.getType() === 'LineString')
+    if (!sketch) return false
+    const fixed = sketch.getGeometry().getCoordinates().slice(0, -1)
+    if (fixed.length >= effectiveMin) return false
+    return fixed.some(coord => {
+      const p = map.getPixelFromCoordinate(coord)
+      return p && Math.hypot(p[0] - event.pixel[0], p[1] - event.pixel[1]) <= FEATURE_HIT_TOLERANCE_PX
+    })
+  }
+
   const draw = new Draw({
     source,
     type: 'LineString',
     condition: (event) => {
       if (!primaryAction(event)) return false
-      if (isDrawing) return true
+      if (isDrawing) return !isDuplicateVertexClick(event)
       if (!featuresLayer) return true
       return !map.hasFeatureAtPixel(event.pixel, {
         layerFilter: (layer) => layer === featuresLayer,
         hitTolerance: FEATURE_HIT_TOLERANCE_PX
       })
     },
-    style: buildSketchStyleFn({ map, featuresLayer, getIsDrawing: () => isDrawing })
+    style: buildSketchStyleFn({ map, featuresLayer, getIsDrawing: () => isDrawing }),
+    ...(typeof minPoints === 'number' ? { minPoints } : {}),
+    ...(typeof maxPoints === 'number' ? { maxPoints } : {})
   })
 
   map.addInteraction(draw)

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.js
@@ -1,9 +1,38 @@
 import { types } from 'mobx-state-tree'
 
+// Panoptes returns workflow config values as strings (e.g. min_vertices: '3').
+// Coerce to a finite number; fall back to the supplied fallback (or undefined)
+// when the snapshot is blank or non-numeric so OL Draw uses its own defaults.
+function coerceVertexCount(snapshot, fallback) {
+  if (snapshot === undefined || snapshot === null || snapshot === '') return fallback
+  const n = typeof snapshot === 'number' ? snapshot : Number(snapshot)
+  return Number.isFinite(n) ? n : fallback
+}
+
+const MinVertexCount = types.snapshotProcessor(
+  types.optional(types.number, 2),
+  {
+    preProcessor(snapshot) {
+      return coerceVertexCount(snapshot, 2)
+    }
+  }
+)
+
+const MaxVertexCount = types.snapshotProcessor(
+  types.maybe(types.number),
+  {
+    preProcessor(snapshot) {
+      return coerceVertexCount(snapshot, undefined)
+    }
+  }
+)
+
 const LineStringTool = types
   .model('LineStringTool', {
     color: types.optional(types.string, ''),
     label: types.optional(types.string, ''),
+    max_vertices: MaxVertexCount,
+    min_vertices: MinVertexCount,
     type: types.literal('LineString')
   })
 

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.spec.jsx
@@ -22,11 +22,23 @@ describe('Model > LineStringTool', function () {
     expect(tool.label).to.equal('')
   })
 
+  it('should default min_vertices to 2', function () {
+    const tool = LineStringTool.create({ type: 'LineString' })
+    expect(tool.min_vertices).to.equal(2)
+  })
+
+  it('should default max_vertices to undefined (no upper bound)', function () {
+    const tool = LineStringTool.create({ type: 'LineString' })
+    expect(tool.max_vertices).to.equal(undefined)
+  })
+
   describe('with defined properties', function () {
     const lineStringToolSnapshot = {
       label: 'Dam crest',
       type: 'LineString',
-      color: '#00ff00'
+      color: '#00ff00',
+      min_vertices: 3,
+      max_vertices: 10
     }
 
     it('should have a color property', function () {
@@ -37,6 +49,43 @@ describe('Model > LineStringTool', function () {
     it('should have a label property', function () {
       const tool = LineStringTool.create(lineStringToolSnapshot)
       expect(tool.label).to.equal('Dam crest')
+    })
+
+    it('should accept min_vertices', function () {
+      const tool = LineStringTool.create(lineStringToolSnapshot)
+      expect(tool.min_vertices).to.equal(3)
+    })
+
+    it('should accept max_vertices', function () {
+      const tool = LineStringTool.create(lineStringToolSnapshot)
+      expect(tool.max_vertices).to.equal(10)
+    })
+  })
+
+  describe('with vertex bounds as strings (Panoptes JSON)', function () {
+    it('should coerce string min_vertices to a number', function () {
+      const tool = LineStringTool.create({ type: 'LineString', min_vertices: '3' })
+      expect(tool.min_vertices).to.equal(3)
+    })
+
+    it('should coerce string max_vertices to a number', function () {
+      const tool = LineStringTool.create({ type: 'LineString', max_vertices: '10' })
+      expect(tool.max_vertices).to.equal(10)
+    })
+
+    it('should fall back to undefined when max_vertices is empty string', function () {
+      const tool = LineStringTool.create({ type: 'LineString', max_vertices: '' })
+      expect(tool.max_vertices).to.equal(undefined)
+    })
+
+    it('should fall back to the default min_vertices when min_vertices is empty string', function () {
+      const tool = LineStringTool.create({ type: 'LineString', min_vertices: '' })
+      expect(tool.min_vertices).to.equal(2)
+    })
+
+    it('should fall back to undefined when max_vertices is non-numeric', function () {
+      const tool = LineStringTool.create({ type: 'LineString', max_vertices: 'abc' })
+      expect(tool.max_vertices).to.equal(undefined)
     })
   })
 })


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #7366

## Describe your changes
- add `min_vertices` and `max_vertices` fields to LineStringTool, forwarded to OL Draw as `minPoints` and `maxPoints`
- coerce string snapshots from Panoptes JSON to numbers, falling back to defaults (min 2, no max) on blank or non-numeric input
- expose `min_vertices` and `max_vertices` as Storybook argTypes on `WithGeoDrawingLineStringTask`
- block clicks on an already-placed vertex until `min_vertices` is reached, so double or triple clicks can't stack duplicates

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- n/a for this PR. End-to-end UX (a LineString tool with configurable bounds on a real workflow) lands when the Lab editor ships at the end of this milestone. Until then, the Storybook story below is the user-facing surface.

What user actions should my reviewer step through to review this PR?
- [x] run `pnpm storybook` in `packages/lib-classifier`, open `Subject Viewers / GeoMapViewer` -> `WithGeoDrawingLineStringTask`
- [x] in the Controls panel, set `min_vertices: 3` and `max_vertices: 10`. You may have to refresh the page (I had to in Safari)
- [x] click 10 distinct map points in succession. The 10th click should auto-finish the line: no double-click needed, the line is drawn and selected
- [x] click one point and double-click; the line should NOT be created (below the min).
- [x] click three points at distinct spots and then double-click; the line SHOULD be created (min reached)
- [x] start a new sketch and double-click on the same spot; you should get one vertex (not two stacked). Click two more distinct points, then double-click to finish
- [x] clear the controls (leave `min_vertices` and `max_vertices` blank); confirm drawing still works with no upper bound and a minimum of 2 vertices
- [x] confirm earlier-PR behaviors are intact: draw a 3-vertex line, click off, hover a vertex (cursor = grab), press (cursor = grabbing), drag (vertex follows)
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `LineStringTool.spec.jsx` and `createGeoLineStringInteraction.spec.js` pass

Which storybook stories should be reviewed?
- `Subject Viewers / GeoMapViewer` -> `WithGeoDrawingLineStringTask`: http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-geo-drawing-line-string-task

Are there plans for follow up PR's to further fix this bug or develop this feature?
- Yes. This is PR 6 of 9 in the Segmented Line milestone. Sequential PRs that follow this one (in merge order):
- [#7367](https://github.com/zooniverse/front-end-monorepo/issues/7367) lib-classifier: Add min and max line count to LineStringTool
- [#7368](https://github.com/zooniverse/front-end-monorepo/issues/7368) lib-classifier: Add delete affordance for selected LineString feature
- [#7459 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7459) Panoptes-Front-End: Add LineString tool to GeoDrawing task editor

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
