### PR TITLE
lib-classifier: Add per-tool line-count bounds to LineStringTool

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.activeToolSync.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.activeToolSync.spec.jsx
@@ -1,0 +1,113 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { Grommet } from 'grommet'
+import zooTheme from '@zooniverse/grommet-theme'
+import sinon from 'sinon'
+import { vi } from 'vitest'
+
+import GeoDrawingTaskModel from '@plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask'
+import GeoMapViewer from './GeoMapViewer'
+
+const createLineStringInteractionSpy = sinon.stub()
+const setActiveOnLineStringDraw = sinon.stub()
+const setActiveOnLineStringModify = sinon.stub()
+
+vi.mock('./helpers/createGeoLineStringInteraction', async () => {
+  const actual = await vi.importActual('./helpers/createGeoLineStringInteraction')
+  return {
+    ...actual,
+    default: (args) => {
+      createLineStringInteractionSpy(args)
+      return {
+        setActive: setActiveOnLineStringDraw,
+        destroy: sinon.stub(),
+        isDrawing: () => false,
+        isCapped: () => false,
+        abortDrawing: sinon.stub()
+      }
+    }
+  }
+})
+
+vi.mock('./helpers/createGeoLineStringModifyInteraction', () => ({
+  default: () => ({
+    setActive: setActiveOnLineStringModify,
+    destroy: sinon.stub(),
+    isModifying: () => false
+  })
+}))
+
+describe('Component > GeoMapViewer — activeToolIndex sync (observer wrap + per-tool Draw)', function () {
+  let task
+
+  beforeEach(function () {
+    createLineStringInteractionSpy.resetHistory()
+    setActiveOnLineStringDraw.resetHistory()
+    setActiveOnLineStringModify.resetHistory()
+    task = GeoDrawingTaskModel.create({
+      activeToolIndex: 0,
+      strings: {
+        'tools.0.label': 'Segmented Line',
+        'tools.1.label': 'Segmented Line 2'
+      },
+      taskKey: 'T0',
+      tools: [
+        { color: '#E65252', label: 'Segmented Line', type: 'LineString', min: 1, max: 3, min_vertices: 3 },
+        { color: '#F1AE45', label: 'Segmented Line 2', type: 'LineString' }
+      ],
+      type: 'geoDrawing'
+    })
+  })
+
+  function renderViewer() {
+    return render(
+      <Grommet theme={zooTheme}>
+        <GeoMapViewer geoDrawingTask={task} />
+      </Grommet>
+    )
+  }
+
+  it('constructs the LineString Draw once on initial mount and activates it', async function () {
+    renderViewer()
+    await waitFor(() => {
+      expect(createLineStringInteractionSpy.callCount).to.be.greaterThan(0)
+      expect(setActiveOnLineStringDraw.callCount).to.be.greaterThan(0)
+    })
+    expect(setActiveOnLineStringDraw.lastCall.args[0]).to.equal(true)
+  })
+
+  it('constructs a NEW LineString Draw when activeToolIndex changes so vertex bounds follow the new tool', async function () {
+    renderViewer()
+    await waitFor(() => {
+      expect(createLineStringInteractionSpy.callCount).to.be.greaterThan(0)
+    })
+    const baseline = createLineStringInteractionSpy.callCount
+
+    act(() => {
+      task.setActiveTool(1)
+    })
+
+    await waitFor(() => {
+      expect(createLineStringInteractionSpy.callCount).to.be.greaterThan(baseline)
+    })
+    expect(createLineStringInteractionSpy.lastCall.args[0].geoDrawingTask).to.equal(task)
+    expect(task.activeToolIndex).to.equal(1)
+  })
+
+  it('reconstructs the Draw on switch back to the original tool too', async function () {
+    renderViewer()
+    await waitFor(() => {
+      expect(createLineStringInteractionSpy.callCount).to.be.greaterThan(0)
+    })
+
+    act(() => { task.setActiveTool(1) })
+    await waitFor(() => {
+      expect(createLineStringInteractionSpy.callCount).to.be.at.least(2)
+    })
+    const afterFirstSwitch = createLineStringInteractionSpy.callCount
+
+    act(() => { task.setActiveTool(0) })
+    await waitFor(() => {
+      expect(createLineStringInteractionSpy.callCount).to.be.greaterThan(afterFirstSwitch)
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.activeToolSync.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.activeToolSync.spec.jsx
@@ -51,8 +51,8 @@ describe('Component > GeoMapViewer — activeToolIndex sync (observer wrap + per
       },
       taskKey: 'T0',
       tools: [
-        { color: '#E65252', label: 'Segmented Line', type: 'LineString', min: 1, max: 3, min_vertices: 3 },
-        { color: '#F1AE45', label: 'Segmented Line 2', type: 'LineString' }
+        { color: '#E65252', label: 'Segmented Line', type: 'SegmentedLine', min: 1, max: 3, min_vertices: 3 },
+        { color: '#F1AE45', label: 'Segmented Line 2', type: 'SegmentedLine' }
       ],
       type: 'geoDrawing'
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -447,6 +447,7 @@ function GeoMapViewer({
               isSketching: lineStringDrawRef.current?.isDrawing() ?? false,
               isOnSelectedVertex,
               isOnAnotherFeature,
+              isAtMaxLines: lineStringDrawRef.current?.isCapped() ?? false,
               isDragging: latestEvent.dragging
             })
             return

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -612,7 +612,7 @@ function GeoMapViewer({
   const activeToolType = geoDrawingTask?.activeTool?.type
   const activeToolIndex = geoDrawingTask?.activeToolIndex
   useEffect(function exitMeasureOnDrawingToolSelect() {
-    if (activeToolType === 'LineString' && isMeasureModeActiveRef.current) {
+    if (activeToolType === 'SegmentedLine' && isMeasureModeActiveRef.current) {
       measureInteractionRef.current?.clear()
       setIsMeasureModeActive(false)
     }
@@ -621,7 +621,7 @@ function GeoMapViewer({
   // OL Draw fixes minPoints/maxPoints at construction, so recreate per active tool.
   useEffect(function manageLineStringDraw() {
     if (!mapRef.current || !featuresRef.current) return undefined
-    if (activeToolType !== 'LineString' || !geoDrawingTask) return undefined
+    if (activeToolType !== 'SegmentedLine' || !geoDrawingTask) return undefined
 
     const interaction = createGeoLineStringInteraction({
       map: mapRef.current,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -1,5 +1,6 @@
 // dependencies
 import { Box } from 'grommet'
+import { observer } from 'mobx-react'
 import { arrayOf, func, shape, string } from 'prop-types'
 import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -148,6 +149,7 @@ function GeoMapViewer({
   const mapContainerRef = useRef()
   const mapRef = useRef()
   const featuresRef = useRef()
+  const featuresLayerRef = useRef()
   const geoJSONFormatRef = useRef()
   const isMeasureModeActiveRef = useRef(false)
   const isDrawModeActiveRef = useRef(false)
@@ -199,6 +201,7 @@ function GeoMapViewer({
     const featuresLayer = new VectorLayer({
       source: featuresSource
     })
+    featuresLayerRef.current = featuresLayer
 
     const map = new Map({
       target: mapContainerRef.current,
@@ -377,14 +380,6 @@ function GeoMapViewer({
       })
       map.addInteraction(moveToClick)
       moveToClickRef.current = moveToClick
-
-      lineStringDrawRef.current = createGeoLineStringInteraction({
-        map,
-        source: featuresSource,
-        featuresLayer,
-        geoDrawingTask,
-        selectInteraction: select
-      })
 
       lineStringModifyRef.current = createGeoLineStringModifyInteraction({
         map,
@@ -583,7 +578,6 @@ function GeoMapViewer({
       if (translateRef.current) map.removeInteraction(translateRef.current)
       if (modifyUncertaintyRef.current) map.removeInteraction(modifyUncertaintyRef.current)
       if (moveToClickRef.current) map.removeInteraction(moveToClickRef.current)
-      lineStringDrawRef.current?.destroy()
       lineStringModifyRef.current?.destroy()
       measureInteractionRef.current?.destroy()
       if (pointerMoveHandlerRef.current) map.un('pointermove', pointerMoveHandlerRef.current)
@@ -592,6 +586,7 @@ function GeoMapViewer({
       map.setTarget(undefined)
       mapRef.current = undefined
       featuresRef.current = undefined
+      featuresLayerRef.current = undefined
       geoJSONFormatRef.current = undefined
       scaleLineRef.current = undefined
       selectRef.current = undefined
@@ -599,7 +594,6 @@ function GeoMapViewer({
       modifyUncertaintyRef.current = undefined
       moveToClickRef.current = undefined
       measureInteractionRef.current = undefined
-      lineStringDrawRef.current = undefined
       lineStringModifyRef.current = undefined
       pointerMoveHandlerRef.current = undefined
       pointerDownHandlerRef.current = undefined
@@ -616,12 +610,35 @@ function GeoMapViewer({
   }, [selectedUnit, geoDrawingTask])
 
   const activeToolType = geoDrawingTask?.activeTool?.type
+  const activeToolIndex = geoDrawingTask?.activeToolIndex
   useEffect(function exitMeasureOnDrawingToolSelect() {
     if (activeToolType === 'LineString' && isMeasureModeActiveRef.current) {
       measureInteractionRef.current?.clear()
       setIsMeasureModeActive(false)
     }
   }, [activeToolType])
+
+  // OL Draw fixes minPoints/maxPoints at construction, so recreate per active tool.
+  useEffect(function manageLineStringDraw() {
+    if (!mapRef.current || !featuresRef.current) return undefined
+    if (activeToolType !== 'LineString' || !geoDrawingTask) return undefined
+
+    const interaction = createGeoLineStringInteraction({
+      map: mapRef.current,
+      source: featuresRef.current,
+      featuresLayer: featuresLayerRef.current,
+      geoDrawingTask,
+      selectInteraction: selectRef.current
+    })
+    lineStringDrawRef.current = interaction
+
+    return function cleanupDraw() {
+      interaction.destroy()
+      if (lineStringDrawRef.current === interaction) {
+        lineStringDrawRef.current = undefined
+      }
+    }
+  }, [activeToolType, activeToolIndex, geoDrawingTask])
 
   useEffect(function syncInteractions() {
     const states = getInteractionStates({ activeToolType, isMeasureModeActive })
@@ -635,7 +652,7 @@ function GeoMapViewer({
     translateRef.current?.setActive(states.translate)
     modifyUncertaintyRef.current?.setActive(states.modifyUncertainty)
     moveToClickRef.current?.setActive(states.moveToClick)
-  }, [activeToolType, isMeasureModeActive])
+  }, [activeToolType, activeToolIndex, isMeasureModeActive])
 
   useEffect(function syncMeasureSelection() {
     if (isMeasureModeActive) {
@@ -903,4 +920,4 @@ GeoMapViewer.propTypes = {
   onSelectedFeatureChange: func
 }
 
-export default GeoMapViewer
+export default observer(GeoMapViewer)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -43,26 +43,26 @@ export const WithGeoDrawingLineStringTask = {
   argTypes: {
     min_vertices: {
       control: { type: 'number', min: 0, step: 1 },
-      description: 'Minimum vertices required before the line can be finished. Leave blank for OL\'s default (2).'
+      description: 'Tool 0 (red): minimum vertices required before the line can be finished. Leave blank for OL\'s default (2).'
     },
     max_vertices: {
       control: { type: 'number', min: 0, step: 1 },
-      description: 'Maximum vertices allowed. Once reached, the line auto-finishes. Leave blank for no limit.'
+      description: 'Tool 0 (red): maximum vertices allowed. Once reached, the line auto-finishes. Leave blank for no limit.'
     },
-    min_lines: {
+    min: {
       control: { type: 'number', min: 0, step: 1 },
-      description: 'Minimum number of lines a volunteer must draw with this tool for the task to report complete. Leave blank for 0 (no minimum).'
+      description: 'Tool 0 (red): minimum number of lines a volunteer must draw with this tool for the task to report complete. Leave blank for 0 (no minimum).'
     },
-    max_lines: {
+    max: {
       control: { type: 'number', min: 0, step: 1 },
-      description: 'Maximum number of lines a volunteer can draw with this tool. Once reached, Draw deactivates. Leave blank for no limit.'
+      description: 'Tool 0 (red): maximum number of lines a volunteer can draw with this tool. Once reached, Draw deactivates. Leave blank for no limit.'
     }
   },
   args: {
     min_vertices: undefined,
     max_vertices: undefined,
-    min_lines: undefined,
-    max_lines: undefined,
+    min: undefined,
+    max: undefined,
     geoJSON: {
       type: 'FeatureCollection',
       bbox: [-91.05, 47.96, -90.97, 48.01],
@@ -85,21 +85,27 @@ export const WithGeoDrawingLineStringTask = {
       }
     }
   },
-  render: ({ min_vertices, max_vertices, min_lines, max_lines, ...rest }) => {
-    const tool = {
+  render: ({ min_vertices, max_vertices, min, max, ...rest }) => {
+    const redTool = {
       type: 'LineString',
-      label: 'Dam crest',
-      color: '#00aa55'
+      label: 'Segmented Line',
+      color: '#E65252'
     }
-    if (min_vertices !== undefined && min_vertices !== '') tool.min_vertices = min_vertices
-    if (max_vertices !== undefined && max_vertices !== '') tool.max_vertices = max_vertices
-    if (min_lines !== undefined && min_lines !== '') tool.min_lines = min_lines
-    if (max_lines !== undefined && max_lines !== '') tool.max_lines = max_lines
+    if (min_vertices !== undefined && min_vertices !== '') redTool.min_vertices = min_vertices
+    if (max_vertices !== undefined && max_vertices !== '') redTool.max_vertices = max_vertices
+    if (min !== undefined && min !== '') redTool.min = min
+    if (max !== undefined && max !== '') redTool.max = max
+
+    const orangeTool = {
+      type: 'LineString',
+      label: 'Segmented Line 2',
+      color: '#F1AE45'
+    }
 
     const geoDrawingTask = GeoDrawingTask.create({
       taskKey: 'T0',
       activeToolIndex: 0,
-      tools: [tool],
+      tools: [redTool, orangeTool],
       type: 'geoDrawing'
     })
     return <GeoMapViewer {...rest} geoDrawingTask={geoDrawingTask} />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -48,11 +48,21 @@ export const WithGeoDrawingLineStringTask = {
     max_vertices: {
       control: { type: 'number', min: 0, step: 1 },
       description: 'Maximum vertices allowed. Once reached, the line auto-finishes. Leave blank for no limit.'
+    },
+    min_lines: {
+      control: { type: 'number', min: 0, step: 1 },
+      description: 'Minimum number of lines a volunteer must draw with this tool for the task to report complete. Leave blank for 0 (no minimum).'
+    },
+    max_lines: {
+      control: { type: 'number', min: 0, step: 1 },
+      description: 'Maximum number of lines a volunteer can draw with this tool. Once reached, Draw deactivates. Leave blank for no limit.'
     }
   },
   args: {
     min_vertices: undefined,
     max_vertices: undefined,
+    min_lines: undefined,
+    max_lines: undefined,
     geoJSON: {
       type: 'FeatureCollection',
       bbox: [-91.05, 47.96, -90.97, 48.01],
@@ -75,7 +85,7 @@ export const WithGeoDrawingLineStringTask = {
       }
     }
   },
-  render: ({ min_vertices, max_vertices, ...rest }) => {
+  render: ({ min_vertices, max_vertices, min_lines, max_lines, ...rest }) => {
     const tool = {
       type: 'LineString',
       label: 'Dam crest',
@@ -83,6 +93,8 @@ export const WithGeoDrawingLineStringTask = {
     }
     if (min_vertices !== undefined && min_vertices !== '') tool.min_vertices = min_vertices
     if (max_vertices !== undefined && max_vertices !== '') tool.max_vertices = max_vertices
+    if (min_lines !== undefined && min_lines !== '') tool.min_lines = min_lines
+    if (max_lines !== undefined && max_lines !== '') tool.max_lines = max_lines
 
     const geoDrawingTask = GeoDrawingTask.create({
       taskKey: 'T0',

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -87,7 +87,7 @@ export const WithGeoDrawingLineStringTask = {
   },
   render: ({ min_vertices, max_vertices, min, max, ...rest }) => {
     const redTool = {
-      type: 'LineString',
+      type: 'SegmentedLine',
       label: 'Segmented Line',
       color: '#E65252'
     }
@@ -97,7 +97,7 @@ export const WithGeoDrawingLineStringTask = {
     if (max !== undefined && max !== '') redTool.max = max
 
     const orangeTool = {
-      type: 'LineString',
+      type: 'SegmentedLine',
       label: 'Segmented Line 2',
       color: '#F1AE45'
     }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
@@ -28,6 +28,12 @@ export function buildSketchStyleFn({ map, featuresLayer, getIsDrawing }) {
   }
 }
 
+function countLineStringFeatures(source) {
+  return source.getFeatures().filter((feature) => (
+    feature.getGeometry?.()?.getType?.() === 'LineString'
+  )).length
+}
+
 function createGeoLineStringInteraction({
   map,
   source,
@@ -56,6 +62,8 @@ function createGeoLineStringInteraction({
       return p && Math.hypot(p[0] - event.pixel[0], p[1] - event.pixel[1]) <= FEATURE_HIT_TOLERANCE_PX
     })
   }
+
+  const featureCountMax = activeTool?.type === 'LineString' ? activeTool.max_lines : undefined
 
   const draw = new Draw({
     source,
@@ -103,21 +111,36 @@ function createGeoLineStringInteraction({
         })
       })
     }
+
+    // OL Draw fires drawend BEFORE source.addFeature, so the new line isn't
+    // counted yet. +1 accounts for it.
+    if (typeof featureCountMax === 'number' && countLineStringFeatures(source) + 1 >= featureCountMax) {
+      draw.setActive(false)
+    }
   })
 
   const drawAbortKey = draw.on('drawabort', function handleDrawAbort() {
     isDrawing = false
   })
 
+  function isCapped() {
+    return typeof featureCountMax === 'number' && countLineStringFeatures(source) >= featureCountMax
+  }
+
   return {
     isDrawing() {
       return isDrawing
     },
+    isCapped,
     abortDrawing() {
       draw.abortDrawing?.()
       isDrawing = false
     },
     setActive(active) {
+      if (active && isCapped()) {
+        draw.setActive(false)
+        return
+      }
       draw.setActive(active)
       if (!active) isDrawing = false
     },

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
@@ -47,9 +47,9 @@ function createGeoLineStringInteraction({
 
   const activeTool = geoDrawingTask?.activeTool
   const activeToolIndex = geoDrawingTask?.activeToolIndex
-  const minPoints = activeTool?.type === 'LineString' ? activeTool.min_vertices : undefined
-  const maxPoints = activeTool?.type === 'LineString' ? activeTool.max_vertices : undefined
-  const featureCountMax = activeTool?.type === 'LineString' ? activeTool.max : undefined
+  const minPoints = activeTool?.type === 'SegmentedLine' ? activeTool.min_vertices : undefined
+  const maxPoints = activeTool?.type === 'SegmentedLine' ? activeTool.max_vertices : undefined
+  const featureCountMax = activeTool?.type === 'SegmentedLine' ? activeTool.max : undefined
   const effectiveMin = typeof minPoints === 'number' ? minPoints : 2
 
   function isDuplicateVertexClick(event) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
@@ -28,10 +28,12 @@ export function buildSketchStyleFn({ map, featuresLayer, getIsDrawing }) {
   }
 }
 
-function countLineStringFeatures(source) {
-  return source.getFeatures().filter((feature) => (
-    feature.getGeometry?.()?.getType?.() === 'LineString'
-  )).length
+function countLineStringFeaturesForTool(source, toolIndex) {
+  return source.getFeatures().filter((feature) => {
+    if (feature.getGeometry?.()?.getType?.() !== 'LineString') return false
+    if (typeof toolIndex !== 'number') return true
+    return feature.get?.('toolIndex') === toolIndex
+  }).length
 }
 
 function createGeoLineStringInteraction({
@@ -44,13 +46,12 @@ function createGeoLineStringInteraction({
   let isDrawing = false
 
   const activeTool = geoDrawingTask?.activeTool
+  const activeToolIndex = geoDrawingTask?.activeToolIndex
   const minPoints = activeTool?.type === 'LineString' ? activeTool.min_vertices : undefined
   const maxPoints = activeTool?.type === 'LineString' ? activeTool.max_vertices : undefined
+  const featureCountMax = activeTool?.type === 'LineString' ? activeTool.max : undefined
   const effectiveMin = typeof minPoints === 'number' ? minPoints : 2
 
-  // Block clicks that land on an already-placed vertex until min_vertices is
-  // reached, so double/triple-clicking can't stack duplicates. After min,
-  // allow them so OL's native double-click-to-finish can still close the line.
   function isDuplicateVertexClick(event) {
     const sketch = draw.getOverlay().getSource().getFeatures()
       .find(f => f.getGeometry()?.getType() === 'LineString')
@@ -62,8 +63,6 @@ function createGeoLineStringInteraction({
       return p && Math.hypot(p[0] - event.pixel[0], p[1] - event.pixel[1]) <= FEATURE_HIT_TOLERANCE_PX
     })
   }
-
-  const featureCountMax = activeTool?.type === 'LineString' ? activeTool.max_lines : undefined
 
   const draw = new Draw({
     source,
@@ -95,9 +94,8 @@ function createGeoLineStringInteraction({
     const feature = event.feature
     if (!feature) return
 
-    const toolIndex = geoDrawingTask?.activeToolIndex
-    if (typeof toolIndex === 'number') {
-      feature.set('toolIndex', toolIndex)
+    if (typeof activeToolIndex === 'number') {
+      feature.set('toolIndex', activeToolIndex)
     }
 
     if (selectInteraction) {
@@ -112,9 +110,8 @@ function createGeoLineStringInteraction({
       })
     }
 
-    // OL Draw fires drawend BEFORE source.addFeature, so the new line isn't
-    // counted yet. +1 accounts for it.
-    if (typeof featureCountMax === 'number' && countLineStringFeatures(source) + 1 >= featureCountMax) {
+    // drawend fires before source.addFeature, so include the in-flight feature.
+    if (typeof featureCountMax === 'number' && countLineStringFeaturesForTool(source, activeToolIndex) + 1 >= featureCountMax) {
       draw.setActive(false)
     }
   })
@@ -124,7 +121,7 @@ function createGeoLineStringInteraction({
   })
 
   function isCapped() {
-    return typeof featureCountMax === 'number' && countLineStringFeatures(source) >= featureCountMax
+    return typeof featureCountMax === 'number' && countLineStringFeaturesForTool(source, activeToolIndex) >= featureCountMax
   }
 
   return {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.spec.js
@@ -84,12 +84,15 @@ describe('helpers > createGeoLineStringInteraction', function () {
     interaction.destroy()
   })
 
-  it('refuses to activate when source already holds activeTool.max_lines LineStrings', function () {
-    // Pre-populate source with 2 LineStrings; tool max_lines is 2.
-    source.addFeature(new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) }))
-    source.addFeature(new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) }))
+  it('refuses to activate when source already holds activeTool.max LineStrings for the active tool', function () {
+    const f1 = new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) })
+    f1.set('toolIndex', 0)
+    const f2 = new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) })
+    f2.set('toolIndex', 0)
+    source.addFeature(f1)
+    source.addFeature(f2)
 
-    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max_lines: 2 } }
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 2 } }
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
 
     interaction.setActive(true)
@@ -99,16 +102,14 @@ describe('helpers > createGeoLineStringInteraction', function () {
     interaction.destroy()
   })
 
-  it('deactivates after drawend brings the count to activeTool.max_lines', function () {
-    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max_lines: 1 } }
+  it('deactivates after drawend brings the count to activeTool.max', function () {
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 1 } }
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
     interaction.setActive(true)
 
     const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
     expect(drawInteraction.getActive()).to.equal(true)
 
-    // OL Draw fires drawend BEFORE adding the feature to source. The handler
-    // must count the in-flight feature, not just what's already in source.
     const feature = new Feature({ geometry: new LineStringGeom([[0, 0], [10, 10]]) })
     drawInteraction.dispatchEvent({ type: 'drawend', feature })
 
@@ -116,15 +117,15 @@ describe('helpers > createGeoLineStringInteraction', function () {
     interaction.destroy()
   })
 
-  it('keeps Draw active when the in-flight feature does not yet hit activeTool.max_lines', function () {
-    // Pre-populate source with 1 LineString; tool max_lines is 3.
-    source.addFeature(new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) }))
-    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max_lines: 3 } }
+  it('keeps Draw active when the in-flight feature does not yet hit activeTool.max', function () {
+    const f1 = new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) })
+    f1.set('toolIndex', 0)
+    source.addFeature(f1)
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 3 } }
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
     interaction.setActive(true)
 
     const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
-    // Finish a second line (source still holds 1; this would make 2). 2 < 3 so Draw stays active.
     const feature = new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) })
     drawInteraction.dispatchEvent({ type: 'drawend', feature })
 
@@ -132,22 +133,41 @@ describe('helpers > createGeoLineStringInteraction', function () {
     interaction.destroy()
   })
 
-  it('exposes isCapped() reflecting whether the source has hit activeTool.max_lines', function () {
-    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max_lines: 2 } }
+  it('exposes isCapped() reflecting whether the active tool has hit its max', function () {
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 2 } }
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
 
     expect(interaction.isCapped()).to.equal(false)
-    source.addFeature(new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) }))
+    const f1 = new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) })
+    f1.set('toolIndex', 0)
+    source.addFeature(f1)
     expect(interaction.isCapped()).to.equal(false)
-    source.addFeature(new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) }))
+    const f2 = new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) })
+    f2.set('toolIndex', 0)
+    source.addFeature(f2)
     expect(interaction.isCapped()).to.equal(true)
     interaction.destroy()
   })
 
-  it('isCapped() returns false when no max_lines is configured', function () {
+  it('isCapped() returns false when no max is configured', function () {
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask, selectInteraction })
     source.addFeature(new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) }))
     source.addFeature(new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) }))
+    expect(interaction.isCapped()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('isCapped() considers only the active tool — features tagged for another tool do not count', function () {
+    const f1 = new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) })
+    f1.set('toolIndex', 1)
+    const f2 = new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) })
+    f2.set('toolIndex', 1)
+    source.addFeature(f1)
+    source.addFeature(f2)
+
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 2 } }
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+
     expect(interaction.isCapped()).to.equal(false)
     interaction.destroy()
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.spec.js
@@ -92,7 +92,7 @@ describe('helpers > createGeoLineStringInteraction', function () {
     source.addFeature(f1)
     source.addFeature(f2)
 
-    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 2 } }
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'SegmentedLine', max: 2 } }
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
 
     interaction.setActive(true)
@@ -103,7 +103,7 @@ describe('helpers > createGeoLineStringInteraction', function () {
   })
 
   it('deactivates after drawend brings the count to activeTool.max', function () {
-    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 1 } }
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'SegmentedLine', max: 1 } }
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
     interaction.setActive(true)
 
@@ -121,7 +121,7 @@ describe('helpers > createGeoLineStringInteraction', function () {
     const f1 = new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) })
     f1.set('toolIndex', 0)
     source.addFeature(f1)
-    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 3 } }
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'SegmentedLine', max: 3 } }
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
     interaction.setActive(true)
 
@@ -134,7 +134,7 @@ describe('helpers > createGeoLineStringInteraction', function () {
   })
 
   it('exposes isCapped() reflecting whether the active tool has hit its max', function () {
-    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 2 } }
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'SegmentedLine', max: 2 } }
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
 
     expect(interaction.isCapped()).to.equal(false)
@@ -165,7 +165,7 @@ describe('helpers > createGeoLineStringInteraction', function () {
     source.addFeature(f1)
     source.addFeature(f2)
 
-    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max: 2 } }
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'SegmentedLine', max: 2 } }
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
 
     expect(interaction.isCapped()).to.equal(false)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.spec.js
