### PR TITLE
app-project: Fix the link to results page in FinishedAnnouncement banner

### DIFF
--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncement.stories.jsx
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncement.stories.jsx
@@ -2,10 +2,9 @@ import { Provider } from 'mobx-react'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
 
 import FinishedAnnouncementConnector from './FinishedAnnouncementConnector'
-// import readme from './README.md'
 
 const mockedRouter = {
-  asPath: '/zookeeper/galaxy-zoo/about/team',
+  asPath: '/projects/zookeeper/galaxy-zoo/about/team',
   basePath: '/projects',
   query: {
     owner: 'zookeeper',
@@ -23,9 +22,9 @@ function NextRouterStory(Story) {
 
 const mockStore = {
   project: {
-    baseUrl: '/projects/zookeeper/galaxy-zoo',
     hasResultsPage: true,
-    isComplete: true
+    isComplete: true,
+    slug: 'zookeeper/galaxy-zoo'
   }
 }
 
@@ -33,13 +32,6 @@ export default {
   title: 'Project App / Screens / Project Home / Announcements / FinishedAnnouncement',
   component: FinishedAnnouncementConnector,
   decorators: [NextRouterStory]
-  // parameters: {
-  //   docs: {
-  //     description: {
-  //       component: readme
-  //     }
-  //   }
-  // }
 }
 
 export const Default = () => (
@@ -50,9 +42,9 @@ export const Default = () => (
 
 const mockStoreNoResults = {
   project: {
-    baseUrl: '/projects/zookeeper/galaxy-zoo',
     hasResultsPage: false,
-    isComplete: true
+    isComplete: true,
+    slug: 'zookeeper/galaxy-zoo'
   }
 }
 

--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.jsx
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.jsx
@@ -9,20 +9,20 @@ import PFE_SLUGS from '../../../../helpers/slugList'
 function useStores() {
   const { store } = useContext(MobXProviderContext)
 
-  const { baseUrl, hasResultsPage, isComplete } = store.project
+  const { hasResultsPage, isComplete } = store.project
 
   return {
-    baseUrl,
     hasResultsPage,
-    isVisible: isComplete
+    isVisible: isComplete,
+    slug: store?.project?.slug
   }
 }
 
 function FinishedAnnouncementConnector() {
   const { t } = useTranslation('components')
-  const { baseUrl = '', hasResultsPage = true, isVisible = false } = useStores()
+  const { hasResultsPage = true, isVisible = false, slug } = useStores()
 
-  const slugArr = baseUrl.split('/')
+  const slugArr = slug?.split('/')
   const owner = slugArr?.[0]
   const projectName = slugArr?.[1]
 
@@ -30,7 +30,7 @@ function FinishedAnnouncementConnector() {
 
   const announcement = t('Announcements.FinishedAnnouncement.announcement')
   const link = {
-    href: isPFEProject ? `https://www.zooniverse.org/projects${baseUrl}/about/results` : `${baseUrl}/about/results`,
+    href: isPFEProject ? `https://www.zooniverse.org/projects/${slug}/about/results` : `/${slug}/about/results`,
     text: t('Announcements.FinishedAnnouncement.seeResults'),
     externalLink: isPFEProject
   }

--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.spec.jsx
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.spec.jsx
@@ -9,6 +9,6 @@ describe('Component > FinishedAnnouncementConnector', function () {
     render(<DefaultStory />)
     const link = await screen.findByRole('link', { name: 'Announcements.FinishedAnnouncement.seeResults' })
     expect(link).toBeDefined()
-    expect(link?.getAttribute('href')).to.equal('/projects/zookeeper/galaxy-zoo/about/results')
+    expect(link?.getAttribute('href')).to.equal('/zookeeper/galaxy-zoo/about/results')
   })
 })

--- a/packages/app-project/src/helpers/getProjectStatsPageProps/getProjectStatsPageProps.js
+++ b/packages/app-project/src/helpers/getProjectStatsPageProps/getProjectStatsPageProps.js
@@ -3,6 +3,7 @@ import { applySnapshot, getSnapshot } from 'mobx-state-tree'
 import notFoundError from '@helpers/notFoundError'
 import fetchLinkedOrganizations from '@helpers/fetchLinkedOrganizations'
 import fetchProjectData from '@helpers/fetchProjectData'
+import fetchProjectPageTitles from '@helpers/fetchProjectPageTitles'
 import fetchTranslations from '@helpers/fetchTranslations'
 import fetchWorkflowStatsHelper from './fetchWorkflowStatsHelper'
 import initStore from '@stores'
@@ -43,6 +44,9 @@ export default async function getProjectStatsPageProps({ locale, params }) {
       )
       return props
     }
+
+    // This is necessary because the FinishedAnnouncement banner looks to see if a project contains Results page content
+    project.about_pages = await fetchProjectPageTitles(project, params.panoptesEnv)
 
     applySnapshot(store.project, project)
   }

--- a/packages/app-project/stores/Project.js
+++ b/packages/app-project/stores/Project.js
@@ -35,10 +35,6 @@ const Project = types
   })
 
   .views(self => ({
-    get baseUrl() {
-      return `/${self.slug}`
-    },
-
     get defaultWorkflow() {
       const activeWorkflows = self.links['active_workflows']
       let singleActiveWorkflow


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/7462

## Describe your changes
- Fetch the `project_pages` in `getProjectStatsPageProps()`. The property needs to be populated in the Project MST store in order to determine if the project has Results page content.
- Grab `slug` from the Project MST store in FinishedAnnouncementBanner store connector.

## How to Review
- Run a finished FEM project locally. The link the banner on the stats page should be a `next/link` Link: https://localhost.zooniverse.org:3000/projects/dverissimo/nature-spam-filter/stats?env=production
- Run a finished PFE project locally. The link in the banner on the stats page should be an anchor to www: https://localhost.zooniverse.org:3000/projects/artem-dot-reshetnikov/saint-george-on-a-bike/stats?env=production

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated