### PR TITLE
lib-classifier: Add delete affordance for selected LineString feature

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -1,28 +1,14 @@
-// dependencies
 import { Box } from 'grommet'
 import { observer } from 'mobx-react'
 import { arrayOf, func, shape, string } from 'prop-types'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
-import throttle from 'lodash/throttle'
-
-// OpenLayers imports
-import { Map, View } from 'ol'
-import { defaults as defaultControls } from 'ol/control/defaults'
-import ScaleLine from 'ol/control/ScaleLine'
-import { singleClick } from 'ol/events/condition'
 import GeoJSON from 'ol/format/GeoJSON'
-import { Translate, Select } from 'ol/interaction'
-import TileLayer from 'ol/layer/Tile'
-import VectorLayer from 'ol/layer/Vector'
-import OSM from 'ol/source/OSM'
-import VectorSource from 'ol/source/Vector'
+import throttle from 'lodash/throttle'
 import { unByKey } from 'ol/Observable'
 import { transform } from 'ol/proj'
 
-// local imports
 import { useTranslation } from '@translations/i18n'
-import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import CoordinateInput from './components/CoordinateInput'
 import MeasureButton from './components/MeasureButton'
 import RecenterButton from './components/RecenterButton'
@@ -30,17 +16,15 @@ import ResetButton from './components/ResetButton'
 import UnitSelect from './components/UnitSelect'
 import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
-import asMSTFeature from './helpers/asMSTFeature'
-import createGeoLineStringInteraction, { FEATURE_HIT_TOLERANCE_PX } from './helpers/createGeoLineStringInteraction'
-import createGeoLineStringModifyInteraction from './helpers/createGeoLineStringModifyInteraction'
-import createMeasureInteraction from './helpers/createMeasureInteraction'
-import createModifyUncertaintyInteraction from './helpers/createModifyUncertaintyInteraction'
-import createMoveToClickInteraction from './helpers/createMoveToClickInteraction'
-import getDrawModeCursor from './helpers/getDrawModeCursor'
-import getFeatureStyle from './helpers/getFeatureStyle'
-import getInteractionStates from './helpers/getInteractionStates'
-import getPixelDistance from './helpers/getPixelDistance'
-import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixelsAcrossWorldCopies } from './helpers/hitTesting'
+import { GEOJSON_READ_OPTIONS, ZOOM_ANIMATION_DURATION_MS } from './helpers/constants'
+import loadGeoJSON from './helpers/loadGeoJSON'
+import { fitViewToFeatures } from './helpers/mapSelection'
+
+import useMapCursor from './hooks/useMapCursor'
+import useMapInteractions from './hooks/useMapInteractions'
+import useMapSelection from './hooks/useMapSelection'
+import useOLMap from './hooks/useOLMap'
+import useSelectionLayer from './hooks/useSelectionLayer'
 
 const StyledBox = styled(Box)`
   position: relative;
@@ -55,14 +39,8 @@ const StyledBox = styled(Box)`
     user-select: none;
   }
 