@@ -84,6 +84,74 @@ describe('helpers > createGeoLineStringInteraction', function () {
     interaction.destroy()
   })
 
+  it('refuses to activate when source already holds activeTool.max_lines LineStrings', function () {
+    // Pre-populate source with 2 LineStrings; tool max_lines is 2.
+    source.addFeature(new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) }))
+    source.addFeature(new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) }))
+
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max_lines: 2 } }
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+
+    interaction.setActive(true)
+
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction.getActive()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('deactivates after drawend brings the count to activeTool.max_lines', function () {
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max_lines: 1 } }
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+    interaction.setActive(true)
+
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction.getActive()).to.equal(true)
+
+    // OL Draw fires drawend BEFORE adding the feature to source. The handler
+    // must count the in-flight feature, not just what's already in source.
+    const feature = new Feature({ geometry: new LineStringGeom([[0, 0], [10, 10]]) })
+    drawInteraction.dispatchEvent({ type: 'drawend', feature })
+
+    expect(drawInteraction.getActive()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('keeps Draw active when the in-flight feature does not yet hit activeTool.max_lines', function () {
+    // Pre-populate source with 1 LineString; tool max_lines is 3.
+    source.addFeature(new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) }))
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max_lines: 3 } }
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+    interaction.setActive(true)
+
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    // Finish a second line (source still holds 1; this would make 2). 2 < 3 so Draw stays active.
+    const feature = new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) })
+    drawInteraction.dispatchEvent({ type: 'drawend', feature })
+
+    expect(drawInteraction.getActive()).to.equal(true)
+    interaction.destroy()
+  })
+
+  it('exposes isCapped() reflecting whether the source has hit activeTool.max_lines', function () {
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'LineString', max_lines: 2 } }
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+
+    expect(interaction.isCapped()).to.equal(false)
+    source.addFeature(new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) }))
+    expect(interaction.isCapped()).to.equal(false)
+    source.addFeature(new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) }))
+    expect(interaction.isCapped()).to.equal(true)
+    interaction.destroy()
+  })
+
+  it('isCapped() returns false when no max_lines is configured', function () {
+    const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask, selectInteraction })
+    source.addFeature(new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) }))
+    source.addFeature(new Feature({ geometry: new LineStringGeom([[2, 2], [3, 3]]) }))
+    expect(interaction.isCapped()).to.equal(false)
+    interaction.destroy()
+  })
+
   it('destroy() removes the Draw from the map', function () {
     const interaction = createGeoLineStringInteraction({ map, source, geoDrawingTask, selectInteraction })
     expect(map.getInteractions().getArray().some(i => i.constructor.name === 'Draw')).to.equal(true)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getDrawModeCursor.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getDrawModeCursor.js
@@ -3,12 +3,14 @@ function getDrawModeCursor({
   isSketching = false,
   isOnSelectedVertex = false,
   isOnAnotherFeature = false,
+  isAtMaxLines = false,
   isDragging = false
 } = {}) {
   if (isModifying) return 'grabbing'
   if (isSketching) return isDragging ? '' : 'crosshair'
   if (isOnSelectedVertex) return isDragging ? 'grabbing' : 'grab'
   if (isOnAnotherFeature) return 'pointer'
+  if (isAtMaxLines) return isDragging ? '' : 'not-allowed'
   return isDragging ? '' : 'crosshair'
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getDrawModeCursor.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getDrawModeCursor.spec.js
@@ -22,6 +22,18 @@ describe('helpers > getDrawModeCursor', function () {
     expect(getDrawModeCursor({ isOnAnotherFeature: true })).to.equal('pointer')
   })
 
+  it('returns not-allowed when the line-count cap is reached on empty map space', function () {
+    expect(getDrawModeCursor({ isAtMaxLines: true })).to.equal('not-allowed')
+    expect(getDrawModeCursor({ isAtMaxLines: true, isDragging: true })).to.equal('')
+  })
+
+  it('keeps grab/pointer/grabbing precedence ahead of isAtMaxLines so existing lines stay editable', function () {
+    expect(getDrawModeCursor({ isAtMaxLines: true, isOnSelectedVertex: true })).to.equal('grab')
+    expect(getDrawModeCursor({ isAtMaxLines: true, isOnSelectedVertex: true, isDragging: true })).to.equal('grabbing')
+    expect(getDrawModeCursor({ isAtMaxLines: true, isOnAnotherFeature: true })).to.equal('pointer')
+    expect(getDrawModeCursor({ isAtMaxLines: true, isModifying: true })).to.equal('grabbing')
+  })
+
   it('defaults to crosshair on empty map, empty when DragPan-style dragging', function () {
     expect(getDrawModeCursor()).to.equal('crosshair')
     expect(getDrawModeCursor({ isDragging: true })).to.equal('')

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getInteractionStates.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getInteractionStates.js
@@ -1,5 +1,5 @@
 function getInteractionStates({ activeToolType, isMeasureModeActive }) {
-  const isDrawing = activeToolType === 'LineString' && !isMeasureModeActive
+  const isDrawing = activeToolType === 'SegmentedLine' && !isMeasureModeActive
 
   return {
     measure: isMeasureModeActive,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getInteractionStates.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getInteractionStates.spec.js
@@ -1,9 +1,9 @@
 import getInteractionStates from './getInteractionStates'
 
 describe('helpers > getInteractionStates', function () {
-  describe('when the LineString tool is active and measure mode is off', function () {
+  describe('when the SegmentedLine tool is active and measure mode is off', function () {
     it('activates Draw and Modify and Select; disables Translate, ModifyUncertainty, MoveToClick, Measure', function () {
-      expect(getInteractionStates({ activeToolType: 'LineString', isMeasureModeActive: false })).to.deep.equal({
+      expect(getInteractionStates({ activeToolType: 'SegmentedLine', isMeasureModeActive: false })).to.deep.equal({
         measure: false,
         lineStringDraw: true,
         lineStringModify: true,
@@ -17,7 +17,7 @@ describe('helpers > getInteractionStates', function () {
 
   describe('when measure mode is on (any active tool)', function () {
     it('activates Measure and disables every feature interaction', function () {
-      expect(getInteractionStates({ activeToolType: 'LineString', isMeasureModeActive: true })).to.deep.equal({
+      expect(getInteractionStates({ activeToolType: 'SegmentedLine', isMeasureModeActive: true })).to.deep.equal({
         measure: true,
         lineStringDraw: false,
         lineStringModify: false,
@@ -28,7 +28,7 @@ describe('helpers > getInteractionStates', function () {
       })
     })
 
-    it('disables every feature interaction even when the tool is not LineString', function () {
+    it('disables every feature interaction even when the tool is not SegmentedLine', function () {
       expect(getInteractionStates({ activeToolType: 'Point', isMeasureModeActive: true })).to.deep.equal({
         measure: true,
         lineStringDraw: false,
@@ -41,7 +41,7 @@ describe('helpers > getInteractionStates', function () {
     })
   })
 
-  describe('when the active tool is not LineString and measure mode is off', function () {
+  describe('when the active tool is not SegmentedLine and measure mode is off', function () {
     it('enables Select and the point-feature interactions; disables Draw, Modify, Measure', function () {
       expect(getInteractionStates({ activeToolType: 'Point', isMeasureModeActive: false })).to.deep.equal({
         measure: false,
@@ -54,7 +54,7 @@ describe('helpers > getInteractionStates', function () {
       })
     })
 
-    it('handles an undefined active tool type the same as a non-LineString tool', function () {
+    it('handles an undefined active tool type the same as a non-SegmentedLine tool', function () {
       expect(getInteractionStates({ activeToolType: undefined, isMeasureModeActive: false })).to.deep.equal({
         measure: false,
         lineStringDraw: false,

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/LineString/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/LineString/index.js
@@ -1,1 +1,0 @@
-export { default } from './LineString'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/SegmentedLine.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/SegmentedLine.js
@@ -7,8 +7,8 @@ import Circle from 'ol/style/Circle'
 
 const DEFAULT_COLOR = '#007bff'
 
-const LineString = types
-  .model('LineString', {
+const SegmentedLine = types
+  .model('SegmentedLine', {
     type: types.literal('Feature'),
     geometry: types.model({
       type: types.literal('LineString'),
@@ -47,7 +47,7 @@ const LineString = types
       if (!tools) return undefined
       const toolIndex = feature?.get?.('toolIndex')
       const indexedTool = typeof toolIndex === 'number' ? tools[toolIndex] : undefined
-      return indexedTool || tools.find(tool => tool.type === 'LineString')
+      return indexedTool || tools.find(tool => tool.type === 'SegmentedLine')
     },
 
     getStyles({
@@ -87,4 +87,4 @@ const LineString = types
     }
   }))
 
-export default LineString
+export default SegmentedLine

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/SegmentedLine.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/SegmentedLine.spec.jsx
@@ -1,7 +1,7 @@
-import LineString from './LineString'
+import SegmentedLine from './SegmentedLine'
 import GeoDrawingTask from '../../../task/models/GeoDrawingTask'
 
-describe('Model > LineString', function () {
+describe('Model > SegmentedLine', function () {
   const basicSnapshot = {
     type: 'Feature',
     geometry: {
@@ -12,7 +12,7 @@ describe('Model > LineString', function () {
   }
 
   it('should exist', function () {
-    const lineString = LineString.create(basicSnapshot)
+    const lineString = SegmentedLine.create(basicSnapshot)
     expect(lineString).to.exist
     expect(lineString).to.be.an('object')
   })
@@ -27,7 +27,7 @@ describe('Model > LineString', function () {
         },
         properties: { name: 'Test line' }
       }
-      const lineString = LineString.create(snapshot)
+      const lineString = SegmentedLine.create(snapshot)
       expect(lineString.geometry.type).to.equal('LineString')
       expect(lineString.geometry.coordinates).to.deep.equal([[10, 20], [11, 21], [12, 22]])
       expect(lineString.properties.name).to.equal('Test line')
@@ -41,7 +41,7 @@ describe('Model > LineString', function () {
       const snapshot = {
         geometry: mockOLGeometry
       }
-      const lineString = LineString.create(snapshot)
+      const lineString = SegmentedLine.create(snapshot)
       expect(lineString.geometry.type).to.equal('LineString')
       expect(lineString.geometry.coordinates).to.deep.equal([[5, 15], [6, 16]])
     })
@@ -50,7 +50,7 @@ describe('Model > LineString', function () {
       const snapshot = {
         geometry: {}
       }
-      const lineString = LineString.create(snapshot)
+      const lineString = SegmentedLine.create(snapshot)
       expect(lineString.geometry.coordinates).to.deep.equal([])
     })
 
@@ -60,7 +60,7 @@ describe('Model > LineString', function () {
           coordinates: [[1, 2], [3, 4]]
         }
       }
-      const lineString = LineString.create(snapshot)
+      const lineString = SegmentedLine.create(snapshot)
       expect(lineString.geometry.type).to.equal('LineString')
     })
   })
@@ -73,14 +73,14 @@ describe('Model > LineString', function () {
             getCoordinates: () => [[10, 20], [11, 21]]
           })
         }
-        const lineString = LineString.create(basicSnapshot)
+        const lineString = SegmentedLine.create(basicSnapshot)
         const coords = lineString.getCoordinates({ feature: mockFeature })
         expect(coords).to.deep.equal([[10, 20], [11, 21]])
       })
 
       it('should return model coordinates as fallback', function () {
         const mockFeature = {}
-        const lineString = LineString.create(basicSnapshot)
+        const lineString = SegmentedLine.create(basicSnapshot)
         const coords = lineString.getCoordinates({ feature: mockFeature })
         expect(coords).to.deep.equal([[2.29, 48.85], [2.30, 48.86], [2.31, 48.87]])
       })
@@ -96,28 +96,28 @@ describe('Model > LineString', function () {
           type: 'geoDrawing',
           tools: [
             { type: 'Point', label: 'Point' },
-            { type: 'LineString', color: '#00ff00', label: 'Dam crest' }
+            { type: 'SegmentedLine', color: '#00ff00', label: 'Dam crest' }
           ]
         })
-        const lineString = LineString.create(basicSnapshot)
+        const lineString = SegmentedLine.create(basicSnapshot)
         const tool = lineString.getTool({ feature: mockFeature, geoDrawingTask })
-        expect(tool?.type).to.equal('LineString')
+        expect(tool?.type).to.equal('SegmentedLine')
         expect(tool?.label).to.equal('Dam crest')
       })
 
-      it('should fall back to first LineString tool when no toolIndex', function () {
+      it('should fall back to first SegmentedLine tool when no toolIndex', function () {
         const mockFeature = { get: () => null }
         const geoDrawingTask = GeoDrawingTask.create({
           taskKey: 'T0',
           type: 'geoDrawing',
           tools: [
             { type: 'Point', label: 'Point' },
-            { type: 'LineString', color: '#00ff00', label: 'Dam crest' }
+            { type: 'SegmentedLine', color: '#00ff00', label: 'Dam crest' }
           ]
         })
-        const lineString = LineString.create(basicSnapshot)
+        const lineString = SegmentedLine.create(basicSnapshot)
         const tool = lineString.getTool({ feature: mockFeature, geoDrawingTask })
-        expect(tool?.type).to.equal('LineString')
+        expect(tool?.type).to.equal('SegmentedLine')
       })
     })
 
@@ -132,12 +132,12 @@ describe('Model > LineString', function () {
         taskKey: 'T0',
         type: 'geoDrawing',
         tools: [
-          { type: 'LineString', color: '#00ff00', label: 'Dam crest' }
+          { type: 'SegmentedLine', color: '#00ff00', label: 'Dam crest' }
         ]
       })
 
       it('should return at least one stroke style when not selected', function () {
-        const lineString = LineString.create(basicSnapshot)
+        const lineString = SegmentedLine.create(basicSnapshot)
         const styles = lineString.getStyles({ feature: mockFeature, geoDrawingTask, isSelected: false })
         expect(styles).to.be.an('array')
         expect(styles.length).to.equal(1)
@@ -145,7 +145,7 @@ describe('Model > LineString', function () {
       })
 
       it('should add per-vertex circle styles when selected', function () {
-        const lineString = LineString.create(basicSnapshot)
+        const lineString = SegmentedLine.create(basicSnapshot)
         const styles = lineString.getStyles({ feature: mockFeature, geoDrawingTask, isSelected: true })
         expect(styles.length).to.equal(3)
         expect(styles[0].getStroke()).to.exist

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/index.js
@@ -1,0 +1,1 @@
+export { default } from './SegmentedLine'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/index.js
@@ -1,2 +1,2 @@
-export { default as LineString } from './LineString'
+export { default as SegmentedLine } from './SegmentedLine'
 export { default as Point } from './Point'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.jsx
@@ -55,6 +55,23 @@ const ToolIcon = styled(Location)`
   flex-shrink: 0;
 `
 
+function formatLineStringBounds(tool) {
+  if (tool?.type !== 'LineString') return null
+  const min = tool.min ?? 0
+  const max = tool.max
+  const minVertices = tool.min_vertices ?? 2
+  const maxVertices = tool.max_vertices
+  const hasConfiguredBounds = min > 0 || max != null || minVertices > 2 || maxVertices != null
+  if (!hasConfiguredBounds) return null
+  const linesText = max == null
+    ? `${min}+ lines`
+    : (min === max ? `${min} lines` : `${min}-${max} lines`)
+  const pointsText = maxVertices == null
+    ? `${minVertices}+ points per line`
+    : (minVertices === maxVertices ? `${minVertices} points per line` : `${minVertices}-${maxVertices} points per line`)
+  return `${linesText}, ${pointsText}`
+}
+
 function GeoDrawingTask({
   disabled = false,
   task
@@ -123,7 +140,8 @@ function GeoDrawingTask({
         const checked = task.activeToolIndex === index
         const currentRadius = task.activeOlFeature?.get?.('uncertainty_radius') ?? task.activeFeature?.properties?.uncertainty_radius
         const showUncertaintySlider = task.activeFeature && task.activeOlFeature && tool.uncertainty_circle && currentRadius !== null
-        
+        const boundsText = formatLineStringBounds(tool)
+
         return (
           <ToolLabel key={`${task.taskKey}_${index}`}>
             <HiddenInput
@@ -142,6 +160,11 @@ function GeoDrawingTask({
                   {task.strings.get(`tools.${index}.label`)}
                 </Text>
               </ToolHeader>
+              {boundsText && (
+                <Text size='xsmall' color='text-weak'>
+                  {boundsText}
+                </Text>
+              )}
               {showUncertaintySlider && (
                 <RadiusSlider
                   disabled={!checked || disabled}

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.jsx
@@ -56,7 +56,7 @@ const ToolIcon = styled(Location)`
 `
 
 function formatLineStringBounds(tool) {
-  if (tool?.type !== 'LineString') return null
+  if (tool?.type !== 'SegmentedLine') return null
   const min = tool.min ?? 0
   const max = tool.max
   const minVertices = tool.min_vertices ?? 2

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.spec.jsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react'
+import { Grommet } from 'grommet'
+import zooTheme from '@zooniverse/grommet-theme'
+
+import GeoDrawingTask from './GeoDrawingTask'
+import GeoDrawingTaskModel from '../models/GeoDrawingTask'
+
+function buildLineStringTask(toolOverrides = {}) {
+  return GeoDrawingTaskModel.create({
+    activeToolIndex: 0,
+    strings: {
+      instruction: 'Draw',
+      'tools.0.label': 'Segmented Line'
+    },
+    taskKey: 'T0',
+    tools: [
+      { color: '#E65252', label: 'Segmented Line', type: 'LineString', ...toolOverrides }
+    ],
+    type: 'geoDrawing'
+  })
+}
+
+function renderTask(task) {
+  return render(
+    <Grommet theme={zooTheme}>
+      <GeoDrawingTask task={task} />
+    </Grommet>
+  )
+}
+
+describe('Component > GeoDrawingTask', function () {
+  describe('LineString bounds subtitle — line-count permutations', function () {
+    it('no min + no max → subtitle suppressed', function () {
+      renderTask(buildLineStringTask())
+      expect(screen.queryByText(/points per line/)).to.not.exist
+    })
+
+    it('no min + max → "0-N lines"', function () {
+      renderTask(buildLineStringTask({ max: 4 }))
+      expect(screen.getByText('0-4 lines, 2+ points per line')).to.exist
+    })
+
+    it('min + no max → "N+ lines"', function () {
+      renderTask(buildLineStringTask({ min: 2 }))
+      expect(screen.getByText('2+ lines, 2+ points per line')).to.exist
+    })
+
+    it('min + max → "N-M lines"', function () {
+      renderTask(buildLineStringTask({ min: 1, max: 3 }))
+      expect(screen.getByText('1-3 lines, 2+ points per line')).to.exist
+    })
+  })
+
+  describe('LineString bounds subtitle — vertex permutations', function () {
+    it('no min_vertices + no max_vertices → subtitle suppressed', function () {
+      renderTask(buildLineStringTask())
+      expect(screen.queryByText(/points per line/)).to.not.exist
+    })
+
+    it('no min_vertices + max_vertices → "2-N points per line"', function () {
+      renderTask(buildLineStringTask({ max_vertices: 10 }))
+      expect(screen.getByText('0+ lines, 2-10 points per line')).to.exist
+    })
+
+    it('min_vertices (>2) + no max_vertices → "N+ points per line"', function () {
+      renderTask(buildLineStringTask({ min_vertices: 4 }))
+      expect(screen.getByText('0+ lines, 4+ points per line')).to.exist
+    })
+
+    it('min_vertices + max_vertices → "N-M points per line"', function () {
+      renderTask(buildLineStringTask({ min_vertices: 3, max_vertices: 10 }))
+      expect(screen.getByText('0+ lines, 3-10 points per line')).to.exist
+    })
+  })
+
+  describe('LineString bounds subtitle — edge cases', function () {
+    it('collapses "N-N lines" to "N lines" when min === max', function () {
+      renderTask(buildLineStringTask({ min: 3, max: 3 }))
+      expect(screen.getByText('3 lines, 2+ points per line')).to.exist
+    })
+
+    it('collapses "N-N points per line" to "N points per line" when min_vertices === max_vertices', function () {
+      renderTask(buildLineStringTask({ min_vertices: 5, max_vertices: 5 }))
+      expect(screen.getByText('0+ lines, 5 points per line')).to.exist
+    })
+
+    it('does NOT render the subtitle for explicit min_vertices: 2 (equals default)', function () {
+      renderTask(buildLineStringTask({ min_vertices: 2 }))
+      expect(screen.queryByText(/points per line/)).to.not.exist
+    })
+
+    it('coerces Panoptes string snapshots through MST and renders the numeric subtitle', function () {
+      renderTask(buildLineStringTask({ min: '1', max: '3', min_vertices: '3', max_vertices: '10' }))
+      expect(screen.getByText('1-3 lines, 3-10 points per line')).to.exist
+    })
+
+    it('suppresses the subtitle on non-LineString tools', function () {
+      const task = GeoDrawingTaskModel.create({
+        activeToolIndex: 0,
+        strings: { 'tools.0.label': 'Map Point' },
+        taskKey: 'T0',
+        tools: [{ color: '#ff0000', label: 'Map Point', type: 'Point' }],
+        type: 'geoDrawing'
+      })
+      renderTask(task)
+      expect(screen.getByText('Map Point')).to.exist
+      expect(screen.queryByText(/points per line/)).to.not.exist
+    })
+
+    it('renders one subtitle per LineString tool (multi-tool: Tool 0 bounded, Tool 1 unbounded)', function () {
+      const task = GeoDrawingTaskModel.create({
+        activeToolIndex: 0,
+        strings: {
+          'tools.0.label': 'Segmented Line',
+          'tools.1.label': 'Segmented Line 2'
+        },
+        taskKey: 'T0',
+        tools: [
+          { color: '#E65252', label: 'Segmented Line', type: 'LineString', min: 1, max: 3, min_vertices: 3, max_vertices: 10 },
+          { color: '#F1AE45', label: 'Segmented Line 2', type: 'LineString' }
+        ],
+        type: 'geoDrawing'
+      })
+      renderTask(task)
+      expect(screen.getByText('1-3 lines, 3-10 points per line')).to.exist
+      expect(screen.getByText('Segmented Line 2')).to.exist
+      expect(screen.getAllByText(/lines,/)).to.have.lengthOf(1)
+    })
+  })
+})

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.spec.jsx
@@ -14,7 +14,7 @@ function buildLineStringTask(toolOverrides = {}) {
     },
     taskKey: 'T0',
     tools: [
-      { color: '#E65252', label: 'Segmented Line', type: 'LineString', ...toolOverrides }
+      { color: '#E65252', label: 'Segmented Line', type: 'SegmentedLine', ...toolOverrides }
     ],
     type: 'geoDrawing'
   })
@@ -116,8 +116,8 @@ describe('Component > GeoDrawingTask', function () {
         },
         taskKey: 'T0',
         tools: [
-          { color: '#E65252', label: 'Segmented Line', type: 'LineString', min: 1, max: 3, min_vertices: 3, max_vertices: 10 },
-          { color: '#F1AE45', label: 'Segmented Line 2', type: 'LineString' }
+          { color: '#E65252', label: 'Segmented Line', type: 'SegmentedLine', min: 1, max: 3, min_vertices: 3, max_vertices: 10 },
+          { color: '#F1AE45', label: 'Segmented Line 2', type: 'SegmentedLine' }
         ],
         type: 'geoDrawing'
       })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.js
@@ -36,6 +36,23 @@ const GeoDrawing = types
         taskType: self.type,
         value: null
       })
+    },
+
+    isComplete(annotation) {
+      if (self.required && !annotation?.isComplete) return false
+
+      const features = annotation?.value?.features ?? []
+      for (const tool of self.tools) {
+        const minLines = tool.min_lines
+        if (typeof minLines === 'number' && minLines > 0) {
+          const matchingCount = features.filter((feature) => (
+            feature?.geometry?.type === tool.type
+          )).length
+          if (matchingCount < minLines) return false
+        }
+      }
+
+      return true
     }
   }))
   .actions(self => {

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.js
@@ -42,11 +42,12 @@ const GeoDrawing = types
       if (self.required && !annotation?.isComplete) return false
 
       const features = annotation?.value?.features ?? []
-      for (const tool of self.tools) {
-        const minLines = tool.min_lines
+      for (let toolIndex = 0; toolIndex < self.tools.length; toolIndex++) {
+        const tool = self.tools[toolIndex]
+        const minLines = tool.min
         if (typeof minLines === 'number' && minLines > 0) {
           const matchingCount = features.filter((feature) => (
-            feature?.geometry?.type === tool.type
+            feature?.properties?.toolIndex === toolIndex
           )).length
           if (matchingCount < minLines) return false
         }

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
@@ -105,7 +105,7 @@ describe('Model > GeoDrawingTask', function () {
       strings: { instruction: 'Draw a line.' },
       taskKey: 'T0',
       tools: [
-        { label: 'Dam crest', type: 'LineString', min: 1, max: 5, min_vertices: 2, max_vertices: 10 }
+        { label: 'Dam crest', type: 'SegmentedLine', min: 1, max: 5, min_vertices: 2, max_vertices: 10 }
       ],
       type: 'geoDrawing'
     }
@@ -132,7 +132,7 @@ describe('Model > GeoDrawingTask', function () {
     it('does not enforce per-tool min when tool.min is 0', function () {
       const task = GeoDrawingTask.create({
         ...lineStringTaskSnapshot,
-        tools: [{ label: 'Dam crest', type: 'LineString' }] // defaults: min = 0
+        tools: [{ label: 'Dam crest', type: 'SegmentedLine' }] // defaults: min = 0
       })
       const annotation = task.defaultAnnotation()
       annotation.update({ type: 'FeatureCollection', features: [] })
@@ -151,13 +151,13 @@ describe('Model > GeoDrawingTask', function () {
       expect(task.isComplete(annotation)).to.equal(false)
     })
 
-    describe('with multiple LineString tools', function () {
+    describe('with multiple SegmentedLine tools', function () {
       const twoToolSnapshot = {
         strings: { instruction: 'Draw both kinds of lines.' },
         taskKey: 'T0',
         tools: [
-          { label: 'Red lines', type: 'LineString', color: '#E65252', min: 1, max: 3 },
-          { label: 'Orange lines', type: 'LineString', color: '#F1AE45' }
+          { label: 'Red lines', type: 'SegmentedLine', color: '#E65252', min: 1, max: 3 },
+          { label: 'Orange lines', type: 'SegmentedLine', color: '#F1AE45' }
         ],
         type: 'geoDrawing'
       }
@@ -191,8 +191,8 @@ describe('Model > GeoDrawingTask', function () {
         const taskSnapshot = {
           ...twoToolSnapshot,
           tools: [
-            { label: 'Red lines', type: 'LineString', color: '#E65252', min: 2 },
-            { label: 'Orange lines', type: 'LineString', color: '#F1AE45' }
+            { label: 'Red lines', type: 'SegmentedLine', color: '#E65252', min: 2 },
+            { label: 'Orange lines', type: 'SegmentedLine', color: '#F1AE45' }
           ]
         }
         const task = GeoDrawingTask.create(taskSnapshot)

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
@@ -100,6 +100,59 @@ describe('Model > GeoDrawingTask', function () {
     })
   })
 
+  describe('Views > isComplete (per-tool min_lines)', function () {
+    const lineStringTaskSnapshot = {
+      strings: { instruction: 'Draw a line.' },
+      taskKey: 'T0',
+      tools: [
+        { label: 'Dam crest', type: 'LineString', min_lines: 1, max_lines: 5, min_vertices: 2, max_vertices: 10 }
+      ],
+      type: 'geoDrawing'
+    }
+
+    it('returns false when annotation has no LineString features and tool.min_lines is 1', function () {
+      const task = GeoDrawingTask.create(lineStringTaskSnapshot)
+      const annotation = task.defaultAnnotation()
+      annotation.update({ type: 'FeatureCollection', features: [] })
+      expect(task.isComplete(annotation)).to.equal(false)
+    })
+
+    it('returns true when annotation has at least tool.min_lines LineString features', function () {
+      const task = GeoDrawingTask.create(lineStringTaskSnapshot)
+      const annotation = task.defaultAnnotation()
+      annotation.update({
+        type: 'FeatureCollection',
+        features: [
+          { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] } }
+        ]
+      })
+      expect(task.isComplete(annotation)).to.equal(true)
+    })
+
+    it('does not enforce per-tool min_lines when tool.min_lines is 0', function () {
+      const task = GeoDrawingTask.create({
+        ...lineStringTaskSnapshot,
+        tools: [{ label: 'Dam crest', type: 'LineString' }] // defaults: min_lines = 0
+      })
+      const annotation = task.defaultAnnotation()
+      annotation.update({ type: 'FeatureCollection', features: [] })
+      expect(task.isComplete(annotation)).to.equal(true)
+    })
+
+    it('counts only features matching the tool type', function () {
+      const task = GeoDrawingTask.create(lineStringTaskSnapshot)
+      const annotation = task.defaultAnnotation()
+      // Only Points; no LineStrings, so the task is incomplete despite features.length > 0
+      annotation.update({
+        type: 'FeatureCollection',
+        features: [
+          { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] } }
+        ]
+      })
+      expect(task.isComplete(annotation)).to.equal(false)
+    })
+  })
+
   describe('Actions > setMapExtent', function () {
     let task
 

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
@@ -100,24 +100,46 @@ describe('Model > GeoDrawingTask', function () {
     })
   })
 
-  describe('Views > isComplete (per-tool min_lines)', function () {
+  describe('Views > isComplete (per-tool min)', function () {
     const lineStringTaskSnapshot = {
       strings: { instruction: 'Draw a line.' },
       taskKey: 'T0',
       tools: [
-        { label: 'Dam crest', type: 'LineString', min_lines: 1, max_lines: 5, min_vertices: 2, max_vertices: 10 }
+        { label: 'Dam crest', type: 'LineString', min: 1, max: 5, min_vertices: 2, max_vertices: 10 }
       ],
       type: 'geoDrawing'
     }
 
-    it('returns false when annotation has no LineString features and tool.min_lines is 1', function () {
+    it('returns false when annotation has no LineString features and tool.min is 1', function () {
       const task = GeoDrawingTask.create(lineStringTaskSnapshot)
       const annotation = task.defaultAnnotation()
       annotation.update({ type: 'FeatureCollection', features: [] })
       expect(task.isComplete(annotation)).to.equal(false)
     })
 
-    it('returns true when annotation has at least tool.min_lines LineString features', function () {
+    it('returns true when annotation has at least tool.min LineString features tagged for that tool', function () {
+      const task = GeoDrawingTask.create(lineStringTaskSnapshot)
+      const annotation = task.defaultAnnotation()
+      annotation.update({
+        type: 'FeatureCollection',
+        features: [
+          { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] }, properties: { toolIndex: 0 } }
+        ]
+      })
+      expect(task.isComplete(annotation)).to.equal(true)
+    })
+
+    it('does not enforce per-tool min when tool.min is 0', function () {
+      const task = GeoDrawingTask.create({
+        ...lineStringTaskSnapshot,
+        tools: [{ label: 'Dam crest', type: 'LineString' }] // defaults: min = 0
+      })
+      const annotation = task.defaultAnnotation()
+      annotation.update({ type: 'FeatureCollection', features: [] })
+      expect(task.isComplete(annotation)).to.equal(true)
+    })
+
+    it('returns false when features lack properties.toolIndex even if tool count would otherwise be met', function () {
       const task = GeoDrawingTask.create(lineStringTaskSnapshot)
       const annotation = task.defaultAnnotation()
       annotation.update({
@@ -126,30 +148,66 @@ describe('Model > GeoDrawingTask', function () {
           { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] } }
         ]
       })
-      expect(task.isComplete(annotation)).to.equal(true)
-    })
-
-    it('does not enforce per-tool min_lines when tool.min_lines is 0', function () {
-      const task = GeoDrawingTask.create({
-        ...lineStringTaskSnapshot,
-        tools: [{ label: 'Dam crest', type: 'LineString' }] // defaults: min_lines = 0
-      })
-      const annotation = task.defaultAnnotation()
-      annotation.update({ type: 'FeatureCollection', features: [] })
-      expect(task.isComplete(annotation)).to.equal(true)
-    })
-
-    it('counts only features matching the tool type', function () {
-      const task = GeoDrawingTask.create(lineStringTaskSnapshot)
-      const annotation = task.defaultAnnotation()
-      // Only Points; no LineStrings, so the task is incomplete despite features.length > 0
-      annotation.update({
-        type: 'FeatureCollection',
-        features: [
-          { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] } }
-        ]
-      })
       expect(task.isComplete(annotation)).to.equal(false)
+    })
+
+    describe('with multiple LineString tools', function () {
+      const twoToolSnapshot = {
+        strings: { instruction: 'Draw both kinds of lines.' },
+        taskKey: 'T0',
+        tools: [
+          { label: 'Red lines', type: 'LineString', color: '#E65252', min: 1, max: 3 },
+          { label: 'Orange lines', type: 'LineString', color: '#F1AE45' }
+        ],
+        type: 'geoDrawing'
+      }
+
+      it('returns false when only tool[1] features exist and tool[0] requires a minimum', function () {
+        const task = GeoDrawingTask.create(twoToolSnapshot)
+        const annotation = task.defaultAnnotation()
+        annotation.update({
+          type: 'FeatureCollection',
+          features: [
+            { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] }, properties: { toolIndex: 1 } }
+          ]
+        })
+        expect(task.isComplete(annotation)).to.equal(false)
+      })
+
+      it('returns true when tool[0] features satisfy its min, regardless of tool[1] count', function () {
+        const task = GeoDrawingTask.create(twoToolSnapshot)
+        const annotation = task.defaultAnnotation()
+        annotation.update({
+          type: 'FeatureCollection',
+          features: [
+            { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] }, properties: { toolIndex: 0 } },
+            { type: 'Feature', geometry: { type: 'LineString', coordinates: [[2, 2], [3, 3]] }, properties: { toolIndex: 1 } }
+          ]
+        })
+        expect(task.isComplete(annotation)).to.equal(true)
+      })
+
+      it('counts only the features whose toolIndex matches the tool being checked', function () {
+        const taskSnapshot = {
+          ...twoToolSnapshot,
+          tools: [
+            { label: 'Red lines', type: 'LineString', color: '#E65252', min: 2 },
+            { label: 'Orange lines', type: 'LineString', color: '#F1AE45' }
+          ]
+        }
+        const task = GeoDrawingTask.create(taskSnapshot)
+        const annotation = task.defaultAnnotation()
+        annotation.update({
+          type: 'FeatureCollection',
+          features: [
+            { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] }, properties: { toolIndex: 0 } },
+            { type: 'Feature', geometry: { type: 'LineString', coordinates: [[2, 2], [3, 3]] }, properties: { toolIndex: 1 } },
+            { type: 'Feature', geometry: { type: 'LineString', coordinates: [[4, 4], [5, 5]] }, properties: { toolIndex: 1 } }
+          ]
+        })
+        expect(task.isComplete(annotation)).to.equal(false)
+      })
+
     })
   })
 

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.js
@@ -3,7 +3,7 @@ import { types } from 'mobx-state-tree'
 // Panoptes returns workflow config values as strings (e.g. min_vertices: '3').
 // Coerce to a finite number; fall back to the supplied fallback (or undefined)
 // when the snapshot is blank or non-numeric so OL Draw uses its own defaults.
-function coerceVertexCount(snapshot, fallback) {
+function coerceCount(snapshot, fallback) {
   if (snapshot === undefined || snapshot === null || snapshot === '') return fallback
   const n = typeof snapshot === 'number' ? snapshot : Number(snapshot)
   return Number.isFinite(n) ? n : fallback
@@ -13,7 +13,7 @@ const MinVertexCount = types.snapshotProcessor(
   types.optional(types.number, 2),
   {
     preProcessor(snapshot) {
-      return coerceVertexCount(snapshot, 2)
+      return coerceCount(snapshot, 2)
     }
   }
 )
@@ -22,7 +22,25 @@ const MaxVertexCount = types.snapshotProcessor(
   types.maybe(types.number),
   {
     preProcessor(snapshot) {
-      return coerceVertexCount(snapshot, undefined)
+      return coerceCount(snapshot, undefined)
+    }
+  }
+)
+
+const MinLineCount = types.snapshotProcessor(
+  types.optional(types.number, 0),
+  {
+    preProcessor(snapshot) {
+      return coerceCount(snapshot, 0)
+    }
+  }
+)
+
+const MaxLineCount = types.snapshotProcessor(
+  types.maybe(types.number),
+  {
+    preProcessor(snapshot) {
+      return coerceCount(snapshot, undefined)
     }
   }
 )
@@ -31,7 +49,9 @@ const LineStringTool = types
   .model('LineStringTool', {
     color: types.optional(types.string, ''),
     label: types.optional(types.string, ''),
+    max_lines: MaxLineCount,
     max_vertices: MaxVertexCount,
+    min_lines: MinLineCount,
     min_vertices: MinVertexCount,
     type: types.literal('LineString')
   })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.js
@@ -1,8 +1,6 @@
 import { types } from 'mobx-state-tree'
 
-// Panoptes returns workflow config values as strings (e.g. min_vertices: '3').
-// Coerce to a finite number; fall back to the supplied fallback (or undefined)
-// when the snapshot is blank or non-numeric so OL Draw uses its own defaults.
+// Panoptes serves workflow config as strings (e.g. min_vertices: '3'); coerce to a finite number.
 function coerceCount(snapshot, fallback) {
   if (snapshot === undefined || snapshot === null || snapshot === '') return fallback
   const n = typeof snapshot === 'number' ? snapshot : Number(snapshot)
@@ -49,9 +47,9 @@ const LineStringTool = types
   .model('LineStringTool', {
     color: types.optional(types.string, ''),
     label: types.optional(types.string, ''),
-    max_lines: MaxLineCount,
+    max: MaxLineCount,
     max_vertices: MaxVertexCount,
-    min_lines: MinLineCount,
+    min: MinLineCount,
     min_vertices: MinVertexCount,
     type: types.literal('LineString')
   })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.spec.jsx
@@ -32,13 +32,25 @@ describe('Model > LineStringTool', function () {
     expect(tool.max_vertices).to.equal(undefined)
   })
 
+  it('should default min_lines to 0', function () {
+    const tool = LineStringTool.create({ type: 'LineString' })
+    expect(tool.min_lines).to.equal(0)
+  })
+
+  it('should default max_lines to undefined (no upper bound)', function () {
+    const tool = LineStringTool.create({ type: 'LineString' })
+    expect(tool.max_lines).to.equal(undefined)
+  })
+
   describe('with defined properties', function () {
     const lineStringToolSnapshot = {
       label: 'Dam crest',
       type: 'LineString',
       color: '#00ff00',
       min_vertices: 3,
-      max_vertices: 10
+      max_vertices: 10,
+      min_lines: 1,
+      max_lines: 5
     }
 
     it('should have a color property', function () {
@@ -59,6 +71,16 @@ describe('Model > LineStringTool', function () {
     it('should accept max_vertices', function () {
       const tool = LineStringTool.create(lineStringToolSnapshot)
       expect(tool.max_vertices).to.equal(10)
+    })
+
+    it('should accept min_lines', function () {
+      const tool = LineStringTool.create(lineStringToolSnapshot)
+      expect(tool.min_lines).to.equal(1)
+    })
+
+    it('should accept max_lines', function () {
+      const tool = LineStringTool.create(lineStringToolSnapshot)
+      expect(tool.max_lines).to.equal(5)
     })
   })
 
@@ -86,6 +108,33 @@ describe('Model > LineStringTool', function () {
     it('should fall back to undefined when max_vertices is non-numeric', function () {
       const tool = LineStringTool.create({ type: 'LineString', max_vertices: 'abc' })
       expect(tool.max_vertices).to.equal(undefined)
+    })
+  })
+
+  describe('with line-count bounds as strings (Panoptes JSON)', function () {
+    it('should coerce string min_lines to a number', function () {
+      const tool = LineStringTool.create({ type: 'LineString', min_lines: '3' })
+      expect(tool.min_lines).to.equal(3)
+    })
+
+    it('should coerce string max_lines to a number', function () {
+      const tool = LineStringTool.create({ type: 'LineString', max_lines: '5' })
+      expect(tool.max_lines).to.equal(5)
+    })
+
+    it('should fall back to undefined when max_lines is empty string', function () {
+      const tool = LineStringTool.create({ type: 'LineString', max_lines: '' })
+      expect(tool.max_lines).to.equal(undefined)
+    })
+
+    it('should fall back to the default min_lines when min_lines is empty string', function () {
+      const tool = LineStringTool.create({ type: 'LineString', min_lines: '' })
+      expect(tool.min_lines).to.equal(0)
+    })
+
+    it('should fall back to undefined when max_lines is non-numeric', function () {
+      const tool = LineStringTool.create({ type: 'LineString', max_lines: 'abc' })
+      expect(tool.max_lines).to.equal(undefined)
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/LineStringTool.spec.jsx
@@ -32,14 +32,14 @@ describe('Model > LineStringTool', function () {
     expect(tool.max_vertices).to.equal(undefined)
   })
 
-  it('should default min_lines to 0', function () {
+  it('should default min to 0', function () {
     const tool = LineStringTool.create({ type: 'LineString' })
-    expect(tool.min_lines).to.equal(0)
+    expect(tool.min).to.equal(0)
   })
 
-  it('should default max_lines to undefined (no upper bound)', function () {
+  it('should default max to undefined (no upper bound)', function () {
     const tool = LineStringTool.create({ type: 'LineString' })
-    expect(tool.max_lines).to.equal(undefined)
+    expect(tool.max).to.equal(undefined)
   })
 
   describe('with defined properties', function () {
@@ -49,8 +49,8 @@ describe('Model > LineStringTool', function () {
       color: '#00ff00',
       min_vertices: 3,
       max_vertices: 10,
-      min_lines: 1,
-      max_lines: 5
+      min: 1,
+      max: 5
     }
 
     it('should have a color property', function () {
@@ -73,14 +73,14 @@ describe('Model > LineStringTool', function () {
       expect(tool.max_vertices).to.equal(10)
     })
 
-    it('should accept min_lines', function () {
+    it('should accept min', function () {
       const tool = LineStringTool.create(lineStringToolSnapshot)
-      expect(tool.min_lines).to.equal(1)
+      expect(tool.min).to.equal(1)
     })
 
-    it('should accept max_lines', function () {
+    it('should accept max', function () {
       const tool = LineStringTool.create(lineStringToolSnapshot)
-      expect(tool.max_lines).to.equal(5)
+      expect(tool.max).to.equal(5)
     })
   })
 
@@ -112,29 +112,29 @@ describe('Model > LineStringTool', function () {
   })
 
   describe('with line-count bounds as strings (Panoptes JSON)', function () {
-    it('should coerce string min_lines to a number', function () {
-      const tool = LineStringTool.create({ type: 'LineString', min_lines: '3' })
-      expect(tool.min_lines).to.equal(3)
+    it('should coerce string min to a number', function () {
+      const tool = LineStringTool.create({ type: 'LineString', min: '3' })
+      expect(tool.min).to.equal(3)
     })
 
-    it('should coerce string max_lines to a number', function () {
-      const tool = LineStringTool.create({ type: 'LineString', max_lines: '5' })
-      expect(tool.max_lines).to.equal(5)
+    it('should coerce string max to a number', function () {
+      const tool = LineStringTool.create({ type: 'LineString', max: '5' })
+      expect(tool.max).to.equal(5)
     })
 
-    it('should fall back to undefined when max_lines is empty string', function () {
-      const tool = LineStringTool.create({ type: 'LineString', max_lines: '' })
-      expect(tool.max_lines).to.equal(undefined)
+    it('should fall back to undefined when max is empty string', function () {
+      const tool = LineStringTool.create({ type: 'LineString', max: '' })
+      expect(tool.max).to.equal(undefined)
     })
 
-    it('should fall back to the default min_lines when min_lines is empty string', function () {
-      const tool = LineStringTool.create({ type: 'LineString', min_lines: '' })
-      expect(tool.min_lines).to.equal(0)
+    it('should fall back to the default min when min is empty string', function () {
+      const tool = LineStringTool.create({ type: 'LineString', min: '' })
+      expect(tool.min).to.equal(0)
     })
 
-    it('should fall back to undefined when max_lines is non-numeric', function () {
-      const tool = LineStringTool.create({ type: 'LineString', max_lines: 'abc' })
-      expect(tool.max_lines).to.equal(undefined)
+    it('should fall back to undefined when max is non-numeric', function () {
+      const tool = LineStringTool.create({ type: 'LineString', max: 'abc' })
+      expect(tool.max).to.equal(undefined)
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/LineStringTool/index.js
@@ -1,1 +1,0 @@
-export { default } from './LineStringTool'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/SegmentedLineTool/SegmentedLineTool.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/SegmentedLineTool/SegmentedLineTool.js
@@ -43,15 +43,15 @@ const MaxLineCount = types.snapshotProcessor(
   }
 )
 
-const LineStringTool = types
-  .model('LineStringTool', {
+const SegmentedLineTool = types
+  .model('SegmentedLineTool', {
     color: types.optional(types.string, ''),
     label: types.optional(types.string, ''),
     max: MaxLineCount,
     max_vertices: MaxVertexCount,
     min: MinLineCount,
     min_vertices: MinVertexCount,
-    type: types.literal('LineString')
+    type: types.literal('SegmentedLine')
   })
 
-export default LineStringTool
+export default SegmentedLineTool

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/SegmentedLineTool/SegmentedLineTool.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/SegmentedLineTool/SegmentedLineTool.spec.jsx
@@ -1,51 +1,51 @@
-import LineStringTool from './LineStringTool'
+import SegmentedLineTool from './SegmentedLineTool'
 
-describe('Model > LineStringTool', function () {
+describe('Model > SegmentedLineTool', function () {
   it('should exist', function () {
-    const tool = LineStringTool.create({ type: 'LineString' })
+    const tool = SegmentedLineTool.create({ type: 'SegmentedLine' })
     expect(tool).to.exist
     expect(tool).to.be.an('object')
   })
 
-  it('should have a type of "LineString"', function () {
-    const tool = LineStringTool.create({ type: 'LineString' })
-    expect(tool.type).to.equal('LineString')
+  it('should have a type of "SegmentedLine"', function () {
+    const tool = SegmentedLineTool.create({ type: 'SegmentedLine' })
+    expect(tool.type).to.equal('SegmentedLine')
   })
 
   it('should default color to empty string', function () {
-    const tool = LineStringTool.create({ type: 'LineString' })
+    const tool = SegmentedLineTool.create({ type: 'SegmentedLine' })
     expect(tool.color).to.equal('')
   })
 
   it('should default label to empty string', function () {
-    const tool = LineStringTool.create({ type: 'LineString' })
+    const tool = SegmentedLineTool.create({ type: 'SegmentedLine' })
     expect(tool.label).to.equal('')
   })
 
   it('should default min_vertices to 2', function () {
-    const tool = LineStringTool.create({ type: 'LineString' })
+    const tool = SegmentedLineTool.create({ type: 'SegmentedLine' })
     expect(tool.min_vertices).to.equal(2)
   })
 
   it('should default max_vertices to undefined (no upper bound)', function () {
-    const tool = LineStringTool.create({ type: 'LineString' })
+    const tool = SegmentedLineTool.create({ type: 'SegmentedLine' })
     expect(tool.max_vertices).to.equal(undefined)
   })
 
   it('should default min to 0', function () {
-    const tool = LineStringTool.create({ type: 'LineString' })
+    const tool = SegmentedLineTool.create({ type: 'SegmentedLine' })
     expect(tool.min).to.equal(0)
   })
 
   it('should default max to undefined (no upper bound)', function () {
-    const tool = LineStringTool.create({ type: 'LineString' })
+    const tool = SegmentedLineTool.create({ type: 'SegmentedLine' })
     expect(tool.max).to.equal(undefined)
   })
 
   describe('with defined properties', function () {
-    const lineStringToolSnapshot = {
+    const segmentedLineToolSnapshot = {
       label: 'Dam crest',
-      type: 'LineString',
+      type: 'SegmentedLine',
       color: '#00ff00',
       min_vertices: 3,
       max_vertices: 10,
@@ -54,86 +54,86 @@ describe('Model > LineStringTool', function () {
     }
 
     it('should have a color property', function () {
-      const tool = LineStringTool.create(lineStringToolSnapshot)
+      const tool = SegmentedLineTool.create(segmentedLineToolSnapshot)
       expect(tool.color).to.equal('#00ff00')
     })
 
     it('should have a label property', function () {
-      const tool = LineStringTool.create(lineStringToolSnapshot)
+      const tool = SegmentedLineTool.create(segmentedLineToolSnapshot)
       expect(tool.label).to.equal('Dam crest')
     })
 
     it('should accept min_vertices', function () {
-      const tool = LineStringTool.create(lineStringToolSnapshot)
+      const tool = SegmentedLineTool.create(segmentedLineToolSnapshot)
       expect(tool.min_vertices).to.equal(3)
     })
 
     it('should accept max_vertices', function () {
-      const tool = LineStringTool.create(lineStringToolSnapshot)
+      const tool = SegmentedLineTool.create(segmentedLineToolSnapshot)
       expect(tool.max_vertices).to.equal(10)
     })
 
     it('should accept min', function () {
-      const tool = LineStringTool.create(lineStringToolSnapshot)
+      const tool = SegmentedLineTool.create(segmentedLineToolSnapshot)
       expect(tool.min).to.equal(1)
     })
 
     it('should accept max', function () {
-      const tool = LineStringTool.create(lineStringToolSnapshot)
+      const tool = SegmentedLineTool.create(segmentedLineToolSnapshot)
       expect(tool.max).to.equal(5)
     })
   })
 
   describe('with vertex bounds as strings (Panoptes JSON)', function () {
     it('should coerce string min_vertices to a number', function () {
-      const tool = LineStringTool.create({ type: 'LineString', min_vertices: '3' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', min_vertices: '3' })
       expect(tool.min_vertices).to.equal(3)
     })
 
     it('should coerce string max_vertices to a number', function () {
-      const tool = LineStringTool.create({ type: 'LineString', max_vertices: '10' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', max_vertices: '10' })
       expect(tool.max_vertices).to.equal(10)
     })
 
     it('should fall back to undefined when max_vertices is empty string', function () {
-      const tool = LineStringTool.create({ type: 'LineString', max_vertices: '' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', max_vertices: '' })
       expect(tool.max_vertices).to.equal(undefined)
     })
 
     it('should fall back to the default min_vertices when min_vertices is empty string', function () {
-      const tool = LineStringTool.create({ type: 'LineString', min_vertices: '' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', min_vertices: '' })
       expect(tool.min_vertices).to.equal(2)
     })
 
     it('should fall back to undefined when max_vertices is non-numeric', function () {
-      const tool = LineStringTool.create({ type: 'LineString', max_vertices: 'abc' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', max_vertices: 'abc' })
       expect(tool.max_vertices).to.equal(undefined)
     })
   })
 
   describe('with line-count bounds as strings (Panoptes JSON)', function () {
     it('should coerce string min to a number', function () {
-      const tool = LineStringTool.create({ type: 'LineString', min: '3' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', min: '3' })
       expect(tool.min).to.equal(3)
     })
 
     it('should coerce string max to a number', function () {
-      const tool = LineStringTool.create({ type: 'LineString', max: '5' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', max: '5' })
       expect(tool.max).to.equal(5)
     })
 
     it('should fall back to undefined when max is empty string', function () {
-      const tool = LineStringTool.create({ type: 'LineString', max: '' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', max: '' })
       expect(tool.max).to.equal(undefined)
     })
 
     it('should fall back to the default min when min is empty string', function () {
-      const tool = LineStringTool.create({ type: 'LineString', min: '' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', min: '' })
       expect(tool.min).to.equal(0)
     })
 
     it('should fall back to undefined when max is non-numeric', function () {
-      const tool = LineStringTool.create({ type: 'LineString', max: 'abc' })
+      const tool = SegmentedLineTool.create({ type: 'SegmentedLine', max: 'abc' })
       expect(tool.max).to.equal(undefined)
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/SegmentedLineTool/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/SegmentedLineTool/index.js
@@ -1,0 +1,1 @@
+export { default } from './SegmentedLineTool'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/index.js
@@ -1,2 +1,2 @@
-export { default as LineStringTool } from './LineStringTool'
+export { default as SegmentedLineTool } from './SegmentedLineTool'
 export { default as PointTool } from './PointTool'


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #7367

## Describe your changes
- add `min` and `max` line-count fields to LineStringTool, enforced per tool
- recreate Draw per active tool so vertex + line caps follow (OL values uneditable after instantiation)
- show configured bounds as a subtitle on each tool card

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- n/a for this PR. End-to-end UX (a LineString tool with `min_lines` / `max_lines` on a real workflow) lands when the Lab editor ships at the end of this milestone. Until then, the Storybook story below is the user-facing surface.

What user actions should my reviewer step through to review this PR?
- [x] run `pnpm storybook` in `packages/lib-classifier`, open `Subject Viewers / GeoMapViewer` -> `WithGeoDrawingLineStringTask`
- [x] in the Controls panel set `max_lines: 2`. Draw two distinct lines; after the 2nd finishes, the tool should deactivate and the cursor should become `not-allowed` over empty map. May have to refresh browser to get params to be enforced in Storybook
- [x] confirm earlier-PR behaviors are intact: PR-5 vertex grab/drag still works; PR-6 vertex bounds still gate drawend
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `LineStringTool.spec.jsx`, `GeoDrawingTask.spec.jsx`, `createGeoLineStringInteraction.spec.js`, and `getDrawModeCursor.spec.js` pass

Which storybook stories should be reviewed?
- `Subject Viewers / GeoMapViewer` -> `WithGeoDrawingLineStringTask`: http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-geo-drawing-line-string-task

Are there plans for follow up PR's to further fix this bug or develop this feature?
- Yes. This is PR 7 of 9 in the Segmented Line milestone. Sequential PRs that follow this one (in merge order):
- [#7368](https://github.com/zooniverse/front-end-monorepo/issues/7368) lib-classifier: Add delete affordance for selected LineString feature
- [#7459 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7459) Panoptes-Front-End: Add LineString tool to GeoDrawing task editor

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
