### PR TITLE
fix(app-project): project stats link is now internal

### DIFF
--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.jsx
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.jsx
@@ -89,8 +89,8 @@ const ProjectStatisticsContainer = ({ className, hideLink = false }) => {
   const owner = router?.query?.owner
   const project = router?.query?.project
   const linkProps = {
-    externalLink: true, // A project stats page uses PFE
-    href: `/projects/${owner}/${project}/stats`
+    externalLink: false,
+    href: `/${owner}/${project}/stats`
   }
 
   return (


### PR DESCRIPTION
Switch the project stats link over to an internal link (using `next/link`.)

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project
## Linked Issue and/or Talk Post
- closes #7473.

## How to Review
https://local.zooniverse.org:3000/projects/fr/nora-dot-eisner/planet-hunters-tess now links to the French statistics page.

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
