### PR TITLE
lib-classifier: Add tile_layers workflow config and TileLayer factory

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createTileLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createTileLayer.js
@@ -1,0 +1,57 @@
+import TileLayer from 'ol/layer/Tile'
+import WebGLTileLayer from 'ol/layer/WebGLTile'
+import OSM from 'ol/source/OSM'
+import GeoTIFF from 'ol/source/GeoTIFF'
+import TileWMS from 'ol/source/TileWMS'
+import XYZ from 'ol/source/XYZ'
+
+const DEFAULT_WMS_FORMAT = 'image/png'
+
+function createTileLayer (descriptor) {
+  const { type, url, params, attributions, format, projection } = descriptor || {}
+  let source
+
+  switch (type) {
+    case 'osm':
+      source = new OSM(attributions ? { attributions } : undefined)
+      break
+
+    case 'wms': {
+      if (!url) throw new Error('createTileLayer: wms descriptor requires a url')
+      if (!params?.LAYERS) {
+        throw new Error('createTileLayer: wms descriptor requires params.LAYERS')
+      }
+      source = new TileWMS({
+        url,
+        params: { ...params, FORMAT: format || params.FORMAT || DEFAULT_WMS_FORMAT },
+        ...(attributions ? { attributions } : {}),
+        ...(projection ? { projection } : {})
+      })
+      break
+    }
+
+    case 'xyz': {
+      if (!url) throw new Error('createTileLayer: xyz descriptor requires a url')
+      source = new XYZ({
+        url,
+        ...(attributions ? { attributions } : {}),
+        ...(projection ? { projection } : {})
+      })
+      break
+    }
+
+    case 'cog': {
+      if (!url) throw new Error('createTileLayer: cog descriptor requires a url')
+      const cogSource = new GeoTIFF({ sources: [{ url }] })
+      if (attributions) cogSource.setAttributions(attributions)
+      return new WebGLTileLayer({ source: cogSource })
+    }
+
+    default:
+      throw new Error(`createTileLayer: unknown descriptor type "${type}"`)
+  }
+
+  return new TileLayer({ preload: 1, source })
+}
+
+export default createTileLayer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createTileLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createTileLayer.spec.js
@@ -1,0 +1,157 @@
+import TileLayer from 'ol/layer/Tile'
+import WebGLTileLayer from 'ol/layer/WebGLTile'
+import OSM from 'ol/source/OSM'
+import GeoTIFF from 'ol/source/GeoTIFF'
+import TileWMS from 'ol/source/TileWMS'
+import XYZ from 'ol/source/XYZ'
+import createTileLayer from './createTileLayer'
+
+describe('helpers > createTileLayer', function () {
+  it('builds an OSM tile layer for type osm', function () {
+    const layer = createTileLayer({ type: 'osm', label: 'OpenStreetMap' })
+    expect(layer).to.be.instanceOf(TileLayer)
+    expect(layer.getSource()).to.be.instanceOf(OSM)
+  })
+
+  it('builds a WMS tile layer for type wms', function () {
+    const layer = createTileLayer({
+      type: 'wms',
+      url: 'https://imageserver.gisdata.mn.gov/cgi-bin/wms?',
+      params: { LAYERS: 'fsa2023' }
+    })
+    expect(layer).to.be.instanceOf(TileLayer)
+    expect(layer.getSource()).to.be.instanceOf(TileWMS)
+    expect(layer.getSource().getParams().LAYERS).to.equal('fsa2023')
+  })
+
+  it('builds an XYZ tile layer for type xyz', function () {
+    const layer = createTileLayer({
+      type: 'xyz',
+      url: 'https://tiles.example.com/{z}/{x}/{y}.png'
+    })
+    expect(layer).to.be.instanceOf(TileLayer)
+    expect(layer.getSource()).to.be.instanceOf(XYZ)
+  })
+
+  it('builds a WebGL tile layer with a GeoTIFF source for type cog', function () {
+    const layer = createTileLayer({
+      type: 'cog',
+      url: 'https://example.com/imagery/cog.tif'
+    })
+    expect(layer).to.be.instanceOf(WebGLTileLayer)
+    expect(layer.getSource()).to.be.instanceOf(GeoTIFF)
+  })
+
+  it('sets attributions on a cog GeoTIFF source', function () {
+    const layer = createTileLayer({
+      type: 'cog',
+      url: 'https://example.com/imagery/cog.tif',
+      attributions: 'MnGeo'
+    })
+    expect(layer.getSource().getAttributions()).to.be.a('function')
+  })
+
+  it('throws when cog descriptor omits url', function () {
+    expect(() => createTileLayer({ type: 'cog' })).to.throw(/url/i)
+  })
+
+  it('defaults wms FORMAT to image/png when neither format nor params.FORMAT is set', function () {
+    const layer = createTileLayer({
+      type: 'wms',
+      url: 'https://example.org/wms',
+      params: { LAYERS: 'foo' }
+    })
+    expect(layer.getSource().getParams().FORMAT).to.equal('image/png')
+  })
+
+  it('uses the first-class format field for wms FORMAT', function () {
+    const layer = createTileLayer({
+      type: 'wms',
+      format: 'image/jpeg',
+      url: 'https://imageserver.gisdata.mn.gov/cgi-bin/wms?',
+      params: { LAYERS: 'fsa2023' }
+    })
+    expect(layer.getSource().getParams().FORMAT).to.equal('image/jpeg')
+  })
+
+  it('falls back to params.FORMAT when no first-class format is set', function () {
+    const layer = createTileLayer({
+      type: 'wms',
+      url: 'https://example.org/wms',
+      params: { LAYERS: 'foo', FORMAT: 'image/png8' }
+    })
+    expect(layer.getSource().getParams().FORMAT).to.equal('image/png8')
+  })
+
+  it('prefers the first-class format field over params.FORMAT', function () {
+    const layer = createTileLayer({
+      type: 'wms',
+      format: 'image/jpeg',
+      url: 'https://example.org/wms',
+      params: { LAYERS: 'foo', FORMAT: 'image/png' }
+    })
+    expect(layer.getSource().getParams().FORMAT).to.equal('image/jpeg')
+  })
+
+  it('passes a projection through to a wms source', function () {
+    const layer = createTileLayer({
+      type: 'wms',
+      url: 'https://example.org/wms',
+      params: { LAYERS: 'foo' },
+      projection: 'EPSG:4326'
+    })
+    expect(layer.getSource().getProjection().getCode()).to.equal('EPSG:4326')
+  })
+
+  it('passes a projection through to an xyz source', function () {
+    const layer = createTileLayer({
+      type: 'xyz',
+      url: 'https://tiles.example.com/{z}/{x}/{y}.png',
+      projection: 'EPSG:4326'
+    })
+    expect(layer.getSource().getProjection().getCode()).to.equal('EPSG:4326')
+  })
+
+  it('defaults an xyz source to EPSG:3857 when no projection is set', function () {
+    const layer = createTileLayer({
+      type: 'xyz',
+      url: 'https://tiles.example.com/{z}/{x}/{y}.png'
+    })
+    expect(layer.getSource().getProjection().getCode()).to.equal('EPSG:3857')
+  })
+
+  it('accepts a projection on a cog descriptor without throwing (applied at render)', function () {
+    const layer = createTileLayer({
+      type: 'cog',
+      url: 'https://example.com/imagery/cog.tif',
+      projection: 'EPSG:26915'
+    })
+    expect(layer).to.be.instanceOf(WebGLTileLayer)
+  })
+
+  it('passes attributions through to the source', function () {
+    const layer = createTileLayer({
+      type: 'wms',
+      url: 'https://example.org/wms',
+      params: { LAYERS: 'foo' },
+      attributions: 'MnGeo'
+    })
+    expect(layer.getSource().getAttributions()).to.be.a('function')
+  })
+
+  it('throws when wms descriptor omits url', function () {
+    expect(() => createTileLayer({ type: 'wms', params: { LAYERS: 'foo' } })).to.throw(/url/i)
+  })
+
+  it('throws when wms descriptor omits params.LAYERS', function () {
+    expect(() => createTileLayer({ type: 'wms', url: 'https://example.org/wms' })).to.throw(/LAYERS/i)
+  })
+
+  it('throws when xyz descriptor omits url', function () {
+    expect(() => createTileLayer({ type: 'xyz' })).to.throw(/url/i)
+  })
+
+  it('throws on an unknown descriptor type', function () {
+    expect(() => createTileLayer({ type: 'bogus' })).to.throw(/unknown descriptor type/i)
+  })
+})

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.spec.js
@@ -83,6 +83,78 @@ describe('Model > Workflow', function () {
     })
   })
 
