### PR TITLE
app-project: Don't return previousData from the stats's SWR hook

### DIFF
--- a/packages/app-project/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/packages/app-project/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,0 +1,25 @@
+import { Component } from 'react'
+// https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return this.props.fallback
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
@@ -8,6 +8,7 @@ import { useContext } from 'react'
 import getDateRangeLabel from './getDateRangeLabel'
 import getCompleteData from './getCompleteData'
 import { getInterval } from '../../helpers/getDateInterval'
+import ErrorBoundary from '@components/ErrorBoundary/ErrorBoundary'
 
 const X_AXIS_FREQUENCY = {
   everyOther: 'everyOther',
@@ -96,64 +97,77 @@ function BarChart({
   }
 
   return (
-    <StyledDataChart
-      a11yTitle={t('ProjectStats.BarChart.a11y', {
-        typeLabel,
-        countLabel: dateRangeLabel.countLabel,
-        startDate: dateRange.startDate,
-        endDate: dateRange.endDate
-      })}
-      className='styled-grommet-barchart'
-      axis={{
-        x: { granularity: 'fine', property: 'period' },
-        y: { granularity: 'fine', property: 'count' }
-      }}
-      chart={chartOptions}
-      data={completeData}
-      detail={!!completeData?.length > 0} // only show detail on hover if completeData if available
-      guide={{
-        y: {
-          granularity: 'fine'
-        }
-      }}
-      series={[
-        {
-          property: 'period',
-          label: dateRangeLabel.countLabel,
-          render: (period, datum, datumIndex) => {
-            const date = new Date(period)
+    <ErrorBoundary fallback={<Text>Something went wrong. Refresh or try again later.</Text>}>
+      <StyledDataChart
+        a11yTitle={t('ProjectStats.BarChart.a11y', {
+          typeLabel,
+          countLabel: dateRangeLabel.countLabel,
+          startDate: dateRange.startDate,
+          endDate: dateRange.endDate
+        })}
+        className='styled-grommet-barchart'
+        axis={{
+          x: { granularity: 'fine', property: 'period' },
+          y: { granularity: 'fine', property: 'count' }
+        }}
+        chart={chartOptions}
+        data={completeData}
+        detail={!!completeData?.length > 0} // only show detail on hover if completeData if available
+        guide={{
+          y: {
+            granularity: 'fine'
+          }
+        }}
+        series={[
+          {
+            property: 'period',
+            label: dateRangeLabel.countLabel,
+            render: (period, datum, datumIndex) => {
+              const date = new Date(period)
 
-            if (xAxisFrequency === X_AXIS_FREQUENCY.everyOther && datum?.index % 2 !== 0) {
-              return (
-                <Text className='hidden-period-label' data-testid='periodLabel' textAlign='center'>
-                  {date.toLocaleDateString(locale, dateRangeLabel.tLDS)}
-                </Text>
-              )
-            } else if (xAxisFrequency === X_AXIS_FREQUENCY.everyFourth && datum?.index % 4 !== 0) {
-              return (
-                <Text className='hidden-period-label' data-testid='periodLabel' textAlign='center'>
-                  {date.toLocaleDateString(locale, dateRangeLabel.tLDS)}
-                </Text>
-              )
-            } else {
-              return (
-                <Text data-testid='periodLabel' textAlign='center'>
-                  {date.toLocaleDateString(locale, dateRangeLabel.tLDS)}
-                </Text>
-              )
+              if (xAxisFrequency === X_AXIS_FREQUENCY.everyOther && datum?.index % 2 !== 0) {
+                return (
+                  <Text
+                    className='hidden-period-label'
+                    data-testid='periodLabel'
+                    textAlign='center'
+                  >
+                    {date.toLocaleDateString(locale, dateRangeLabel.tLDS)}
+                  </Text>
+                )
+              } else if (
+                xAxisFrequency === X_AXIS_FREQUENCY.everyFourth &&
+                datum?.index % 4 !== 0
+              ) {
+                return (
+                  <Text
+                    className='hidden-period-label'
+                    data-testid='periodLabel'
+                    textAlign='center'
+                  >
+                    {date.toLocaleDateString(locale, dateRangeLabel.tLDS)}
+                  </Text>
+                )
+              } else {
+                return (
+                  <Text data-testid='periodLabel' textAlign='center'>
+                    {date.toLocaleDateString(locale, dateRangeLabel.tLDS)}
+                  </Text>
+                )
+              }
+            }
+          },
+          {
+            property: 'count',
+            label: typeLabel,
+            render: number => {
+              return <Text data-testid='countLabel'>{number.toLocaleString(locale)}</Text>
             }
           }
-        },
-        {
-          property: 'count',
-          label: typeLabel,
-          render: number => {
-            return <Text data-testid='countLabel'>{number.toLocaleString(locale)}</Text>
-          }
-        }
-      ]}
-      size='fill'
-    />
+        ]}
+        size='fill'
+      />
+    </ErrorBoundary>
   )
 }
 

--- a/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/BarChart/BarChart.jsx
@@ -7,7 +7,6 @@ import { useContext } from 'react'
 
 import getDateRangeLabel from './getDateRangeLabel'
 import getCompleteData from './getCompleteData'
-import { getInterval } from '../../helpers/getDateInterval'
 import ErrorBoundary from '@components/ErrorBoundary/ErrorBoundary'
 
 const X_AXIS_FREQUENCY = {
@@ -23,7 +22,7 @@ const StyledDataChart = styled(DataChart)`
 
 function BarChart({
   data = [], // response from ERAS query
-  dateRange,
+  dateInterval,
   type = 'count' // or 'comments'
 }) {
   const { i18n, t } = useTranslation('screens')
@@ -36,16 +35,6 @@ function BarChart({
     comments: t('ProjectStats.comments')
   }
   const typeLabel = TYPE_LABEL[type]
-
-  const { startDate, endDate } = dateRange || {}
-  const differenceInDays = (new Date(endDate) - new Date(startDate)) / (1000 * 60 * 60 * 24)
-  const period = getInterval(differenceInDays)
-
-  const dateInterval = {
-    end_date: endDate,
-    period,
-    start_date: startDate
-  }
 
   // getCompleteData returns an array of objects with a period and count property including any without stats with a count of 0
   const completeData = getCompleteData(data, dateInterval)
@@ -102,8 +91,8 @@ function BarChart({
         a11yTitle={t('ProjectStats.BarChart.a11y', {
           typeLabel,
           countLabel: dateRangeLabel.countLabel,
-          startDate: dateRange.startDate,
-          endDate: dateRange.endDate
+          startDate: dateInterval?.['start_date'],
+          endDate: dateInterval?.['end_date']
         })}
         className='styled-grommet-barchart'
         axis={{

--- a/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
@@ -219,7 +219,6 @@ function ChartContainer({ workflows }) {
   const smallScreen = size === 'small'
 
   const renderBarChart = data?.data?.length > 0 && !!endDate && !!startDate && !!type && !loadingOrValidating
-  const chartDateRange = { startDate, endDate }
 
   return (
     <>
@@ -340,7 +339,7 @@ function ChartContainer({ workflows }) {
         <Relative height='medium' margin={{ vertical: 'medium' }}>
           {loadingOrValidating ? <LoadingPlaceholder /> : null}
           {renderBarChart ? (
-            <BarChart data={data?.data} dateRange={chartDateRange} type={type} />
+            <BarChart data={data?.data} dateInterval={dateInterval} type={type} />
           ) : null}
           {!loadingOrValidating && data?.data?.length === 0 ? <EmptyPlaceholder /> : null}
         </Relative>

--- a/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/ChartContainer/ChartContainer.jsx
@@ -218,13 +218,7 @@ function ChartContainer({ workflows }) {
 
   const smallScreen = size === 'small'
 
-  /*
-    We show the previousData via useProjectStats() SWR while loading or validating,
-    but Grommet's DataChart > Detail component will randomly error sometimes when revalidating
-    the data because Grommet `detail` uses `series.render` method. Trying to prevent a page
-    crash here by double checking everything in `renderBarChart`.
-  */
-  const renderBarChart = data?.data?.length > 0 && !!endDate && !!startDate && !!type
+  const renderBarChart = data?.data?.length > 0 && !!endDate && !!startDate && !!type && !loadingOrValidating
   const chartDateRange = { startDate, endDate }
 
   return (

--- a/packages/app-project/src/screens/ProjectStatsPage/components/Placeholders/LoadingPlaceholder.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/Placeholders/LoadingPlaceholder.jsx
@@ -5,8 +5,6 @@ const StyledBox = styled(Box)`
   position: absolute;
   top: 0;
   left: 0;
-  opacity: 0.4;
-  z-index: 999; // required so it displays over Grommet DataChart bars
 `
 
 export default function LoadingPlaceholder() {

--- a/packages/app-project/src/screens/ProjectStatsPage/helpers/useProjectStats.js
+++ b/packages/app-project/src/screens/ProjectStatsPage/helpers/useProjectStats.js
@@ -2,7 +2,8 @@ import { env } from '@zooniverse/panoptes-js'
 import useSWR from 'swr'
 
 const SWROptions = {
-  keepPreviousData: true, // Show previous data with a placeholder overtop when isLoading or isValidating
+  // keepPreviousData: true, // Ideally we'd be able to use this for the UX, but because BarChart calculates compeleteData
+  // based on endDate and startDate, those props change before previousData resolves to data, and causes mismatches in Grommet's DataChart :(
   revalidateIfStale: true,
   revalidateOnMount: true,
   revalidateOnFocus: false,


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Solves a bug where occasionally Grommet's DataChart would throw an error and crash the page. Finally figured out this happened specifically when the `useProjectStats()` hook returned `previousData`, but the `endDate` and `startDate` had updated. In this case, `getCompleteData()` in BarChart would be using out-of-date `data` with the updated date range :( Ideally we'd be able to use SWR's `returnPreviousData` for the UX, but because BarChart calculates `completeData` based on `data` AND the date range, it causes a mismatch in Grommet's `<DataChart>` `<Detail>` component, throwing the error.

UPDATE: I saw the bug again when running this in production mode only once, and then never again... I guess other than the mismatch between `data` and the date range, maybe it could be caused by hovering on the chart before it’s ready? The date range select dropdown does cause your mouse to be hovered over the chart immediately on select.

## Describe your changes
- Remove `keepPreviousData` from `useProjectStats()` SWR hook.
- Add an ErrorBoundary component around Grommet's DataChart

## How to Review
- Test any project stats page. Occasionally the bug would pop up when viewing a new date range. 

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated