### PR TITLE
Project Stats: fix crash when start_date is after end_date

### DIFF
--- a/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
@@ -338,10 +338,10 @@ function ChartContainer({ workflows }) {
             the data because Grommet `detail` uses `series.render` method. Crashes the page if it can't
             find the expected `period`.
           */}
-          {data?.data.length > 0 ? (
+          {data?.data?.length > 0 ? (
             <BarChart data={data?.data} dateRange={{ startDate, endDate }} type={type} />
           ) : null}
-          {!loadingOrValidating && data?.data.length === 0 ? <EmptyPlaceholder /> : null}
+          {!loadingOrValidating && data?.data?.length === 0 ? <EmptyPlaceholder /> : null}
         </Relative>
       </ContentBox>
     </>

--- a/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
@@ -216,6 +216,15 @@ function ChartContainer({ workflows }) {
 
   const smallScreen = size === 'small'
 
+  /*
+    We show the previousData via useProjectStats() SWR while loading or validating,
+    but Grommet's DataChart > Detail component will randomly error sometimes when revalidating
+    the data because Grommet `detail` uses `series.render` method. Trying to prevent a page
+    crash here by double checking everything in `renderBarChart`.
+  */
+  const renderBarChart = data?.data?.length > 0 && !!endDate && !!startDate && !!type
+  const chartDateRange = { startDate, endDate }
+
   return (
     <>
       {/* Only render these <input> if ChartContainer has mounted */}
@@ -332,14 +341,8 @@ function ChartContainer({ workflows }) {
         ) : null}
         <Relative height='medium' margin={{ vertical: 'medium' }}>
           {loadingOrValidating ? <LoadingPlaceholder /> : null}
-          {/*
-            We want to show the previousData via useProjectStats() SWR while loading or validating,
-            but Grommet's DataChart > Detail component will randomly error sometimes when refreshing
-            the data because Grommet `detail` uses `series.render` method. Crashes the page if it can't
-            find the expected `period`.
-          */}
-          {data?.data?.length > 0 ? (
-            <BarChart data={data?.data} dateRange={{ startDate, endDate }} type={type} />
+          {renderBarChart ? (
+            <BarChart data={data?.data} dateRange={chartDateRange} type={type} />
           ) : null}
           {!loadingOrValidating && data?.data?.length === 0 ? <EmptyPlaceholder /> : null}
         </Relative>


### PR DESCRIPTION
## PR Overview

Package: app-project
Affects: Project Stats pages

This PR fixes an issue on the Project Stats page, which crashes if the selected date range is invalid - specifically, in the case when the start date comes _after_ the end date.[^1]

[^1]: the time cops disapprove of this time crime.

Issue: "If start_date is after end_date, then page crashes."

- Can be replicated by going to the project's stats page, opening the time range dropdown, choosing Custom, and setting (say) end date = 1 Jan '26, start date = 1 May '26
- Page crashes with console error: "Cannot read properties of undefined (reading 'length')"
- Error is in ChartContainer.jsx: when useProjectStats() is called with wonky date ranges, it returns `data` with the value `{error: 'Date range entered is not valid'}` instead of `undefined`, as the code expects. This causes the use of `data?.data.length` in the code to break.  

Solution: 

- Add existence checks.
- Page now fails gracefully with the error message: "Invalid date range, start date must be before end date"

<img width="732" height="484" alt="image" src="https://github.com/user-attachments/assets/089430bd-33c6-4acf-89c7-cb569c46fdca" />

### Testing

- [Choose a project, go to its stats page.](https://local.zooniverse.org:3000/projects/zookeeper/galaxy-zoo/stats?env=production)
- Open time range dropdown, choose Custom, set end date before start date.
- Page should now fail gracefully.
- You should be able to continue using the stats page, e.g. choosing a valid date range this time.

### Status

Ready for review! I won't be in on Friday, so please feel free to approve+merge or discard this PR while I'm away.