+  describe('with subject_viewer_config.tile_layers', function () {
+    const tileLayers = [
+      { type: 'osm', label: 'OpenStreetMap' },
+      {
+        type: 'wms',
+        label: '2023 imagery',
+        url: 'https://imageserver.gisdata.mn.gov/cgi-bin/wms',
+        params: { LAYERS: 'fsa2023' },
+        attributions: 'MnGeo'
+      },
+      {
+        type: 'xyz',
+        label: 'Custom XYZ tiles',
+        url: 'https://tiles.example.com/{z}/{x}/{y}.png'
+      }
+    ]
+
+    it('should round-trip a populated tile_layers array on a geoMap workflow', function () {
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'workflow1',
+        configuration: {
+          subject_viewer: 'geoMap',
+          subject_viewer_config: {
+            tile_layers: tileLayers
+          }
+        },
+        display_name: 'A test geoMap workflow with configured tile layers',
+        version: '0.0'
+      })
+      const workflow = Workflow.create(workflowSnapshot)
+      expect(workflow.configuration.subject_viewer_config.tile_layers).to.deep.equal(tileLayers)
+    })
+
+    it('should accept an empty tile_layers array', function () {
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'workflow1',
+        configuration: {
+          subject_viewer: 'geoMap',
+          subject_viewer_config: {
+            tile_layers: []
+          }
+        },
+        display_name: 'A test geoMap workflow with no configured tile layers',
+        version: '0.0'
+      })
+      const workflow = Workflow.create(workflowSnapshot)
+      expect(workflow.configuration.subject_viewer_config.tile_layers).to.deep.equal([])
+    })
+
+    it('should be valid when tile_layers is omitted entirely (back-compat)', function () {
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'workflow1',
+        configuration: {
+          subject_viewer: 'geoMap',
+          subject_viewer_config: {
+            zoomConfiguration: {
+              direction: 'both',
+              minZoom: 1,
+              maxZoom: 10,
+              zoomInValue: 1.2,
+              zoomOutValue: 0.8
+            }
+          }
+        },
+        display_name: 'A test geoMap workflow without tile_layers',
+        version: '0.0'
+      })
+      const workflow = Workflow.create(workflowSnapshot)
+      expect(workflow.configuration.subject_viewer_config.tile_layers).to.equal(undefined)
+    })
+  })
+
   describe('workflow steps', function () {
     let step
     const task = MultipleChoiceTaskFactory.build({ taskKey: 'T1' })

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -36,7 +36,8 @@ const WorkflowConfiguration = types.snapshotProcessor(
             zoomInValue: types.number,
             zoomOutValue: types.number
           })
-        )
+        ),
+        tile_layers: types.maybe(types.frozen([]))
       })
     )
   })


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #7382
- Closes #7377