-  .ol-measure-tooltip.hidden {
-    display: none;
-  }
-
-  .ol-measure-tooltip-static {
-    background: #ffcc33;
-    color: #000;
-  }
+  .ol-measure-tooltip.hidden { display: none; }
+  .ol-measure-tooltip-static { background: #ffcc33; color: #000; }
 `
 
 const ControlsBox = styled(Box)`
@@ -79,59 +57,12 @@ const MapContainer = styled.div`
   width: 100%;
 `
 
-// Zoom animation duration in milliseconds
-const ZOOM_ANIMATION_DURATION_MS = 250
-// Minimum time between hit checks on pointermove, to throttle expensive hit testing
-const POINTER_MOVE_HIT_CHECK_INTERVAL_MS = 80
-// Minimum pixel distance the pointer must move to trigger a new hit test on pointermove, to throttle expensive hit testing
-const POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS = 4
-
-// Maps UnitSelect display options to OpenLayers ScaleLine unit strings
-const UNIT_OPTION_TO_SCALE_LINE_UNITS = {
-  meters: 'metric',
-  kilometers: 'metric',
-  feet: 'imperial',
-  miles: 'imperial',
-  'nautical miles': 'nautical'
-}
-
-// Helper function to fit view to features extent
-function fitViewToFeatures(map, features) {
-  const view = map.getView()
-  view.fit(features.getExtent(), {
-    padding: [32, 32, 32, 32],
-    maxZoom: 12,
-    duration: ZOOM_ANIMATION_DURATION_MS
-  })
-}
-
-// Helper to select the first feature in a list, used after loading new features, resetting, etc.
-function selectFirstFeature(selectInteraction, newFeatures) {
-  if (!selectInteraction || newFeatures.length === 0) return
-
-  selectInteraction.getFeatures().clear()
-  selectInteraction.getFeatures().push(newFeatures[0])
-
-  selectInteraction.dispatchEvent({
-    type: 'select',
-    selected: [newFeatures[0]],
-    deselected: []
-  })
-}
-
-function clearSelectedFeature(selectInteraction) {
-  if (!selectInteraction) return
-
-  const deselected = [...selectInteraction.getFeatures().getArray()]
-
-  if (deselected.length === 0) return
-
-  selectInteraction.getFeatures().clear()
-  selectInteraction.dispatchEvent({
-    type: 'select',
-    selected: [],
-    deselected
-  })
+function sanitizeProperties(properties = {}) {
+  return Object.fromEntries(
+    Object.entries(properties).filter(([key, value]) => (
+      key !== 'geometry' && typeof value !== 'function' && value !== undefined
+    ))
+  )
 }
 
 function GeoMapViewer({
@@ -145,761 +76,165 @@ function GeoMapViewer({
   const [selectedUnit, setSelectedUnit] = useState('meters')
   const { t } = useTranslation('components')
 
-  // Map and layer refs: created once on mount, reused across feature updates
-  const mapContainerRef = useRef()
-  const mapRef = useRef()
-  const featuresRef = useRef()
-  const featuresLayerRef = useRef()
-  const geoJSONFormatRef = useRef()
-  const isMeasureModeActiveRef = useRef(false)
-  const isDrawModeActiveRef = useRef(false)
-  
-  // Interaction refs: created once and reused to avoid re-stacking on data updates
-  const scaleLineRef = useRef()
-  const selectRef = useRef()
-  const translateRef = useRef()
-  const modifyUncertaintyRef = useRef()
-  const moveToClickRef = useRef()
-  const measureInteractionRef = useRef()
-  const lineStringDrawRef = useRef()
-  const lineStringModifyRef = useRef()
-  const pointerMoveHandlerRef = useRef()
-  const pointerDownHandlerRef = useRef()
+  const containerRef = useRef()
 
-  // Shared options for reading GeoJSON and projecting to the map view
-  const geoJSONReadOptions = {
-    dataProjection: 'EPSG:4326', // incoming GeoJSON coords in WGS 84
-    featureProjection: 'EPSG:3857' // map display projection in Web Mercator
-  }
-
-  // Determine if we have an active drawing task with tools, to enable interactions and show reset features button
-  const hasGeoDrawingTask = geoDrawingTask && geoDrawingTask.tools.length > 0
-
-  // Create the map once on mount with all layers and interactions
-  // Interactions are created here and reused on data updates to avoid stacking event listeners
-  useEffect(function createMapOnce() {
-    // if the map is already created, do nothing
-    // or if the map container ref is not set yet, do nothing
-    if (mapRef.current || !mapContainerRef.current) return undefined
-
-    // create a GeoJSON format reader
-    const geoJSONFormat = new GeoJSON()
-    geoJSONFormatRef.current = geoJSONFormat
-    
-    const baseLayer = new TileLayer({
-      // preload tiles for 1 level of zooming
-      preload: 1,
-      // use OpenStreetMap as the base layer
-      source: new OSM(),
-    })
-
-    // create a vector source and layer for the GeoJSON features
-    const featuresSource = new VectorSource({
-      features: []
-    })
-    featuresRef.current = featuresSource
-    const featuresLayer = new VectorLayer({
-      source: featuresSource
-    })
-    featuresLayerRef.current = featuresLayer
-
-    const map = new Map({
-      target: mapContainerRef.current,
-      layers: [
-        baseLayer,
-        featuresLayer
-      ],
-      view: new View({
-        center: [0, 0],
-        zoom: 0,
-      }),
-      controls: defaultControls({ zoom: false }).extend([
-        (() => { const sl = new ScaleLine(); scaleLineRef.current = sl; return sl })()
-      ])
-    })
-
-    // track the latest pointermove event for hit testing, 
-    // and throttle hit testing to improve performance during fast mouse moves and zoom/pan animations
-    let pointerMoveRafId = null
-
-    // Helper to compute style with current resolution
-    function handleFeatureStyle({ feature, isSelected = false }) {
-      return getFeatureStyle({
-        feature,
-        geoDrawingTask: hasGeoDrawingTask ? geoDrawingTask : null,
-        isSelected,
-        resolution: map.getView().getResolution()
-      })
-    }
-
-    if (hasGeoDrawingTask) {
-      // Create select interaction first so it's available to style function
-      const select = new Select({
-        condition: singleClick,
-        hitTolerance: FEATURE_HIT_TOLERANCE_PX,
-        layers: [featuresLayer],
-        style: (feature) => handleFeatureStyle({ feature, isSelected: true })
-      })
-
-      // Sync active feature selection
-      select.on('select', (event) => {
-        const selected = event.selected?.[0]
-        const mstFeature = selected ? asMSTFeature(selected) : null
-
-        if (onSelectedFeatureChange) {
-          onSelectedFeatureChange(selected ? { mstFeature, olFeature: selected } : null)
-          return
-        }
-
-        if (selected) {
-          geoDrawingTask?.setActiveFeature?.(mstFeature)
-          geoDrawingTask?.setActiveOlFeature?.(selected)
-        } else {
-          geoDrawingTask?.clearActiveFeature?.()
-          geoDrawingTask?.clearActiveOlFeature?.()
-        }
-      })
-
-      // Set the style function after map and select are created
-      featuresLayer.setStyle((feature) => handleFeatureStyle({
-        feature,
-        isSelected: select.getFeatures().getArray().includes(feature)
-      }))
-
-      // Create translate interaction restricted to the center point hit area.
-      // Without a condition, OL's Translate uses its own hit detection against the
-      // feature's rendered style (which includes the uncertainty circle), causing
-      // drags anywhere inside the circle to move the feature. The condition limits
-      // translation to pointerdown events within POINT_CENTER_HIT_RADIUS_PIXELS of
-      // the feature center.
-      const translate = new Translate({
-        features: select.getFeatures(),
-        condition: (mapBrowserEvent) => {
-          const selectedFeatures = select.getFeatures().getArray()
-          if (selectedFeatures.length === 0) return false
-
-          const selectedFeature = selectedFeatures[0]
-          const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
-          if (!Array.isArray(pointCoordinates)) return false
-
-          return getFeaturePixelsAcrossWorldCopies(map, pointCoordinates).some(
-            pointPixel => isPixelNearPointCenter({
-              pixel: mapBrowserEvent.pixel,
-              pointPixel,
-              radius: POINT_CENTER_HIT_RADIUS_PIXELS
-            })
-          )
-        }
-      })
-
-      // Add select and translate interactions to the map
-      map.addInteraction(select)
-      map.addInteraction(translate)
-      selectRef.current = select
-      translateRef.current = translate
-
-      // Create and add uncertainty circle modification interaction
-      const modifyUncertainty = createModifyUncertaintyInteraction({
-        geoDrawingTask,
-        selectInteraction: select,
-        translateInteraction: translate
-      })
-      map.addInteraction(modifyUncertainty)
-      modifyUncertaintyRef.current = modifyUncertainty
-
-      // Track whether a point is actively being dragged to switch grab -> grabbing.
-      // Center-point drags are captured by moveToClick (not Translate), so we use
-      // onDragStart/onDragEnd callbacks to update the cursor immediately on press.
-      let isDraggingPoint = false
-      let latestPointerMoveEvent = null
-      let lastAppliedCursor = ''
-      let lastHitCheckTs = 0
-      let lastHitCheckPixel = null
-      let lastHitCheckResult = false
-
-      function applyCursor(element, cursor) {
-        if (lastAppliedCursor === cursor) return
-        element.style.cursor = cursor
-        lastAppliedCursor = cursor
-      }
-
-      function isPointerOverFeature(pixel) {
-        let isOverFeature = false
-
-        featuresLayer.getSource().forEachFeature((feature) => {
-          if (isOverFeature) return
-
-          const coords = feature.getGeometry()?.getCoordinates?.()
-          if (!Array.isArray(coords)) return
-
-          const pointPixels = getFeaturePixelsAcrossWorldCopies(map, coords)
-
-          if (pointPixels.some(pointPixel => isPixelNearPointCenter({
-            pixel,
-            pointPixel,
-            radius: POINT_CENTER_HIT_RADIUS_PIXELS
-          }))) {
-            isOverFeature = true
-            return
-          }
-
-          const mstFeature = asMSTFeature(feature)
-          const uncertaintyRadiusPixels = mstFeature?.getUncertaintyRadiusPixels?.({
-            feature,
-            geoDrawingTask,
-            resolution: map.getView().getResolution()
-          })
-
-          if (
-            typeof uncertaintyRadiusPixels === 'number'
-            && uncertaintyRadiusPixels > 0
-            && pointPixels.some(pointPixel => getPixelDistance(pixel, pointPixel) <= uncertaintyRadiusPixels)
-          ) {
-            isOverFeature = true
-          }
-        })
-
-        return isOverFeature
-      }
-
-      // Create and add move-to-click interaction
-      const moveToClick = createMoveToClickInteraction({
-        selectInteraction: select,
-        geoDrawingTask,
-        featuresLayer,
-        onDragStart: () => {
-          isDraggingPoint = true
-          const viewport = map.getViewport()
-          if (viewport) viewport.style.cursor = 'grabbing'
-        },
-        onDragEnd: () => {
-          isDraggingPoint = false
-          const viewport = map.getViewport()
-          if (viewport) viewport.style.cursor = 'grab'
-        }
-      })
-      map.addInteraction(moveToClick)
-      moveToClickRef.current = moveToClick
-
-      lineStringModifyRef.current = createGeoLineStringModifyInteraction({
-        map,
-        selectInteraction: select,
-        onModifyEnd: () => {
-          const viewport = map.getViewport()
-          if (viewport) viewport.style.cursor = 'grab'
-        }
-      })
-
-      // Add cursor states that match the active interactions.
-      // Note: we target the viewport element (not the outer target element) so that
-      // our inline style.cursor overrides OL's class-based cursor (ol-grab, ol-grabbing)
-      // which Translate sets on the viewport via classList.
-      const handlePointerMove = (event) => {
-        latestPointerMoveEvent = event
-
-        if (pointerMoveRafId !== null) return
-
-        pointerMoveRafId = requestAnimationFrame(() => {
-          pointerMoveRafId = null
-
-          const latestEvent = latestPointerMoveEvent
-          if (!latestEvent) return
-
-          if (isMeasureModeActiveRef.current) {
-            const targetElement = map.getTargetElement()
-
-            if (targetElement) {
-              applyCursor(targetElement, '')
-            }
-
-            return
-          }
-
-          const element = map.getViewport()
-          if (!element) return
-
-          if (isDrawModeActiveRef.current) {
-            const selectedFeature = select.getFeatures().item(0)
-            const selectedGeometry = selectedFeature?.getGeometry?.()
-            const selectedLineStringCoords = selectedGeometry?.getType?.() === 'LineString'
-              ? selectedGeometry.getCoordinates?.() || []
-              : []
-            const isOnSelectedVertex = selectedLineStringCoords.some((coord) => (
-              getPixelDistance(latestEvent.pixel, map.getPixelFromCoordinate(coord)) <= 10
-            ))
-
-            let isOnAnotherFeature = false
-            map.forEachFeatureAtPixel(latestEvent.pixel, (feature) => {
-              if (feature !== selectedFeature) {
-                isOnAnotherFeature = true
-                return true
-              }
-              return false
-            }, { layerFilter: (layer) => layer === featuresLayer, hitTolerance: FEATURE_HIT_TOLERANCE_PX })
-
-            element.style.cursor = getDrawModeCursor({
-              isModifying: lineStringModifyRef.current?.isModifying() ?? false,
-              isSketching: lineStringDrawRef.current?.isDrawing() ?? false,
-              isOnSelectedVertex,
-              isOnAnotherFeature,
-              isAtMaxLines: lineStringDrawRef.current?.isCapped() ?? false,
-              isDragging: latestEvent.dragging
-            })
-            return
-          }
-
-          let cursor = ''
-          const selectedFeature = select.getFeatures().item(0)
-
-          if (selectedFeature) {
-            const mstFeature = asMSTFeature(selectedFeature)
-            const pointCoordinates = selectedFeature.getGeometry()?.getCoordinates?.()
-
-            if (mstFeature && Array.isArray(pointCoordinates)) {
-              const pointPixels = getFeaturePixelsAcrossWorldCopies(map, pointCoordinates)
-              const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
-                feature: selectedFeature,
-                geoDrawingTask
-              })
-
-              if (pointPixels.some(pointPixel => isPixelNearPointCenter({
-                pixel: latestEvent.pixel,
-                pointPixel,
-                radius: POINT_CENTER_HIT_RADIUS_PIXELS
-              }))) {
-                cursor = isDraggingPoint ? 'grabbing' : 'grab'
-              }
-
-              if (!cursor && dragHandleCoordinates) {
-                const dragHandlePixels = getFeaturePixelsAcrossWorldCopies(map, dragHandleCoordinates)
-                if (dragHandlePixels.some(handlePixel => isPixelNearDragHandle({
-                  pixel: latestEvent.pixel,
-                  handlePixel,
-                  tolerance: 15
-                }))) {
-                  cursor = 'ew-resize'
-                }
-              }
-
-              if (!cursor) {
-                const uncertaintyRadiusPixels = mstFeature.getUncertaintyRadiusPixels?.({
-                  feature: selectedFeature,
-                  geoDrawingTask,
-                  resolution: map.getView().getResolution()
-                })
-
-                if (
-                  typeof uncertaintyRadiusPixels === 'number'
-                  && uncertaintyRadiusPixels > 0
-                  && pointPixels.some(pointPixel => getPixelDistance(latestEvent.pixel, pointPixel) <= uncertaintyRadiusPixels)
-                ) {
-                  cursor = 'default'
-                }
-              }
-            }
-          }
-
-          if (!cursor) {
-            if (selectedFeature) {
-              // When a feature is selected, only show pointer over another feature's center point (which is selectable)
-              let hoveringOtherCenter = false
-              featuresLayer.getSource().forEachFeature((feature) => {
-                if (feature === selectedFeature || hoveringOtherCenter) return
-                const coords = feature.getGeometry()?.getCoordinates?.()
-                if (!Array.isArray(coords)) return
-                if (getFeaturePixelsAcrossWorldCopies(map, coords).some(
-                  featurePixel => isPixelNearPointCenter({
-                    pixel: latestEvent.pixel,
-                    pointPixel: featurePixel,
-                    radius: POINT_CENTER_HIT_RADIUS_PIXELS
-                  })
-                )) {
-                  hoveringOtherCenter = true
-                }
-              })
-              cursor = hoveringOtherCenter ? 'pointer' : 'default'
-            } else {
-              const now = performance.now()
-              const movedEnough = !lastHitCheckPixel
-                || getPixelDistance(latestEvent.pixel, lastHitCheckPixel) >= POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS
-              const elapsedEnough = (now - lastHitCheckTs) >= POINTER_MOVE_HIT_CHECK_INTERVAL_MS
-
-              if (movedEnough || elapsedEnough) {
-                lastHitCheckResult = isPointerOverFeature(latestEvent.pixel)
-                lastHitCheckTs = now
-                lastHitCheckPixel = [...latestEvent.pixel]
-              }
-
-              cursor = lastHitCheckResult ? 'pointer' : 'default'
-            }
-          }
-
-          applyCursor(element, cursor)
-        })
-      }
-      map.on('pointermove', handlePointerMove)
-      pointerMoveHandlerRef.current = handlePointerMove
-
-      const handlePointerDown = (event) => {
-        if (!isDrawModeActiveRef.current) return
-        const selectedFeature = select.getFeatures().item(0)
-        const selectedGeometry = selectedFeature?.getGeometry?.()
-        if (selectedGeometry?.getType?.() !== 'LineString') return
-        const coords = selectedGeometry.getCoordinates?.() || []
-        const nearVertex = coords.some((coord) => {
-          const vertexPixel = map.getPixelFromCoordinate(coord)
-          return getPixelDistance(event.pixel, vertexPixel) <= 10
-        })
-        if (nearVertex) {
-          const viewport = map.getViewport()
-          if (viewport) viewport.style.cursor = 'grabbing'
-        }
-      }
-      map.on('pointerdown', handlePointerDown)
-      pointerDownHandlerRef.current = handlePointerDown
-    } else {
-      // No task: disable feature interactions; render static styles
-      featuresLayer.setStyle((feature) => handleFeatureStyle({ feature, isSelected: false }))
-    }
-
-    const measureInteraction = createMeasureInteraction({
-      map,
-      messages: {
-        clickToContinue: t('SubjectViewer.GeoMapViewer.MeasureInteraction.clickToContinue'),
-        clickToStart: t('SubjectViewer.GeoMapViewer.MeasureInteraction.clickToStart')
-      }
-    })
-    measureInteractionRef.current = measureInteraction
-
-    mapRef.current = map
-
-    return () => {
-      if (selectRef.current) map.removeInteraction(selectRef.current)
-      if (translateRef.current) map.removeInteraction(translateRef.current)
-      if (modifyUncertaintyRef.current) map.removeInteraction(modifyUncertaintyRef.current)
-      if (moveToClickRef.current) map.removeInteraction(moveToClickRef.current)
-      lineStringModifyRef.current?.destroy()
-      measureInteractionRef.current?.destroy()
-      if (pointerMoveHandlerRef.current) map.un('pointermove', pointerMoveHandlerRef.current)
-      if (pointerMoveRafId !== null) cancelAnimationFrame(pointerMoveRafId)
-      if (pointerDownHandlerRef.current) map.un('pointerdown', pointerDownHandlerRef.current)
-      map.setTarget(undefined)
-      mapRef.current = undefined
-      featuresRef.current = undefined
-      featuresLayerRef.current = undefined
-      geoJSONFormatRef.current = undefined
-      scaleLineRef.current = undefined
-      selectRef.current = undefined
-      translateRef.current = undefined
-      modifyUncertaintyRef.current = undefined
-      moveToClickRef.current = undefined
-      measureInteractionRef.current = undefined
-      lineStringModifyRef.current = undefined
-      pointerMoveHandlerRef.current = undefined
-      pointerDownHandlerRef.current = undefined
-    }
-  }, [])
-
-  useEffect(function syncScaleLineUnits() {
-    const olUnits = UNIT_OPTION_TO_SCALE_LINE_UNITS[selectedUnit] ?? 'metric'
-    scaleLineRef.current?.setUnits(olUnits)
-    measureInteractionRef.current?.setUnit(selectedUnit)
-    if (geoDrawingTask?.setUnit) {
-      geoDrawingTask.setUnit(selectedUnit)
-    }
-  }, [selectedUnit, geoDrawingTask])
-
+  const hasGeoDrawingTask = !!(geoDrawingTask && geoDrawingTask.tools.length > 0)
   const activeToolType = geoDrawingTask?.activeTool?.type
-  const activeToolIndex = geoDrawingTask?.activeToolIndex
-  useEffect(function exitMeasureOnDrawingToolSelect() {
-    if (activeToolType === 'SegmentedLine' && isMeasureModeActiveRef.current) {
-      measureInteractionRef.current?.clear()
-      setIsMeasureModeActive(false)
+
+  const { map, source, layer, scaleLine } = useOLMap(containerRef)
+
+  const { select, translate } = useMapSelection({
+    map,
+    source,
+    layer,
+    geoDrawingTask,
+    hasGeoDrawingTask,
+    isMeasureModeActive,
+    onSelectedFeatureChange
+  })
+
+  const { draw, modify, moveToClick, measure } = useMapInteractions({
+    map,
+    source,
+    layer,
+    scaleLine,
+    select,
+    translate,
+    geoDrawingTask,
+    hasGeoDrawingTask,
+    isMeasureModeActive,
+    setIsMeasureModeActive,
+    selectedUnit,
+    containerRef,
+    t
+  })
+
+  useSelectionLayer({
+    map,
+    source,
+    layer,
+    select,
+    geoDrawingTask,
+    hasGeoDrawingTask,
+    ariaLabel: t('SubjectViewer.GeoMapViewer.DeleteOverlay.ariaLabel')
+  })
+
+  useMapCursor({
+    map,
+    layer,
+    select,
+    draw,
+    modify,
+    moveToClick,
+    geoDrawingTask,
+    hasGeoDrawingTask,
+    activeToolType,
+    isMeasureModeActive
+  })
+
+  useEffect(() => {
+    loadGeoJSON({ map, source, select, measure, data: geoJSON })
+  }, [map, source, select, measure, geoJSON])
+
+  useEffect(() => {
+    if (!source || !onFeaturesChange) return undefined
+    const format = new GeoJSON()
+    function emit() {
+      const collection = format.writeFeaturesObject(source.getFeatures(), GEOJSON_READ_OPTIONS)
+      onFeaturesChange({
+        type: 'FeatureCollection',
+        features: collection.features?.map((feature) => ({
+          ...feature,
+          properties: sanitizeProperties(feature.properties || {})
+        })) || []
+      })
     }
-  }, [activeToolType])
+    const keys = [
+      source.on('addfeature', emit),
+      source.on('removefeature', emit),
+      source.on('changefeature', emit)
+    ]
+    return () => keys.forEach(unByKey)
+  }, [source, onFeaturesChange])
 
-  // OL Draw fixes minPoints/maxPoints at construction, so recreate per active tool.
-  useEffect(function manageLineStringDraw() {
-    if (!mapRef.current || !featuresRef.current) return undefined
-    if (activeToolType !== 'SegmentedLine' || !geoDrawingTask) return undefined
-
-    const interaction = createGeoLineStringInteraction({
-      map: mapRef.current,
-      source: featuresRef.current,
-      featuresLayer: featuresLayerRef.current,
-      geoDrawingTask,
-      selectInteraction: selectRef.current
-    })
-    lineStringDrawRef.current = interaction
-
-    return function cleanupDraw() {
-      interaction.destroy()
-      if (lineStringDrawRef.current === interaction) {
-        lineStringDrawRef.current = undefined
-      }
-    }
-  }, [activeToolType, activeToolIndex, geoDrawingTask])
-
-  useEffect(function syncInteractions() {
-    const states = getInteractionStates({ activeToolType, isMeasureModeActive })
-    isDrawModeActiveRef.current = states.lineStringDraw
-    isMeasureModeActiveRef.current = isMeasureModeActive
-
-    measureInteractionRef.current?.setActive(states.measure)
-    lineStringDrawRef.current?.setActive(states.lineStringDraw)
-    lineStringModifyRef.current?.setActive(states.lineStringModify)
-    selectRef.current?.setActive(states.select)
-    translateRef.current?.setActive(states.translate)
-    modifyUncertaintyRef.current?.setActive(states.modifyUncertainty)
-    moveToClickRef.current?.setActive(states.moveToClick)
-  }, [activeToolType, activeToolIndex, isMeasureModeActive])
-
-  useEffect(function syncMeasureSelection() {
-    if (isMeasureModeActive) {
-      clearSelectedFeature(selectRef.current)
-      const mapElement = mapRef.current?.getTargetElement()
-      if (mapElement) mapElement.style.cursor = ''
-    } else {
-      const features = featuresRef.current?.getFeatures() ?? []
-      selectFirstFeature(selectRef.current, features)
-    }
-  }, [isMeasureModeActive])
-
-  // Shared helper: clear the vector source, optionally load new GeoJSON, fit view and select first feature.
-  // Used by both the updateFeatures effect (on geoJSON prop change) and handleReset.
-  function loadFeaturesFromGeoJSON(geojsonData) {
-    const map = mapRef.current
-    const features = featuresRef.current
-    if (!map || !features) return
-
-    measureInteractionRef.current?.clear()
-    features.clear()
-
-    if (geojsonData) {
-      const geoJSONFormat = geoJSONFormatRef.current
-      const newFeatures = geoJSONFormat.readFeatures(geojsonData, geoJSONReadOptions)
-      features.addFeatures(newFeatures)
-
-      if (features.getFeatures().length) {
-        fitViewToFeatures(map, features)
-        selectFirstFeature(selectRef.current, newFeatures)
-      }
-    }
-  }
-
-  // Update feature data when geoJSON changes
-  // This effect only updates the vector source; map and interactions remain unchanged
-  useEffect(function updateFeatures() {
-    if (!mapRef.current || !featuresRef.current) return undefined
-    loadFeaturesFromGeoJSON(geoJSON)
-    return undefined
-  }, [geoJSON])
-
-  // Track map extent changes and notify the task
-  useEffect(function trackMapExtent() {
-    const map = mapRef.current
+  useEffect(() => {
     if (!map || !onMapExtentChange) return undefined
-
-    function updateExtent() {
+    function emit() {
       const view = map.getView()
       const extent = view.calculateExtent()
-      const widthMeters = extent[2] - extent[0]
-      const heightMeters = extent[3] - extent[1]
-      
       onMapExtentChange({
-        widthMeters,
-        heightMeters,
+        widthMeters: extent[2] - extent[0],
+        heightMeters: extent[3] - extent[1],
         resolution: view.getResolution()
       })
     }
-
-    // Initial calculation
-    updateExtent()
-
-    // Update on view changes (throttled)
-    const throttledUpdate = throttle(updateExtent, ZOOM_ANIMATION_DURATION_MS)
-    const key = map.on('moveend', throttledUpdate)
-
+    emit()
+    const throttled = throttle(emit, ZOOM_ANIMATION_DURATION_MS)
+    const key = map.on('moveend', throttled)
     return () => {
       unByKey(key)
-      throttledUpdate.cancel()
+      throttled.cancel()
     }
-  }, [onMapExtentChange])
+  }, [map, onMapExtentChange])
 
-  // Listen for feature changes and persist as a sanitized FeatureCollection
-  useEffect(function attachFeatureListeners() {
-    if (!onFeaturesChange) return undefined
+  const handleRecenter = useCallback(() => {
+    if (!map || !source || source.getFeatures().length === 0) return
+    fitViewToFeatures(map, source, ZOOM_ANIMATION_DURATION_MS)
+  }, [map, source])
 
-    const featuresSource = featuresRef.current
-    if (!featuresSource) return undefined
-
-    const geoJSONFormat = geoJSONFormatRef.current || new GeoJSON()
-    geoJSONFormatRef.current = geoJSONFormat
-
-    function sanitizeProperties(properties = {}) {
-      return Object.fromEntries(
-        Object.entries(properties).filter(([key, value]) => (
-          key !== 'geometry' && typeof value !== 'function' && value !== undefined
-        ))
-      )
-    }
-
-    function serializeAndNotify() {
-      const olFeatures = featuresSource.getFeatures()
-      const featureCollection = geoJSONFormat.writeFeaturesObject(olFeatures, geoJSONReadOptions)
-
-      const sanitizedFeatures = featureCollection.features?.map((feature) => ({
-        ...feature,
-        properties: sanitizeProperties(feature.properties || {})
-      })) || []
-
-      onFeaturesChange({
-        type: 'FeatureCollection',
-        features: sanitizedFeatures
-      })
-    }
-
-    const keys = [
-      featuresSource.on('addfeature', serializeAndNotify),
-      featuresSource.on('removefeature', serializeAndNotify),
-      featuresSource.on('changefeature', serializeAndNotify)
-    ]
-
-    return () => {
-      keys.forEach((key) => unByKey(key))
-    }
-  }, [onFeaturesChange])
-  
-  // Handler to recenter the map to fit all features
-  function handleRecenter() {
-    const map = mapRef.current
-    const features = featuresRef.current
-    if (!map || !features) return
-
-    const featuresList = features.getFeatures()
-    if (featuresList.length > 0) {
-      fitViewToFeatures(map, features)
-    }
-  }
-
-  // Handler to reset features to the original geoJSON
-  function handleReset() {
-    if (!mapRef.current || !featuresRef.current || !geoJSON) return
+  const handleReset = useCallback(() => {
+    if (!map || !source || !geoJSON) return
     setIsMeasureModeActive(false)
-    loadFeaturesFromGeoJSON(geoJSON)
-  }
+    loadGeoJSON({ map, source, select, measure, data: geoJSON })
+  }, [map, source, select, measure, geoJSON])
 
-  // Handler to zoom the map view in by one level
-  function handleZoomIn() {
-    const map = mapRef.current
+  const handleZoom = useCallback((delta) => {
     if (!map) return
-
     const view = map.getView()
-    const currentZoom = view.getZoom() ?? 0
-    const targetZoom = view.getConstrainedZoom(currentZoom + 1)
+    const target = view.getConstrainedZoom((view.getZoom() ?? 0) + delta)
     view.cancelAnimations()
-    view.animate({
-      zoom: targetZoom,
-      duration: ZOOM_ANIMATION_DURATION_MS
-    })
-  }
+    view.animate({ zoom: target, duration: ZOOM_ANIMATION_DURATION_MS })
+  }, [map])
 
-  // Handler to zoom the map view out by one level
-  function handleZoomOut() {
-    const map = mapRef.current
-    if (!map) return
-
-    const view = map.getView()
-    const currentZoom = view.getZoom() ?? 0
-    const targetZoom = view.getConstrainedZoom(currentZoom - 1)
-    view.cancelAnimations()
-    view.animate({
-      zoom: targetZoom,
-      duration: ZOOM_ANIMATION_DURATION_MS
-    })
-  }
-
-  function handleToggleMeasureMode() {
+  const handleToggleMeasureMode = useCallback(() => {
     setIsMeasureModeActive((active) => {
-      const next = !active
-      if (next) {
-        lineStringDrawRef.current?.abortDrawing()
-      }
-      return next
+      if (!active) draw?.abortDrawing()
+      return !active
     })
-  }
+  }, [draw])
 
-  function handleUnitChange(unit) {
-    setSelectedUnit(unit)
-  }
-
-  // Handler to navigate map to entered coordinates
-  function handleCoordinateGo({ latitude, longitude }) {
-    const map = mapRef.current
+  const handleCoordinateGo = useCallback(({ latitude, longitude }) => {
     if (!map) return
-
-    // Transform from data projection to map projection
-    const transformedCoords = transform(
-      [longitude, latitude],
-      geoJSONReadOptions.dataProjection,
-      geoJSONReadOptions.featureProjection
-    )
-
-    // Animate map to the coordinates
+    const coords = transform([longitude, latitude], GEOJSON_READ_OPTIONS.dataProjection, GEOJSON_READ_OPTIONS.featureProjection)
     const view = map.getView()
-    const currentZoom = view.getZoom() ?? 0
-    const targetZoom = Math.max(currentZoom, 14) // don't zoom out if already zoomed in
+    const target = Math.max(view.getZoom() ?? 0, 14)
     view.cancelAnimations()
-    view.animate({
-      center: transformedCoords,
-      zoom: targetZoom,
-      duration: ZOOM_ANIMATION_DURATION_MS
-    })
-  }
-
-  const mapLabel = t('SubjectViewer.GeoMapViewer.mapLabel')
+    view.animate({ center: coords, zoom: target, duration: ZOOM_ANIMATION_DURATION_MS })
+  }, [map])
 
   return (
-    <StyledBox
-      forwardedAs='section'
-      fill
-    >
+    <StyledBox forwardedAs='section' fill>
       <ControlsBox>
-        <ZoomInButton onClick={handleZoomIn} />
-        <ZoomOutButton onClick={handleZoomOut} />
-        <MeasureButton
-          active={isMeasureModeActive}
-          onClick={handleToggleMeasureMode}
-        />
+        <ZoomInButton onClick={() => handleZoom(1)} />
+        <ZoomOutButton onClick={() => handleZoom(-1)} />
+        <MeasureButton active={isMeasureModeActive} onClick={handleToggleMeasureMode} />
         {geoJSON && (
           <>
             <RecenterButton onClick={handleRecenter} />
-            {hasGeoDrawingTask && (
-              <ResetButton onClick={handleReset} />
-            )}
+            {hasGeoDrawingTask && <ResetButton onClick={handleReset} />}
           </>
         )}
       </ControlsBox>
       <MapContainer
-        ref={mapContainerRef}
-        aria-label={mapLabel}
+        ref={containerRef}
+        aria-label={t('SubjectViewer.GeoMapViewer.mapLabel')}
         role='region'
         className='map-container'
         tabIndex={0}
       />
-      <Box
-        direction='row'
-        align='center'
-        gap='small'
-        margin={{ top: 'xsmall' }}
-      >
-        <UnitSelect
-          value={selectedUnit}
-          onChange={handleUnitChange}
-        />
-        <CoordinateInput
-          onGoSubmit={handleCoordinateGo}
-        />
+      <Box direction='row' align='center' gap='small' margin={{ top: 'xsmall' }}>
+        <UnitSelect value={selectedUnit} onChange={setSelectedUnit} />
+        <CoordinateInput onGoSubmit={handleCoordinateGo} />
       </Box>
     </StyledBox>
   )
@@ -907,12 +242,8 @@ function GeoMapViewer({
 
 GeoMapViewer.propTypes = {
   geoDrawingTask: shape({
-    tools: arrayOf(shape({
-      type: string.isRequired,
-      label: string,
-      color: string,
-    })),
-    type: string.isRequired,
+    tools: arrayOf(shape({ type: string.isRequired, label: string, color: string })),
+    type: string.isRequired
   }),
   geoJSON: shape({}),
   onFeaturesChange: func,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/asMSTFeature.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/asMSTFeature.js
@@ -1,10 +1,15 @@
 import { isStateTreeNode } from 'mobx-state-tree'
 import * as features from '@plugins/tasks/experimental/geoDrawing/features/models'
 
+const MODEL_KEY_BY_GEOMETRY_TYPE = {
+  Point: 'Point',
+  LineString: 'SegmentedLine'
+}
+
 function toMSTFeature(olFeature) {
   const geometry = olFeature?.getGeometry?.()
   const geometryType = geometry?.getType?.()
-  const GeoFeatureModel = geometryType ? features[geometryType] : undefined
+  const GeoFeatureModel = geometryType ? features[MODEL_KEY_BY_GEOMETRY_TYPE[geometryType]] : undefined
   if (!GeoFeatureModel?.create) return null
   const { geometry: _olGeometry, ...properties } = olFeature.getProperties?.() || {}
   return GeoFeatureModel.create({
@@ -13,9 +18,6 @@ function toMSTFeature(olFeature) {
   })
 }
 
-/**
- * Returns MST feature if already MST; otherwise tries to construct from OL feature.
- */
 function asMSTFeature(feature) {
   if (!feature) return null
   if (isStateTreeNode(feature)) return feature

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/asMSTFeature.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/asMSTFeature.spec.js
@@ -1,0 +1,31 @@
+import Feature from 'ol/Feature'
+import { LineString, Point } from 'ol/geom'
+import { isStateTreeNode } from 'mobx-state-tree'
+
+import asMSTFeature from './asMSTFeature'
+
+describe('helpers > asMSTFeature', function () {
+  it('resolves a LineString OL feature to a SegmentedLine MST model that produces styles', function () {
+    const feature = new Feature({
+      geometry: new LineString([[0, 0], [10, 10], [20, 5]])
+    })
+    const mstFeature = asMSTFeature(feature)
+    expect(mstFeature).to.not.equal(null)
+    expect(isStateTreeNode(mstFeature)).to.equal(true)
+    const styles = mstFeature.getStyles({ feature, geoDrawingTask: null, isSelected: false })
+    expect(styles).to.be.an('array')
+    expect(styles.length).to.be.greaterThan(0)
+  })
+
+  it('resolves a Point OL feature to an MST model', function () {
+    const feature = new Feature({ geometry: new Point([1, 2]) })
+    const mstFeature = asMSTFeature(feature)
+    expect(mstFeature).to.not.equal(null)
+    expect(isStateTreeNode(mstFeature)).to.equal(true)
+  })
+
+  it('returns null for an unsupported geometry type', function () {
+    const feature = new Feature({})
+    expect(asMSTFeature(feature)).to.equal(null)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/constants.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/constants.js
@@ -1,0 +1,16 @@
+export const ZOOM_ANIMATION_DURATION_MS = 250
+export const POINTER_MOVE_HIT_CHECK_INTERVAL_MS = 80
+export const POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS = 4
+
+export const GEOJSON_READ_OPTIONS = {
+  dataProjection: 'EPSG:4326',
+  featureProjection: 'EPSG:3857'
+}
+
+export const UNIT_OPTION_TO_SCALE_LINE_UNITS = {
+  meters: 'metric',
+  kilometers: 'metric',
+  feet: 'imperial',
+  miles: 'imperial',
+  'nautical miles': 'nautical'
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
@@ -84,6 +84,17 @@ function createGeoLineStringInteraction({
   map.addInteraction(draw)
   draw.setActive(false)
 
+  // Remember the caller's desired active state so cap-recovery (delete) can re-enable Draw.
+  let lastRequestedActive = false
+
+  function syncActive() {
+    const target = lastRequestedActive && !isCapped()
+    if (draw.getActive() !== target) draw.setActive(target)
+  }
+
+  const sourceAddKey = source.on('addfeature', syncActive)
+  const sourceRemoveKey = source.on('removefeature', syncActive)
+
   const drawStartKey = draw.on('drawstart', function handleDrawStart() {
     isDrawing = true
   })
@@ -134,17 +145,16 @@ function createGeoLineStringInteraction({
       isDrawing = false
     },
     setActive(active) {
-      if (active && isCapped()) {
-        draw.setActive(false)
-        return
-      }
-      draw.setActive(active)
+      lastRequestedActive = active
+      syncActive()
       if (!active) isDrawing = false
     },
     destroy() {
       if (drawStartKey) unByKey(drawStartKey)
       if (drawEndKey) unByKey(drawEndKey)
       if (drawAbortKey) unByKey(drawAbortKey)
+      if (sourceAddKey) unByKey(sourceAddKey)
+      if (sourceRemoveKey) unByKey(sourceRemoveKey)
       draw.setActive(false)
       isDrawing = false
       map.removeInteraction(draw)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringModifyInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringModifyInteraction.js
@@ -9,14 +9,29 @@ export function hasLineStringFeature(features) {
 function createGeoLineStringModifyInteraction({
   map,
   selectInteraction,
-  onModifyEnd
+  onModifyEnd,
+  getMaxVertices
 }) {
   let isModifying = false
+
+  function getSelectedLineStringVertexCount() {
+    const feature = selectInteraction.getFeatures().getArray()
+      .find((f) => f.getGeometry?.()?.getType?.() === 'LineString')
+    if (!feature) return null
+    return feature.getGeometry().getCoordinates().length
+  }
 
   const modify = new Modify({
     features: selectInteraction.getFeatures(),
     pixelTolerance: 10,
-    condition: (event) => primaryAction(event) && hasLineStringFeature(selectInteraction.getFeatures().getArray())
+    condition: (event) => primaryAction(event) && hasLineStringFeature(selectInteraction.getFeatures().getArray()),
+    insertVertexCondition: () => {
+      const max = typeof getMaxVertices === 'function' ? getMaxVertices() : undefined
+      if (typeof max !== 'number') return true
+      const count = getSelectedLineStringVertexCount()
+      if (count === null) return true
+      return count < max
+    }
   })
 
   const startKey = modify.on('modifystart', () => { isModifying = true })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createModifyUncertaintyInteraction.js
@@ -23,6 +23,7 @@ function shouldStartDragHandleInteraction({
 }
 
 function createModifyUncertaintyInteraction({
+  map,
   geoDrawingTask,
   selectInteraction,
   translateInteraction,
@@ -34,7 +35,7 @@ function createModifyUncertaintyInteraction({
     isDragging: false
   }
 
-  // Cache MST feature creation to avoid repeated creation on pointermove
+  // Avoid rebuilding MST features on every pointermove.
   const mstFeatureCache = new WeakMap()
 
   function getCachedMSTFeature(olFeature) {
@@ -44,9 +45,6 @@ function createModifyUncertaintyInteraction({
     return mstFeatureCache.get(olFeature)
   }
 
-  /**
-   * Check if pointer is near the uncertainty circle drag handle of any selected feature
-   */
   function checkDragHandleClick(pixel, map) {
     if (!selectInteraction) return null
 
@@ -56,10 +54,9 @@ function createModifyUncertaintyInteraction({
       const mstFeature = getCachedMSTFeature(olFeature)
       if (!mstFeature) continue
 
-      // Check if this feature has an uncertainty circle
-      const radius = mstFeature.getUncertaintyRadius?.({ 
-        feature: olFeature, 
-        geoDrawingTask 
+      const radius = mstFeature.getUncertaintyRadius?.({
+        feature: olFeature,
+        geoDrawingTask
       })
       if (radius === null) continue
 
@@ -72,14 +69,12 @@ function createModifyUncertaintyInteraction({
         return null
       }
 
-      // Get the drag handle coordinates
       const dragHandleCoordinates = mstFeature.getDragHandleCoordinates?.({
         feature: olFeature,
         geoDrawingTask
       })
       if (!dragHandleCoordinates) continue
 
-      // Check if click is near the full resize handle across all world copies.
       const dragHandlePixels = getFeaturePixelsAcrossWorldCopies(map, dragHandleCoordinates)
       if (dragHandlePixels.some(handlePixel => shouldStartDragHandleInteraction({
         pixel,
@@ -94,9 +89,6 @@ function createModifyUncertaintyInteraction({
     return null
   }
 
-  /**
-   * Handle pointer down - detect if clicking near drag handle
-   */
   function handleDownEvent(event) {
     const map = this.getMap()
     if (!map) return false
@@ -107,27 +99,21 @@ function createModifyUncertaintyInteraction({
       state.draggedFeature = selectedFeature
       state.isDragging = true
 
-      // Disable Translate interaction while dragging uncertainty drag handle
       if (translateInteraction) {
         translateInteraction.setActive(false)
       }
 
-      // Update cursor
       const viewport = map.getViewport()
       if (viewport) {
         viewport.style.cursor = 'ew-resize'
       }
 
-      // Return true to start drag sequence
       return true
     }
 
     return false
   }
 
-  /**
-   * Handle drag - update radius based on distance from center
-   */
   function handleDragEvent(event) {
     if (!state.isDragging || !state.draggedFeature) {
       return
@@ -139,10 +125,7 @@ function createModifyUncertaintyInteraction({
     const coordinate = map.getCoordinateFromPixel(event.pixel)
     const centerCoordinates = state.draggedFeature.getGeometry().getCoordinates()
 
-    // After a cross-dateline drag, centerCoordinates is in the canonical world range but
-    // getCoordinateFromPixel returns a coordinate in the world copy the user is viewing.
-    // Normalize the drag coordinate to the nearest world copy of the center so that
-    // getPixelDistance always computes the short (correct) distance, not the ~40M-m cross-world distance.
+    // Wrap drag X to nearest world copy of the center so cross-dateline radii stay short.
     const extent = map.getView().getProjection().getExtent()
     const worldWidth = extent ? extent[2] - extent[0] : 0
     let dragX = coordinate[0]
@@ -153,12 +136,11 @@ function createModifyUncertaintyInteraction({
     }
     const normalizedCoordinate = [dragX, coordinate[1]]
 
-    // Calculate new radius in meters
     const newRadius = Math.round(
       Math.max(minRadius, getPixelDistance(centerCoordinates, normalizedCoordinate))
     )
 
-    // Update uncertainty radius through GeoDrawingTask to keep MST activeFeature and slider in sync
+    // Route through GeoDrawingTask so MST activeFeature + slider stay in sync.
     if (geoDrawingTask?.setActiveFeatureUncertaintyRadius) {
       geoDrawingTask.setActiveFeatureUncertaintyRadius(newRadius)
     } else {
@@ -167,42 +149,44 @@ function createModifyUncertaintyInteraction({
     }
   }
 
-  /**
-   * Handle pointer up - finish dragging
-   */
   function handleUpEvent(event) {
     if (state.isDragging) {
       state.isDragging = false
       state.draggedFeature = null
 
-      // Re-enable Translate interaction
       if (translateInteraction) {
         translateInteraction.setActive(true)
       }
 
-      // Reset cursor
       const map = this.getMap()
       const viewport = map?.getViewport()
       if (viewport) {
         viewport.style.cursor = ''
       }
 
-      // Return false to prevent the event from deselecting the feature
+      // Returning false prevents OL from deselecting the feature on up.
       return false
     }
 
     return true
   }
 
-  // Create the custom uncertainty circle PointerInteraction with handlers.
-  // Cursor hover state is managed centrally by GeoMapViewer.
   const interaction = new PointerInteraction({
     handleDownEvent,
     handleDragEvent,
     handleUpEvent
   })
 
-  return interaction
+  if (map) map.addInteraction(interaction)
+
+  return {
+    setActive(active) {
+      interaction.setActive(active)
+    },
+    destroy() {
+      if (map) map.removeInteraction(interaction)
+    }
+  }
 }
 
 export default createModifyUncertaintyInteraction

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
@@ -7,13 +7,7 @@ import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixel
 
 export const MOVE_TO_CLICK_HOLD_DELAY = 250
 
-/**
- * Wrap an X coordinate back into the projection's world extent so that features
- * dragged past the dateline remain visible and renderable by OpenLayers.
- * Derives the extent from the projection's own definition, so it works correctly
- * for any projection that declares a world extent (e.g. EPSG:3857, EPSG:4326).
- * Returns x unchanged if the projection has no defined world extent.
- */
+// Wrap X back into the projection's world extent so cross-dateline drags stay renderable.
 function normalizeCoordinateToWorld(x, projectionCode) {
   const proj = getProjection(projectionCode)
   const extent = proj?.getExtent()
@@ -24,11 +18,10 @@ function normalizeCoordinateToWorld(x, projectionCode) {
 }
 
 function createMoveToClickInteraction({
+  map,
   selectInteraction,
   geoDrawingTask,
-  featuresLayer,
-  onDragStart = undefined,
-  onDragEnd = undefined
+  featuresLayer
 }) {
   const state = {
     downCoordinate: null,
@@ -135,9 +128,6 @@ function createMoveToClickInteraction({
     }
   }
 
-  /**
-   * Handle pointer down - record state for potential click-to-move
-   */
   function handleDownEvent(event) {
     const map = this.getMap()
     if (!map || !selectInteraction || !geoDrawingTask) {
@@ -167,13 +157,13 @@ function createMoveToClickInteraction({
 
     state.clickedOnFeature = clickedInsideSelectedFeature
 
-    // Prioritize center-point dragging over uncertainty-handle checks.
-    // At far zoom, tiny uncertainty circles can place the handle near center.
+    // At far zoom, tiny uncertainty circles can place the handle near center; check center first.
     if (clickedInsideSelectedFeature) {
       state.draggingFeature = true
       state.disabledSelect = true
       selectInteraction.setActive(false)
-      onDragStart?.()
+      const viewport = map.getViewport()
+      if (viewport) viewport.style.cursor = 'grabbing'
       return true
     }
 
@@ -201,9 +191,7 @@ function createMoveToClickInteraction({
       : false
 
     if (clickedInUncertaintyCircleOnly) {
-      // Capture the event so we can detect a click (no drag) vs a drag (map pan).
-      // Setting clickedOnFeature=true prevents the empty-space teleport path in handleUpEvent.
-      // draggingFeature stays false so stopDown() returns false, letting DragPan handle drags.
+      // Capture without draggingFeature so DragPan still handles map drags via stopDown=false.
       state.clickedOnFeature = true
       state.clickedInUncertaintyCircle = true
       state.disabledSelect = true
@@ -211,7 +199,6 @@ function createMoveToClickInteraction({
       return true
     }
 
-    // If clicking on a different feature's center point, let Select handle it (it will select that feature)
     let clickedOtherFeatureCenter = false
     featuresLayer.getSource().forEachFeature((feature) => {
       if (feature === state.selectedFeature || clickedOtherFeatureCenter) return
@@ -233,11 +220,7 @@ function createMoveToClickInteraction({
     return true
   }
 
-  /** 
-   * In the OpenLayers PointerInteraction, stopDown determines if the down event is propagated to other interactions.
-   * We return true to stop down events from propagating to DragPan.
-   * We return false to allow DragPan to handle the event, which lets the user drag the map.
-   */
+  // OL PointerInteraction stopDown: true blocks DragPan, false lets it run.
   function stopDown() {
     return state.draggingFeature
   }
@@ -268,10 +251,6 @@ function createMoveToClickInteraction({
     }
   }
 
-  /**
-   * Handle pointer up - teleport feature on click within uncertainty circle or empty space;
-   * move feature if dragged from center point.
-   */
   function handleUpEvent(event) {
     const map = this.getMap()
 
@@ -293,7 +272,6 @@ function createMoveToClickInteraction({
 
     const wasDragging = state.draggingFeature
 
-    // Reset state
     resetPointerState()
 
     if (state.disabledSelect) {
@@ -301,7 +279,8 @@ function createMoveToClickInteraction({
     }
 
     if (wasDragging) {
-      onDragEnd?.()
+      const viewport = map.getViewport()
+      if (viewport) viewport.style.cursor = 'grab'
     }
 
     return false
@@ -316,7 +295,6 @@ function createMoveToClickInteraction({
     }, 0)
   }
 
-  // Create and return the interaction
   const interaction = new PointerInteraction({
     handleDownEvent,
     handleDragEvent,
@@ -324,7 +302,19 @@ function createMoveToClickInteraction({
     stopDown
   })
 
-  return interaction
+  if (map) map.addInteraction(interaction)
+
+  return {
+    isDragging() {
+      return state.draggingFeature
+    },
+    setActive(active) {
+      interaction.setActive(active)
+    },
+    destroy() {
+      if (map) map.removeInteraction(interaction)
+    }
+  }
 }
 
 export default createMoveToClickInteraction

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.js
@@ -1,0 +1,145 @@
+import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
+
+import asMSTFeature from './asMSTFeature'
+import { FEATURE_HIT_TOLERANCE_PX } from './createGeoLineStringInteraction'
+import getDrawModeCursor from './getDrawModeCursor'
+import getInteractionStates from './getInteractionStates'
+import getPixelDistance from './getPixelDistance'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixelsAcrossWorldCopies } from './hitTesting'
+import isLineStringFeature from './isLineStringFeature'
+
+function getDrawCursor({ map, layer, select, draw, modify, pixel, dragging }) {
+  const selectedFeature = select.getFeatures().item(0)
+  const coords = isLineStringFeature(selectedFeature)
+    ? selectedFeature.getGeometry().getCoordinates?.() || []
+    : []
+  const isOnSelectedVertex = coords.some((coord) => (
+    getPixelDistance(pixel, map.getPixelFromCoordinate(coord)) <= 10
+  ))
+
+  let isOnAnotherFeature = false
+  map.forEachFeatureAtPixel(pixel, (feature) => {
+    if (feature !== selectedFeature) {
+      isOnAnotherFeature = true
+      return true
+    }
+    return false
+  }, { layerFilter: (l) => l === layer, hitTolerance: FEATURE_HIT_TOLERANCE_PX })
+
+  return getDrawModeCursor({
+    isModifying: modify?.isModifying() ?? false,
+    isSketching: draw?.isDrawing() ?? false,
+    isOnSelectedVertex,
+    isOnAnotherFeature,
+    isAtMaxLines: draw?.isCapped() ?? false,
+    isDragging: dragging
+  })
+}
+
+function getSelectedFeatureCursor({ map, selectedFeature, geoDrawingTask, pixel, isDraggingPoint }) {
+  const mstFeature = asMSTFeature(selectedFeature)
+  const coords = selectedFeature.getGeometry()?.getCoordinates?.()
+  if (!mstFeature || !Array.isArray(coords)) return null
+
+  const pixels = getFeaturePixelsAcrossWorldCopies(map, coords)
+  if (pixels.some((p) => isPixelNearPointCenter({ pixel, pointPixel: p, radius: POINT_CENTER_HIT_RADIUS_PIXELS }))) {
+    return isDraggingPoint ? 'grabbing' : 'grab'
+  }
+
+  const handleCoords = mstFeature.getDragHandleCoordinates?.({ feature: selectedFeature, geoDrawingTask })
+  if (handleCoords) {
+    const handlePixels = getFeaturePixelsAcrossWorldCopies(map, handleCoords)
+    if (handlePixels.some((handlePixel) => isPixelNearDragHandle({ pixel, handlePixel, tolerance: 15 }))) {
+      return 'ew-resize'
+    }
+  }
+
+  const uncertaintyRadius = mstFeature.getUncertaintyRadiusPixels?.({
+    feature: selectedFeature,
+    geoDrawingTask,
+    resolution: map.getView().getResolution()
+  })
+  if (typeof uncertaintyRadius === 'number' && uncertaintyRadius > 0
+    && pixels.some((p) => getPixelDistance(pixel, p) <= uncertaintyRadius)) {
+    return 'default'
+  }
+
+  return null
+}
+
+function getOtherCenterCursor({ map, layer, selectedFeature, pixel }) {
+  let hovering = false
+  layer.getSource().forEachFeature((feature) => {
+    if (feature === selectedFeature || hovering) return
+    const coords = feature.getGeometry()?.getCoordinates?.()
+    if (!Array.isArray(coords)) return
+    if (getFeaturePixelsAcrossWorldCopies(map, coords).some(
+      (p) => isPixelNearPointCenter({ pixel, pointPixel: p, radius: POINT_CENTER_HIT_RADIUS_PIXELS })
+    )) {
+      hovering = true
+    }
+  })
+  return hovering ? 'pointer' : 'default'
+}
+
+export function isPointerOverFeature({ map, layer, pixel, geoDrawingTask }) {
+  let over = false
+  layer.getSource().forEachFeature((feature) => {
+    if (over) return
+    const coords = feature.getGeometry()?.getCoordinates?.()
+    if (!Array.isArray(coords)) return
+    const pixels = getFeaturePixelsAcrossWorldCopies(map, coords)
+    if (pixels.some((p) => isPixelNearPointCenter({ pixel, pointPixel: p, radius: POINT_CENTER_HIT_RADIUS_PIXELS }))) {
+      over = true
+      return
+    }
+    const mstFeature = asMSTFeature(feature)
+    const radius = mstFeature?.getUncertaintyRadiusPixels?.({
+      feature,
+      geoDrawingTask,
+      resolution: map.getView().getResolution()
+    })
+    if (typeof radius === 'number' && radius > 0
+      && pixels.some((p) => getPixelDistance(pixel, p) <= radius)) {
+      over = true
+    }
+  })
+  return over
+}
+
+export default function getCursorFromState({
+  map,
+  layer,
+  select,
+  draw,
+  modify,
+  geoDrawingTask,
+  activeToolType,
+  isMeasureModeActive,
+  isDraggingPoint,
+  pixel,
+  dragging,
+  cachedFeatureHit
+}) {
+  const states = getInteractionStates({ activeToolType, isMeasureModeActive })
+
+  if (states.measure) return ''
+  if (states.lineStringDraw) {
+    return getDrawCursor({ map, layer, select, draw, modify, pixel, dragging })
+  }
+
+  const selected = select.getFeatures().item(0)
+  if (selected) {
+    const selectedCursor = getSelectedFeatureCursor({
+      map,
+      selectedFeature: selected,
+      geoDrawingTask,
+      pixel,
+      isDraggingPoint
+    })
+    if (selectedCursor) return selectedCursor
+    return getOtherCenterCursor({ map, layer, selectedFeature: selected, pixel })
+  }
+
+  return cachedFeatureHit ? 'pointer' : 'default'
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getFeatureStyle.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getFeatureStyle.js
@@ -1,20 +1,7 @@
 import asMSTFeature from './asMSTFeature'
 
-function getFeatureStyle({
-  feature,
-  geoDrawingTask,
-  isSelected = false,
-  resolution
-}) {
+export default function getFeatureStyle({ feature, geoDrawingTask, isSelected = false, resolution }) {
   const mstFeature = asMSTFeature(feature)
   if (!mstFeature) return null
-
-  return mstFeature.getStyles({
-    feature,
-    geoDrawingTask,
-    isSelected,
-    resolution
-  })
+  return mstFeature.getStyles({ feature, geoDrawingTask, isSelected, resolution })
 }
-
-export default getFeatureStyle

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/hitTesting.js
@@ -13,11 +13,7 @@ export function isPixelNearPointCenter({
   return (deltaX * deltaX) + (deltaY * deltaY) <= radius * radius
 }
 
-/**
- * Returns all pixel positions for a coordinate, including ±worldWidth offsets.
- * After coordinate normalization a feature's canonical X may not match the world copy the user is viewing, 
- * so every copy that could be on screen must be checked.
- */
+// After normalization a canonical X may not match the on-screen world copy; return all candidates.
 export function getFeaturePixelsAcrossWorldCopies(map, coord) {
   const extent = map.getView().getProjection().getExtent()
   const worldWidth = extent ? extent[2] - extent[0] : 0

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/isLineStringFeature.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/isLineStringFeature.js
@@ -1,0 +1,3 @@
+export default function isLineStringFeature(feature) {
+  return feature?.getGeometry?.()?.getType?.() === 'LineString'
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.js
@@ -1,0 +1,19 @@
+import GeoJSON from 'ol/format/GeoJSON'
+
+import { GEOJSON_READ_OPTIONS, ZOOM_ANIMATION_DURATION_MS } from './constants'
+import { fitViewToFeatures, selectFirstFeature } from './mapSelection'
+
+export default function loadGeoJSON({ map, source, select, measure, data }) {
+  if (!map || !source) return
+  measure?.clear?.()
+  source.clear()
+  if (!data) return
+
+  const format = new GeoJSON()
+  const features = format.readFeatures(data, GEOJSON_READ_OPTIONS)
+  source.addFeatures(features)
+  if (source.getFeatures().length) {
+    fitViewToFeatures(map, source, ZOOM_ANIMATION_DURATION_MS)
+    selectFirstFeature(select, features)
+  }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/mapSelection.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/mapSelection.js
@@ -1,0 +1,22 @@
+export function selectFirstFeature(select, features) {
+  if (!select || features.length === 0) return
+  select.getFeatures().clear()
+  select.getFeatures().push(features[0])
+  select.dispatchEvent({ type: 'select', selected: [features[0]], deselected: [] })
+}
+
+export function clearSelectedFeature(select) {
+  if (!select) return
+  const deselected = [...select.getFeatures().getArray()]
+  if (deselected.length === 0) return
+  select.getFeatures().clear()
+  select.dispatchEvent({ type: 'select', selected: [], deselected })
+}
+
+export function fitViewToFeatures(map, features, duration) {
+  map.getView().fit(features.getExtent(), {
+    padding: [32, 32, 32, 32],
+    maxZoom: 12,
+    duration
+  })
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapCursor.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapCursor.js
@@ -1,0 +1,102 @@
+import { useEffect } from 'react'
+
+import { POINTER_MOVE_HIT_CHECK_INTERVAL_MS, POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS } from '../helpers/constants'
+import getCursorFromState, { isPointerOverFeature } from '../helpers/getCursorFromState'
+import getPixelDistance from '../helpers/getPixelDistance'
+import isLineStringFeature from '../helpers/isLineStringFeature'
+
+export default function useMapCursor({
+  map,
+  layer,
+  select,
+  draw,
+  modify,
+  moveToClick,
+  geoDrawingTask,
+  hasGeoDrawingTask,
+  activeToolType,
+  isMeasureModeActive
+}) {
+  useEffect(() => {
+    if (!map || !layer || !select || !hasGeoDrawingTask) return undefined
+
+    let rafId = null
+    let latestEvent = null
+    let lastCursor = ''
+    let lastHitTs = 0
+    let lastHitPixel = null
+    let lastHitResult = false
+
+    function applyCursor(cursor) {
+      if (lastCursor === cursor) return
+      const viewport = map.getViewport()
+      if (viewport) viewport.style.cursor = cursor
+      lastCursor = cursor
+    }
+
+    function onPointerMove(event) {
+      latestEvent = event
+      if (rafId !== null) return
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        const e = latestEvent
+        if (!e) return
+
+        if (isMeasureModeActive) {
+          const target = map.getTargetElement()
+          if (target) target.style.cursor = ''
+          return
+        }
+
+        const now = performance.now()
+        const moved = !lastHitPixel || getPixelDistance(e.pixel, lastHitPixel) >= POINTER_MOVE_HIT_CHECK_MIN_DELTA_PIXELS
+        const elapsed = (now - lastHitTs) >= POINTER_MOVE_HIT_CHECK_INTERVAL_MS
+        if (moved || elapsed) {
+          lastHitResult = isPointerOverFeature({ map, layer, pixel: e.pixel, geoDrawingTask })
+          lastHitTs = now
+          lastHitPixel = [...e.pixel]
+        }
+
+        const cursor = getCursorFromState({
+          map,
+          layer,
+          select,
+          draw,
+          modify,
+          geoDrawingTask,
+          activeToolType,
+          isMeasureModeActive,
+          isDraggingPoint: moveToClick?.isDragging() ?? false,
+          pixel: e.pixel,
+          dragging: e.dragging,
+          cachedFeatureHit: lastHitResult
+        })
+        applyCursor(cursor)
+      })
+    }
+
+    function onPointerDown(event) {
+      const isDrawing = activeToolType === 'SegmentedLine' && !isMeasureModeActive
+      if (!isDrawing) return
+      const selected = select.getFeatures().item(0)
+      if (!isLineStringFeature(selected)) return
+      const coords = selected.getGeometry().getCoordinates?.() || []
+      const nearVertex = coords.some((coord) => (
+        getPixelDistance(event.pixel, map.getPixelFromCoordinate(coord)) <= 10
+      ))
+      if (nearVertex) {
+        const viewport = map.getViewport()
+        if (viewport) viewport.style.cursor = 'grabbing'
+      }
+    }
+
+    map.on('pointermove', onPointerMove)
+    map.on('pointerdown', onPointerDown)
+
+    return () => {
+      map.un('pointermove', onPointerMove)
+      map.un('pointerdown', onPointerDown)
+      if (rafId !== null) cancelAnimationFrame(rafId)
+    }
+  }, [map, layer, select, draw, modify, moveToClick, geoDrawingTask, hasGeoDrawingTask, activeToolType, isMeasureModeActive])
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapInteractions.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapInteractions.js
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react'
+
+import { UNIT_OPTION_TO_SCALE_LINE_UNITS } from '../helpers/constants'
+import createGeoLineStringInteraction from '../helpers/createGeoLineStringInteraction'
+import createGeoLineStringModifyInteraction from '../helpers/createGeoLineStringModifyInteraction'
+import createMeasureInteraction from '../helpers/createMeasureInteraction'
+import createModifyUncertaintyInteraction from '../helpers/createModifyUncertaintyInteraction'
+import createMoveToClickInteraction from '../helpers/createMoveToClickInteraction'
+import getInteractionStates from '../helpers/getInteractionStates'
+
+export default function useMapInteractions({
+  map,
+  source,
+  layer,
+  scaleLine,
+  select,
+  translate,
+  geoDrawingTask,
+  hasGeoDrawingTask,
+  isMeasureModeActive,
+  setIsMeasureModeActive,
+  selectedUnit,
+  containerRef,
+  t
+}) {
+  const [interactions, setInteractions] = useState({
+    draw: null,
+    modify: null,
+    uncertaintyModify: null,
+    moveToClick: null,
+    measure: null
+  })
+  const activeToolType = geoDrawingTask?.activeTool?.type
+  const activeToolIndex = geoDrawingTask?.activeToolIndex
+
+  useEffect(() => {
+    if (!map) return undefined
+    const measure = createMeasureInteraction({
+      map,
+      messages: {
+        clickToContinue: t('SubjectViewer.GeoMapViewer.MeasureInteraction.clickToContinue'),
+        clickToStart: t('SubjectViewer.GeoMapViewer.MeasureInteraction.clickToStart')
+      }
+    })
+    setInteractions((prev) => ({ ...prev, measure }))
+    return () => {
+      measure.destroy()
+      setInteractions((prev) => ({ ...prev, measure: null }))
+    }
+  }, [map, t])
+
+  // OL Draw fixes min/max/toolIndex at construction; recreate on tool switch.
+  useEffect(() => {
+    if (!map || !source || !layer || !select || !hasGeoDrawingTask) return undefined
+    const draw = createGeoLineStringInteraction({
+      map,
+      source,
+      featuresLayer: layer,
+      geoDrawingTask,
+      selectInteraction: select
+    })
+    setInteractions((prev) => ({ ...prev, draw }))
+    return () => {
+      draw.destroy()
+      setInteractions((prev) => ({ ...prev, draw: null }))
+    }
+  }, [map, source, layer, select, geoDrawingTask, hasGeoDrawingTask, activeToolIndex])
+
+  useEffect(() => {
+    if (!map || !select || !translate || !layer || !hasGeoDrawingTask) return undefined
+
+    const modify = createGeoLineStringModifyInteraction({
+      map,
+      selectInteraction: select,
+      onModifyEnd: () => {
+        const viewport = map.getViewport()
+        if (viewport) viewport.style.cursor = 'grab'
+      },
+      getMaxVertices: () => {
+        const tool = geoDrawingTask?.activeTool
+        return tool?.type === 'SegmentedLine' ? tool.max_vertices : undefined
+      }
+    })
+
+    const uncertaintyModify = createModifyUncertaintyInteraction({
+      map,
+      geoDrawingTask,
+      selectInteraction: select,
+      translateInteraction: translate
+    })
+
+    const moveToClick = createMoveToClickInteraction({
+      map,
+      selectInteraction: select,
+      geoDrawingTask,
+      featuresLayer: layer
+    })
+
+    setInteractions((prev) => ({ ...prev, modify, uncertaintyModify, moveToClick }))
+    return () => {
+      modify.destroy()
+      uncertaintyModify.destroy()
+      moveToClick.destroy()
+      setInteractions((prev) => ({ ...prev, modify: null, uncertaintyModify: null, moveToClick: null }))
+    }
+  }, [map, select, translate, layer, geoDrawingTask, hasGeoDrawingTask])
+
+  const { draw, modify, uncertaintyModify, moveToClick, measure } = interactions
+
+  useEffect(() => {
+    const states = getInteractionStates({ activeToolType, isMeasureModeActive })
+    measure?.setActive(states.measure)
+    draw?.setActive(states.lineStringDraw)
+    modify?.setActive(states.lineStringModify)
+    select?.setActive(states.select)
+    translate?.setActive(states.translate)
+    uncertaintyModify?.setActive(states.modifyUncertainty)
+    moveToClick?.setActive(states.moveToClick)
+  }, [activeToolType, activeToolIndex, isMeasureModeActive, select, translate, draw, modify, uncertaintyModify, moveToClick, measure])
+
+  useEffect(() => {
+    if (!scaleLine) return
+    scaleLine.setUnits(UNIT_OPTION_TO_SCALE_LINE_UNITS[selectedUnit] ?? 'metric')
+    measure?.setUnit(selectedUnit)
+    geoDrawingTask?.setUnit?.(selectedUnit)
+  }, [scaleLine, selectedUnit, geoDrawingTask, measure])
+
+  useEffect(() => {
+    if (activeToolType === 'SegmentedLine' && isMeasureModeActive) {
+      measure?.clear()
+      setIsMeasureModeActive(false)
+    }
+  }, [activeToolType, isMeasureModeActive, measure, setIsMeasureModeActive])
+
+  useEffect(() => {
+    const container = containerRef?.current
+    if (!container || !draw) return undefined
+    function onKeyDown(event) {
+      if (event.key !== 'Escape') return
+      if (!draw.isDrawing()) return
+      event.preventDefault()
+      event.stopPropagation()
+      draw.abortDrawing()
+    }
+    container.addEventListener('keydown', onKeyDown)
+    return () => container.removeEventListener('keydown', onKeyDown)
+  }, [containerRef, draw])
+
+  return { draw, modify, moveToClick, measure }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapSelection.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapSelection.js
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react'
+import { singleClick } from 'ol/events/condition'
+import { Select, Translate } from 'ol/interaction'
+import { unByKey } from 'ol/Observable'
+
+import asMSTFeature from '../helpers/asMSTFeature'
+import { FEATURE_HIT_TOLERANCE_PX } from '../helpers/createGeoLineStringInteraction'
+import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixelsAcrossWorldCopies } from '../helpers/hitTesting'
+import { clearSelectedFeature, selectFirstFeature } from '../helpers/mapSelection'
+
+export default function useMapSelection({
+  map,
+  source,
+  layer,
+  geoDrawingTask,
+  hasGeoDrawingTask,
+  isMeasureModeActive,
+  onSelectedFeatureChange
+}) {
+  const [interactions, setInteractions] = useState({ select: null, translate: null })
+  const activeToolIndex = geoDrawingTask?.activeToolIndex
+
+  useEffect(() => {
+    if (!map || !layer || !hasGeoDrawingTask) return undefined
+
+    const select = new Select({
+      condition: singleClick,
+      hitTolerance: FEATURE_HIT_TOLERANCE_PX,
+      layers: [layer],
+      style: null
+    })
+
+    const translate = new Translate({
+      features: select.getFeatures(),
+      condition: (event) => {
+        const selected = select.getFeatures().getArray()[0]
+        const coords = selected?.getGeometry()?.getCoordinates?.()
+        if (!Array.isArray(coords)) return false
+        return getFeaturePixelsAcrossWorldCopies(map, coords).some((pointPixel) => (
+          isPixelNearPointCenter({ pixel: event.pixel, pointPixel, radius: POINT_CENTER_HIT_RADIUS_PIXELS })
+        ))
+      }
+    })
+
+    map.addInteraction(select)
+    map.addInteraction(translate)
+    setInteractions({ select, translate })
+
+    return () => {
+      map.removeInteraction(translate)
+      map.removeInteraction(select)
+      setInteractions({ select: null, translate: null })
+    }
+  }, [map, layer, hasGeoDrawingTask])
+
+  const { select, translate } = interactions
+
+  useEffect(() => {
+    if (!select) return undefined
+
+    const key = select.on('select', (event) => {
+      const selected = event.selected?.[0]
+      const mstFeature = selected ? asMSTFeature(selected) : null
+
+      if (selected) {
+        const featureToolIndex = selected.get?.('toolIndex')
+        if (typeof featureToolIndex === 'number' && featureToolIndex !== geoDrawingTask?.activeToolIndex) {
+          geoDrawingTask?.setActiveTool?.(featureToolIndex)
+        }
+      }
+
+      if (onSelectedFeatureChange) {
+        onSelectedFeatureChange(selected ? { mstFeature, olFeature: selected } : null)
+        return
+      }
+
+      if (selected) {
+        geoDrawingTask?.setActiveFeature?.(mstFeature)
+        geoDrawingTask?.setActiveOlFeature?.(selected)
+      } else {
+        geoDrawingTask?.clearActiveFeature?.()
+        geoDrawingTask?.clearActiveOlFeature?.()
+      }
+    })
+
+    return () => unByKey(key)
+  }, [select, geoDrawingTask, onSelectedFeatureChange])
+
+  useEffect(() => {
+    if (!select || !hasGeoDrawingTask) return
+    const features = select.getFeatures()
+    const current = features.item(0)
+    if (!current) return
+    const featureToolIndex = current.get?.('toolIndex')
+    if (typeof featureToolIndex !== 'number' || featureToolIndex === activeToolIndex) return
+    features.clear()
+    select.dispatchEvent({ type: 'select', selected: [], deselected: [current] })
+  }, [select, hasGeoDrawingTask, activeToolIndex])
+
+  useEffect(() => {
+    if (!select) return
+    if (isMeasureModeActive) {
+      clearSelectedFeature(select)
+      const target = map?.getTargetElement()
+      if (target) target.style.cursor = ''
+    } else if (source) {
+      selectFirstFeature(select, source.getFeatures() ?? [])
+    }
+  }, [isMeasureModeActive, select, map, source])
+
+  return { select, translate }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+import { Map, View } from 'ol'
+import { defaults as defaultControls } from 'ol/control/defaults'
+import ScaleLine from 'ol/control/ScaleLine'
+import TileLayer from 'ol/layer/Tile'
+import VectorLayer from 'ol/layer/Vector'
+import OSM from 'ol/source/OSM'
+import VectorSource from 'ol/source/Vector'
+
+export default function useOLMap(containerRef) {
+  const [state, setState] = useState({ map: null, source: null, layer: null, scaleLine: null })
+
+  useEffect(() => {
+    if (!containerRef.current) return undefined
+
+    const source = new VectorSource({ features: [] })
+    const layer = new VectorLayer({ source })
+    const scaleLine = new ScaleLine()
+    const map = new Map({
+      target: containerRef.current,
+      layers: [
+        new TileLayer({ preload: 1, source: new OSM() }),
+        layer
+      ],
+      view: new View({ center: [0, 0], zoom: 0 }),
+      controls: defaultControls({ zoom: false }).extend([scaleLine])
+    })
+
+    setState({ map, source, layer, scaleLine })
+    if (typeof window !== 'undefined') window.__olMap = map
+
+    return () => {
+      map.setTarget(undefined)
+      if (typeof window !== 'undefined' && window.__olMap === map) delete window.__olMap
+      setState({ map: null, source: null, layer: null, scaleLine: null })
+    }
+  }, [containerRef])
+
+  return state
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
@@ -27,11 +27,9 @@ export default function useOLMap(containerRef) {
     })
 
     setState({ map, source, layer, scaleLine })
-    if (typeof window !== 'undefined') window.__olMap = map
 
     return () => {
       map.setTarget(undefined)
-      if (typeof window !== 'undefined' && window.__olMap === map) delete window.__olMap
       setState({ map: null, source: null, layer: null, scaleLine: null })
     }
   }, [containerRef])

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useSelectionLayer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useSelectionLayer.jsx
@@ -1,0 +1,118 @@
+import { useEffect } from 'react'
+import { createRoot } from 'react-dom/client'
+import { unByKey } from 'ol/Observable'
+import Overlay from 'ol/Overlay'
+
+import DeleteIcon from '@plugins/drawingTools/components/DeleteButton/DeleteIcon'
+import getFeatureStyle from '../helpers/getFeatureStyle'
+import isLineStringFeature from '../helpers/isLineStringFeature'
+import { clearSelectedFeature } from '../helpers/mapSelection'
+
+const ICON_RADIUS = 8
+const ICON_BOX = (ICON_RADIUS + 2) * 2
+
+function isFirstVertexStyle(style, feature) {
+  const coord = style.getGeometry?.()?.getCoordinates?.()
+  if (!coord) return false
+  const first = feature.getGeometry().getFirstCoordinate()
+  return coord[0] === first[0] && coord[1] === first[1]
+}
+
+export default function useSelectionLayer({
+  map,
+  source,
+  layer,
+  select,
+  geoDrawingTask,
+  hasGeoDrawingTask,
+  ariaLabel
+}) {
+  useEffect(() => {
+    if (!map || !layer) return undefined
+
+    let isHoveringDelete = false
+
+    layer.setStyle((feature) => {
+      const isSelected = hasGeoDrawingTask && select?.getFeatures().getArray().includes(feature)
+      const styles = getFeatureStyle({
+        feature,
+        geoDrawingTask: hasGeoDrawingTask ? geoDrawingTask : null,
+        isSelected,
+        resolution: map.getView().getResolution()
+      })
+
+      if (!styles || !isSelected || !isHoveringDelete || !isLineStringFeature(feature)) {
+        return styles
+      }
+
+      return styles.filter((style) => !isFirstVertexStyle(style, feature))
+    })
+
+    if (!select || !source) return undefined
+
+    const element = document.createElement('div')
+    element.style.display = 'none'
+    const root = createRoot(element)
+
+    function handleDelete() {
+      const current = select.getFeatures()?.item(0)
+      if (!isLineStringFeature(current)) return
+      source.removeFeature(current)
+      clearSelectedFeature(select)
+    }
+
+    function invalidateSelected() {
+      const selected = select.getFeatures()?.item(0)
+      if (selected) selected.changed()
+    }
+
+    root.render(
+      <button
+        aria-label={ariaLabel}
+        onClick={(event) => { event.preventDefault(); event.stopPropagation(); handleDelete() }}
+        onPointerEnter={() => { isHoveringDelete = true; invalidateSelected() }}
+        onPointerLeave={() => { isHoveringDelete = false; invalidateSelected() }}
+        style={{ background: 'transparent', border: 0, padding: 0, cursor: 'pointer', lineHeight: 0 }}
+        title={ariaLabel}
+        type='button'
+      >
+        <svg height={ICON_BOX} viewBox={`-${ICON_BOX / 2} -${ICON_BOX / 2} ${ICON_BOX} ${ICON_BOX}`} width={ICON_BOX}>
+          <DeleteIcon radius={ICON_RADIUS} />
+        </svg>
+      </button>
+    )
+
+    const overlay = new Overlay({ element, positioning: 'center-center', offset: [-16, -16], stopEvent: true })
+    map.addOverlay(overlay)
+
+    let changeKey = null
+    const selectKey = select.on('select', (event) => {
+      if (changeKey) { unByKey(changeKey); changeKey = null }
+      // OL caches per-feature style; invalidate both sides on a selection swap.
+      ;[...(event.deselected || []), ...(event.selected || [])].forEach((feature) => {
+        feature?.changed?.()
+      })
+      layer.changed()
+
+      const selected = event.selected?.[0]
+      if (isLineStringFeature(selected)) {
+        overlay.setPosition(selected.getGeometry().getFirstCoordinate())
+        element.style.display = ''
+        changeKey = selected.on('change', () => {
+          overlay.setPosition(selected.getGeometry().getFirstCoordinate())
+        })
+      } else {
+        overlay.setPosition(undefined)
+        element.style.display = 'none'
+        isHoveringDelete = false
+      }
+    })
+
+    return () => {
+      if (changeKey) unByKey(changeKey)
+      unByKey(selectKey)
+      map.removeOverlay(overlay)
+      root.unmount()
+    }
+  }, [map, source, layer, select, geoDrawingTask, hasGeoDrawingTask, ariaLabel])
+}

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.jsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react'
 import styled, { css, withTheme } from 'styled-components'
 
 import useSVGContext from '@plugins/drawingTools/hooks/useSVGContext'
+import DeleteIcon from './DeleteIcon'
 
 const StyledGroup = styled('g')`
   &:focus {
@@ -15,52 +16,27 @@ const StyledGroup = styled('g')`
 `
 
 const DEFAULT_HANDLER = () => false
-const DEFAULT_THEME = {
-  global: {
-    colors: {}
-  }
-}
+const DEFAULT_THEME = { global: { colors: {} } }
 
-function DeleteButton ({ 
-  label, 
-  mark, 
-  onDelete = DEFAULT_HANDLER, 
-  onDeselect = DEFAULT_HANDLER, 
-  rotate = 0, 
+function DeleteButton({
+  label,
+  mark,
+  onDelete = DEFAULT_HANDLER,
+  onDeselect = DEFAULT_HANDLER,
+  rotate = 0,
   theme = DEFAULT_THEME
 }) {
   const { scale } = useSVGContext()
   const focusColor = theme.global.colors[theme.global.colors.focus]
-  const RADIUS = (window?.innerWidth < 900) ? 5 : 8
-  const STROKE_COLOR = 'white'
-  const FILL_COLOR = 'black'
-  const STROKE_WIDTH = 1.5
-  const CROSS_PATH = `
-    M ${-1 * RADIUS * 0.7} 0
-    L ${RADIUS * 0.7} 0
-    M 0 ${-1 * RADIUS * 0.7}
-    L 0 ${RADIUS * 0.7}
-  `
+  const radius = (window?.innerWidth < 900) ? 5 : 8
   const { x, y } = mark.deleteButtonPosition(scale)
-  const transform = `
-    translate(${x}, ${y})
-    rotate(${rotate})
-    scale(${1 / scale})
-  `
-  
-  function onKeyDown (event) {
-    switch (event.key) {
-      case 'Enter':
-      case ' ': {
-        return onPointerDown(event)
-      }
-      default: {
-        return true
-      }
-    }
+
+  function onKeyDown(event) {
+    if (event.key === 'Enter' || event.key === ' ') return onPointerDown(event)
+    return true
   }
 
-  function onPointerDown (event) {
+  function onPointerDown(event) {
     event.preventDefault()
     event.stopPropagation()
     onDelete()
@@ -76,19 +52,10 @@ function DeleteButton ({
       onKeyDown={onKeyDown}
       onPointerDown={onPointerDown}
       role='button'
-      stroke={STROKE_COLOR}
-      strokeWidth={STROKE_WIDTH}
       tabIndex='-1'
-      transform={transform}
+      transform={`translate(${x}, ${y}) rotate(${rotate}) scale(${1 / scale})`}
     >
-      <circle
-        fill={FILL_COLOR}
-        r={RADIUS}
-      />
-      <path
-        d={CROSS_PATH}
-        transform='rotate(45)'
-      />
+      <DeleteIcon radius={radius} />
     </StyledGroup>
   )
 }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteIcon.jsx
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteIcon.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types'
+
+function DeleteIcon({ radius = 8, strokeWidth = 1.5 }) {
+  const tick = radius * 0.7
+  return (
+    <>
+      <circle fill='black' r={radius} stroke='white' strokeWidth={strokeWidth} />
+      <path
+        d={`M ${-tick} 0 L ${tick} 0 M 0 ${-tick} L 0 ${tick}`}
+        stroke='white'
+        strokeWidth={strokeWidth}
+        transform='rotate(45)'
+      />
+    </>
+  )
+}
+
+DeleteIcon.propTypes = {
+  radius: PropTypes.number,
+  strokeWidth: PropTypes.number
+}
+
+export default DeleteIcon

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/SegmentedLine.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/SegmentedLine.js
@@ -50,36 +50,21 @@ const SegmentedLine = types
       return indexedTool || tools.find(tool => tool.type === 'SegmentedLine')
     },
 
-    getStyles({
-      feature,
-      geoDrawingTask,
-      isSelected = false
-    }) {
+    getStyles({ feature, geoDrawingTask, isSelected = false }) {
       const tool = self.getTool({ feature, geoDrawingTask })
       const color = tool?.color || DEFAULT_COLOR
-
-      const strokeWidth = isSelected ? 4 : 3
-      const styles = []
-
-      styles.push(
-        new Style({
-          stroke: new Stroke({ color, width: strokeWidth })
-        })
-      )
+      const styles = [new Style({ stroke: new Stroke({ color, width: isSelected ? 4 : 3 }) })]
 
       if (isSelected) {
-        const coordinates = self.getCoordinates({ feature })
-        coordinates.forEach((coord) => {
-          styles.push(
-            new Style({
-              geometry: new OLPoint(coord),
-              image: new Circle({
-                radius: 5,
-                fill: new Fill({ color: 'white' }),
-                stroke: new Stroke({ color, width: 2 })
-              })
+        self.getCoordinates({ feature }).forEach((coord) => {
+          styles.push(new Style({
+            geometry: new OLPoint(coord),
+            image: new Circle({
+              radius: 5,
+              fill: new Fill({ color: 'white' }),
+              stroke: new Stroke({ color, width: 2 })
             })
-          )
+          }))
         })
       }
 

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/SegmentedLine.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/features/models/SegmentedLine/SegmentedLine.spec.jsx
@@ -152,6 +152,7 @@ describe('Model > SegmentedLine', function () {
         expect(styles[1].getImage()).to.exist
         expect(styles[2].getImage()).to.exist
       })
+
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.jsx
@@ -9,8 +9,10 @@ import styled, { css } from 'styled-components'
 
 import UNIT_CONVERSIONS from '@helpers/unitConversions'
 
+import InputStatus from '@plugins/tasks/components/InputStatus'
 import FeatureCard from './components/FeatureCard'
 import RadiusSlider from './components/RadiusSlider'
+import SegmentedLineIcon from './components/SegmentedLineIcon'
 
 const StyledText = styled(Text)`
   margin: 0;
@@ -55,21 +57,13 @@ const ToolIcon = styled(Location)`
   flex-shrink: 0;
 `
 
-function formatLineStringBounds(tool) {
-  if (tool?.type !== 'SegmentedLine') return null
-  const min = tool.min ?? 0
-  const max = tool.max
-  const minVertices = tool.min_vertices ?? 2
-  const maxVertices = tool.max_vertices
-  const hasConfiguredBounds = min > 0 || max != null || minVertices > 2 || maxVertices != null
-  if (!hasConfiguredBounds) return null
-  const linesText = max == null
-    ? `${min}+ lines`
-    : (min === max ? `${min} lines` : `${min}-${max} lines`)
-  const pointsText = maxVertices == null
-    ? `${minVertices}+ points per line`
-    : (minVertices === maxVertices ? `${minVertices} points per line` : `${minVertices}-${maxVertices} points per line`)
-  return `${linesText}, ${pointsText}`
+const SegmentedLineToolIcon = styled(SegmentedLineIcon)`
+  flex-shrink: 0;
+`
+
+const TOOL_ICONS = {
+  SegmentedLine: SegmentedLineToolIcon,
+  Point: ToolIcon
 }
 
 function GeoDrawingTask({
@@ -140,7 +134,8 @@ function GeoDrawingTask({
         const checked = task.activeToolIndex === index
         const currentRadius = task.activeOlFeature?.get?.('uncertainty_radius') ?? task.activeFeature?.properties?.uncertainty_radius
         const showUncertaintySlider = task.activeFeature && task.activeOlFeature && tool.uncertainty_circle && currentRadius !== null
-        const boundsText = formatLineStringBounds(tool)
+        const drawnCount = task.drawnCountForTool(index)
+        const ToolTypeIcon = TOOL_ICONS[tool.type] || ToolIcon
 
         return (
           <ToolLabel key={`${task.taskKey}_${index}`}>
@@ -155,16 +150,12 @@ function GeoDrawingTask({
             />
             <ToolCard pad='small' checked={checked}>
               <ToolHeader>
-                <ToolIcon color={tool.color} />
+                <ToolTypeIcon color={tool.color} />
                 <Text size='small'>
                   {task.strings.get(`tools.${index}.label`)}
                 </Text>
+                <InputStatus count={drawnCount} tool={tool} />
               </ToolHeader>
-              {boundsText && (
-                <Text size='xsmall' color='text-weak'>
-                  {boundsText}
-                </Text>
-              )}
               {showUncertaintySlider && (
                 <RadiusSlider
                   disabled={!checked || disabled}

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/GeoDrawingTask.spec.jsx
@@ -29,85 +29,33 @@ function renderTask(task) {
 }
 
 describe('Component > GeoDrawingTask', function () {
-  describe('LineString bounds subtitle — line-count permutations', function () {
-    it('no min + no max → subtitle suppressed', function () {
+  describe('tool input status (shared InputStatus)', function () {
+    it('no min + no max → "0 drawn"', function () {
       renderTask(buildLineStringTask())
-      expect(screen.queryByText(/points per line/)).to.not.exist
+      expect(screen.getByText('0 drawn')).to.exist
     })
 
-    it('no min + max → "0-N lines"', function () {
+    it('max only → "0 of N maximum drawn"', function () {
       renderTask(buildLineStringTask({ max: 4 }))
-      expect(screen.getByText('0-4 lines, 2+ points per line')).to.exist
+      expect(screen.getByText('0 of 4 maximum drawn')).to.exist
     })
 
-    it('min + no max → "N+ lines"', function () {
+    it('min only → "0 of N required drawn"', function () {
       renderTask(buildLineStringTask({ min: 2 }))
-      expect(screen.getByText('2+ lines, 2+ points per line')).to.exist
+      expect(screen.getByText('0 of 2 required drawn')).to.exist
     })
 
-    it('min + max → "N-M lines"', function () {
+    it('min + max → "0 of N required, M maximum drawn"', function () {
       renderTask(buildLineStringTask({ min: 1, max: 3 }))
-      expect(screen.getByText('1-3 lines, 2+ points per line')).to.exist
-    })
-  })
-
-  describe('LineString bounds subtitle — vertex permutations', function () {
-    it('no min_vertices + no max_vertices → subtitle suppressed', function () {
-      renderTask(buildLineStringTask())
-      expect(screen.queryByText(/points per line/)).to.not.exist
+      expect(screen.getByText('0 of 1 required, 3 maximum drawn')).to.exist
     })
 
-    it('no min_vertices + max_vertices → "2-N points per line"', function () {
-      renderTask(buildLineStringTask({ max_vertices: 10 }))
-      expect(screen.getByText('0+ lines, 2-10 points per line')).to.exist
+    it('coerces Panoptes string snapshots (min/max) through MST', function () {
+      renderTask(buildLineStringTask({ min: '1', max: '3' }))
+      expect(screen.getByText('0 of 1 required, 3 maximum drawn')).to.exist
     })
 
-    it('min_vertices (>2) + no max_vertices → "N+ points per line"', function () {
-      renderTask(buildLineStringTask({ min_vertices: 4 }))
-      expect(screen.getByText('0+ lines, 4+ points per line')).to.exist
-    })
-
-    it('min_vertices + max_vertices → "N-M points per line"', function () {
-      renderTask(buildLineStringTask({ min_vertices: 3, max_vertices: 10 }))
-      expect(screen.getByText('0+ lines, 3-10 points per line')).to.exist
-    })
-  })
-
-  describe('LineString bounds subtitle — edge cases', function () {
-    it('collapses "N-N lines" to "N lines" when min === max', function () {
-      renderTask(buildLineStringTask({ min: 3, max: 3 }))
-      expect(screen.getByText('3 lines, 2+ points per line')).to.exist
-    })
-
-    it('collapses "N-N points per line" to "N points per line" when min_vertices === max_vertices', function () {
-      renderTask(buildLineStringTask({ min_vertices: 5, max_vertices: 5 }))
-      expect(screen.getByText('0+ lines, 5 points per line')).to.exist
-    })
-
-    it('does NOT render the subtitle for explicit min_vertices: 2 (equals default)', function () {
-      renderTask(buildLineStringTask({ min_vertices: 2 }))
-      expect(screen.queryByText(/points per line/)).to.not.exist
-    })
-
-    it('coerces Panoptes string snapshots through MST and renders the numeric subtitle', function () {
-      renderTask(buildLineStringTask({ min: '1', max: '3', min_vertices: '3', max_vertices: '10' }))
-      expect(screen.getByText('1-3 lines, 3-10 points per line')).to.exist
-    })
-
-    it('suppresses the subtitle on non-LineString tools', function () {
-      const task = GeoDrawingTaskModel.create({
-        activeToolIndex: 0,
-        strings: { 'tools.0.label': 'Map Point' },
-        taskKey: 'T0',
-        tools: [{ color: '#ff0000', label: 'Map Point', type: 'Point' }],
-        type: 'geoDrawing'
-      })
-      renderTask(task)
-      expect(screen.getByText('Map Point')).to.exist
-      expect(screen.queryByText(/points per line/)).to.not.exist
-    })
-
-    it('renders one subtitle per LineString tool (multi-tool: Tool 0 bounded, Tool 1 unbounded)', function () {
+    it('renders one status per tool (multi-tool: Tool 0 bounded, Tool 1 unbounded)', function () {
       const task = GeoDrawingTaskModel.create({
         activeToolIndex: 0,
         strings: {
@@ -116,15 +64,15 @@ describe('Component > GeoDrawingTask', function () {
         },
         taskKey: 'T0',
         tools: [
-          { color: '#E65252', label: 'Segmented Line', type: 'SegmentedLine', min: 1, max: 3, min_vertices: 3, max_vertices: 10 },
+          { color: '#E65252', label: 'Segmented Line', type: 'SegmentedLine', min: 1, max: 3 },
           { color: '#F1AE45', label: 'Segmented Line 2', type: 'SegmentedLine' }
         ],
         type: 'geoDrawing'
       })
       renderTask(task)
-      expect(screen.getByText('1-3 lines, 3-10 points per line')).to.exist
+      expect(screen.getByText('0 of 1 required, 3 maximum drawn')).to.exist
+      expect(screen.getByText('0 drawn')).to.exist
       expect(screen.getByText('Segmented Line 2')).to.exist
-      expect(screen.getAllByText(/lines,/)).to.have.lengthOf(1)
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/components/SegmentedLineIcon/SegmentedLineIcon.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/components/SegmentedLineIcon/SegmentedLineIcon.jsx
@@ -1,0 +1,31 @@
+import { oneOfType, number, string } from 'prop-types'
+
+function SegmentedLineIcon({ className, color, size = 24 }) {
+  const stroke = color || 'currentColor'
+  return (
+    <svg
+      aria-hidden='true'
+      className={className}
+      fill='none'
+      height={size}
+      role='img'
+      viewBox='0 0 16 12'
+      width={size}
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path d='M1.78372 10.0158L5.88317 1.76869L10.8975 9.98045L14.1423 1.76868' stroke={stroke} />
+      <circle cx='10.8748' cy='9.87476' r='1.37476' fill={stroke} stroke={stroke} />
+      <circle cx='1.87476' cy='9.87476' r='1.37476' fill={stroke} stroke={stroke} />
+      <circle cx='5.87476' cy='1.87476' r='1.37476' fill={stroke} stroke={stroke} />
+      <circle cx='14.1252' cy='1.87476' r='1.37476' fill={stroke} stroke={stroke} />
+    </svg>
+  )
+}
+
+SegmentedLineIcon.propTypes = {
+  className: string,
+  color: string,
+  size: oneOfType([number, string])
+}
+
+export default SegmentedLineIcon

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/components/SegmentedLineIcon/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/components/components/SegmentedLineIcon/index.js
@@ -1,0 +1,1 @@
+export { default } from './SegmentedLineIcon'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.js
@@ -1,5 +1,5 @@
 import cuid from 'cuid'
-import { types } from 'mobx-state-tree'
+import { getRoot, types } from 'mobx-state-tree'
 import Task from '../../../../models/Task'
 import GeoDrawingAnnotation from './GeoDrawingAnnotation'
 import * as features from '../../features/models'
@@ -27,6 +27,15 @@ const GeoDrawing = types
   .views(self => ({
     get activeTool () {
       return self.tools[self.activeToolIndex]
+    },
+
+    get drawnFeatures () {
+      const annotation = getRoot(self)?.classifications?.annotation?.(self)
+      return annotation?.value?.features ?? []
+    },
+
+    drawnCountForTool (toolIndex) {
+      return self.drawnFeatures.filter(feature => feature?.properties?.toolIndex === toolIndex).length
     },
 
     defaultAnnotation(id = cuid()) {

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -184,6 +184,9 @@
         "placeholder": "latitude, longitude",
         "submit": "Go"
       },
+      "DeleteOverlay": {
+        "ariaLabel": "Delete selected feature"
+      },
       "MeasureButton": {
         "ariaLabel": "Measure distance"
       },


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #7368

## Describe your changes
- Add a delete interaction for LineString features following the existing Drawing Task `DeleteButton` convention; click the X to remove the line, hover hides the underlying first-vertex circle, and the X tracks drags/modifies
- Pressing Escape mid-sketch aborts an in-progress LineString; deleting a capped feature releases `max_lines` so the volunteer can redraw
- Major refactor of GeoMapViewer into 5 subsystem hooks (`useOLMap`, `useMapSelection`, `useMapInteractions`, `useMapCursor`, `useSelectionLayer`) so each FSM transition lives next to its siblings
- Normalize the OL interaction factories to self-install on the map and expose `{ setActive, destroy }`

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- n/a for this PR. End-to-end UX (delete affordance inside a real LineString workflow) lands when the Lab editor ships at the end of this milestone. Until then, the Storybook story below is the user-facing surface.

What user actions should my reviewer step through to review this PR?
- [x] run `pnpm storybook` in `packages/lib-classifier`, open `Subject Viewers / GeoMapViewer` -> `WithGeoDrawingLineStringTask`
- [x] draw a LineString; once finished, click it to select it. A small black X-in-circle should appear next to the start of the line, matching the X used by the Line drawing tool
- [x] hover the X: the first-vertex circle beneath it should disappear while you hover, then come back when you move off
- [x] drag the line (or drag its first vertex via the Modify interaction): the X should follow and stay anchored to the start vertex
- [x] start drawing a new line, place a couple of vertices, then press Escape: the in-progress sketch should disappear and the tool should be ready to start a fresh line
- [x] click the X: the line should disappear from the map and the X should disappear with it
- [x] click an empty area to deselect; if a line was selected the X should hide. Re-selecting the line should bring the X back at the start vertex
- [x] set `max_lines: 2` in the Controls panel, draw 2 lines, then delete one via the X; you should be able to draw a third line again (cap recovers)
- [x] confirm earlier-PR behaviors are intact: PR-5 vertex grab/drag still works; PR-6 vertex bounds still gate drawend; PR-7 cap + `not-allowed` cursor still apply
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `LineString.spec.jsx`, `GeoMapViewer.spec.jsx`, `LineStringTool.spec.jsx`, `GeoDrawingTask.spec.jsx`, `createGeoLineStringInteraction.spec.js`, and `createGeoLineStringModifyInteraction.spec.js` pass

Which storybook stories should be reviewed?
- `Subject Viewers / GeoMapViewer` -> `WithGeoDrawingLineStringTask`: http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-geo-drawing-line-string-task
- For visual reference, the same X icon convention used elsewhere: `Drawing Tools / Line` -> `Complete`: http://localhost:6006/?path=/story/drawing-tools-line--complete

Are there plans for follow up PR's to further fix this bug or develop this feature?
- Yes. This is PR 8 of 9 in the Segmented Line milestone. The remaining PR:
- [#7459 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7459) Panoptes-Front-End: Add LineString tool to GeoDrawing task editor