## Describe your changes
- add a `tile_layers` field to the geoMap `subject_viewer_config`, an array of basemap layer descriptors (empty by default, so existing geoMap workflows are unchanged)
- add a `createTileLayer` factory that builds an OpenLayers layer from a descriptor: `osm`, `wms`, and `xyz` render through `TileLayer`; `cog` (Cloud Optimized GeoTIFF) renders through `WebGLTile` over a `GeoTIFF` source
- default the WMS `FORMAT` to `image/png`, overridable per layer via a `format` field (or `params.FORMAT`)
- pass an optional per-layer `projection` through to the `wms` and `xyz` sources
- throw on an unknown type or a missing required field (`url` for wms/xyz/cog, `params.LAYERS` for wms) so a misconfigured layer surfaces early
- combines the config field (#7382) and the factory (#7377) in one PR, since the factory is where the descriptor shape is actually enforced

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- n/a for this PR. It is the workflow-config schema plus the layer factory, neither of which renders yet. Configured layers first render in #7384, and the Lab editor to author them lands later in the milestone.

What user actions should my reviewer step through to review this PR?
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `createTileLayer.spec.js` and `Workflow.spec.js` pass
- [x] read `helpers/createTileLayer.js`: confirm `osm`/`wms`/`xyz` build a `TileLayer` and `cog` builds a `WebGLTile` over a `GeoTIFF` source
- [x] confirm the WMS `FORMAT` precedence: a `format` field wins, else `params.FORMAT`, else `image/png`
- [x] confirm a geoMap workflow with no `tile_layers` is unchanged (back-compat case in `Workflow.spec.js`)

Which storybook stories should be reviewed?
- n/a for this PR. The factory is not wired into the viewer yet, so there is no story to show; the first story and render land in #7384.

Are there plans for follow up PR's to further fix this bug or develop this feature?
- Yes. This is PR 1 of 9 in the Map Layers milestone. Sequential PRs that follow this one (in merge order):
- [#7383](https://github.com/zooniverse/front-end-monorepo/issues/7383) lib-classifier: Add storeMapper to read tile_layers from workflow configuration
- [#7384](https://github.com/zooniverse/front-end-monorepo/issues/7384) lib-classifier: Build and render configured tile layers in GeoMapViewer
- [#7379](https://github.com/zooniverse/front-end-monorepo/issues/7379) lib-classifier: Add LayerControl component for layer switching
- [#7380](https://github.com/zooniverse/front-end-monorepo/issues/7380) lib-classifier: Swap active layer visibility and filter features by activeLayerIndex
- [#7381](https://github.com/zooniverse/front-end-monorepo/issues/7381) lib-classifier: Clear selected features on layer switch
- [#7462 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7462) Panoptes-Front-End: Add tile layer entry editor to GeoDrawing workflow config
- [#7463 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7463) Panoptes-Front-End: Add WMS and XYZ URL validation for tile layer entries
- [#7464 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7464) Panoptes-Front-End: Add basemap selector to GeoDrawing workflow config

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
