### PR TITLE
lib-classifier: Build and render configured tile layers in GeoMapViewer

### DIFF
--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -52,6 +52,7 @@
     "mobx-state-tree": "~5.4.0",
     "mst-middlewares": "~6.1.0",
     "ol": "^10.7.0",
+    "proj4": "^2.20.8",
     "react-i18next": "~14.1.0",
     "react-player": "~2.13.0",
     "react-resize-detector": "~9.1.0",

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -1,6 +1,6 @@
 import { Box } from 'grommet'
 import { observer } from 'mobx-react'
-import { arrayOf, func, shape, string } from 'prop-types'
+import { arrayOf, bool, func, shape, string } from 'prop-types'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import GeoJSON from 'ol/format/GeoJSON'
@@ -65,12 +65,16 @@ function sanitizeProperties(properties = {}) {
   )
 }
 
+const EMPTY_TILE_LAYERS = []
+
 function GeoMapViewer({
   geoDrawingTask,
   geoJSON = undefined,
   onFeaturesChange = undefined,
   onMapExtentChange = undefined,
-  onSelectedFeatureChange = undefined
+  onMapReady = undefined,
+  onSelectedFeatureChange = undefined,
+  tileLayers = EMPTY_TILE_LAYERS
 }) {
   const [isMeasureModeActive, setIsMeasureModeActive] = useState(false)
   const [selectedUnit, setSelectedUnit] = useState('meters')
@@ -81,7 +85,7 @@ function GeoMapViewer({
   const hasGeoDrawingTask = !!(geoDrawingTask && geoDrawingTask.tools.length > 0)
   const activeToolType = geoDrawingTask?.activeTool?.type
 
-  const { map, source, layer, scaleLine } = useOLMap(containerRef)
+  const { map, source, layer, scaleLine } = useOLMap(containerRef, tileLayers)
 
   const { select, translate } = useMapSelection({
     map,
@@ -131,6 +135,10 @@ function GeoMapViewer({
     activeToolType,
     isMeasureModeActive
   })
+
+  useEffect(() => {
+    if (map && onMapReady) onMapReady(map)
+  }, [map, onMapReady])
 
   useEffect(() => {
     loadGeoJSON({ map, source, select, measure, data: geoJSON })
@@ -248,7 +256,18 @@ GeoMapViewer.propTypes = {
   geoJSON: shape({}),
   onFeaturesChange: func,
   onMapExtentChange: func,
-  onSelectedFeatureChange: func
+  onMapReady: func,
+  onSelectedFeatureChange: func,
+  tileLayers: arrayOf(shape({
+    type: string.isRequired,
+    label: string,
+    url: string,
+    params: shape({}),
+    attributions: string,
+    format: string,
+    projection: string,
+    default: bool
+  }))
 }
 
 export default observer(GeoMapViewer)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.spec.jsx
@@ -1,5 +1,6 @@
 import { composeStory } from '@storybook/react'
 import { render, screen, waitFor } from '@testing-library/react'
+import TileLayer from 'ol/layer/Tile'
 import Meta, { Default, WithGeoDrawingTask, WithoutGeoDrawingTask } from './GeoMapViewer.stories'
 
 const DefaultStory = composeStory(Default, Meta)
@@ -77,6 +78,50 @@ describe('Component > GeoMapViewer', function () {
       unmount()
       
       expect(screen.queryByRole('region', { name: 'Interactive map' })).to.not.exist
+    })
+  })
+
+  describe('configured tile layers', function () {
+    const twoLayers = [
+      { type: 'osm', label: 'OpenStreetMap' },
+      { type: 'wms', label: 'imagery', url: 'https://example.org/wms', params: { LAYERS: 'foo' } }
+    ]
+
+    function baseLayers (map) {
+      // basemap tile layers are TileLayers; the feature + selection layers are VectorLayers
+      return map.getLayers().getArray().filter(layer => layer instanceof TileLayer)
+    }
+
+    it('falls back to a single OSM base layer when no tile_layers are configured', async function () {
+      let map = null
+      render(<DefaultStory onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      expect(baseLayers(map)).to.have.lengthOf(1)
+    })
+
+    it('builds one base tile layer per configured descriptor', async function () {
+      let map = null
+      render(<DefaultStory tileLayers={twoLayers} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      expect(baseLayers(map)).to.have.lengthOf(2)
+    })
+
+    it('shows only the first configured layer by default', async function () {
+      let map = null
+      render(<DefaultStory tileLayers={twoLayers} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      expect(baseLayers(map).map(layer => layer.getVisible())).to.deep.equal([true, false])
+    })
+
+    it('shows the layer marked default instead of the first', async function () {
+      const withDefault = [
+        { type: 'osm', label: 'OpenStreetMap' },
+        { type: 'wms', label: 'imagery', url: 'https://example.org/wms', params: { LAYERS: 'foo' }, default: true }
+      ]
+      let map = null
+      render(<DefaultStory tileLayers={withDefault} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      expect(baseLayers(map).map(layer => layer.getVisible())).to.deep.equal([false, true])
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -1,3 +1,6 @@
+import { useEffect, useMemo, useState } from 'react'
+import { fromLonLat } from 'ol/proj'
+
 import GeoMapViewer from './GeoMapViewer'
 
 import GeoDrawingTask from '@plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask'
@@ -9,6 +12,66 @@ export default {
 
 export const Default = {
   args: {},
+}
+
+const MULTI_LAYERS = [
+  { type: 'osm', label: 'OpenStreetMap' },
+  {
+    type: 'xyz',
+    label: 'OpenTopoMap',
+    url: 'https://a.tile.opentopomap.org/{z}/{x}/{y}.png',
+    attributions: '© OpenTopoMap (CC-BY-SA)'
+  },
+  {
+    type: 'wms',
+    label: 'MnGeo 2023 imagery',
+    url: 'https://imageserver.gisdata.mn.gov/cgi-bin/wms?',
+    params: { LAYERS: 'fsa2023' },
+    format: 'image/jpeg',
+    attributions: 'MnGeo'
+  },
+  {
+    type: 'cog',
+    label: 'NAIP 2023 (COG)',
+    url: 'https://naipeuwest.blob.core.windows.net/naip/v002/mn/2023/mn_030cm_2023/48091/m_4809149_se_15_030_20230830_20240228.tif',
+    attributions: 'USDA NAIP'
+  }
+]
+
+const LAYER_LABELS = MULTI_LAYERS.reduce((labels, layer) => ({ ...labels, [layer.type]: layer.label }), {})
+
+const COG_CENTER = [-91.906, 48.156]
+
+function MultiLayerStory({ visibleLayer }) {
+  const [map, setMap] = useState(null)
+  const tileLayers = useMemo(
+    () => MULTI_LAYERS.map(layer => ({ ...layer, default: layer.type === visibleLayer })),
+    [visibleLayer]
+  )
+
+  useEffect(() => {
+    if (!map) return
+    map.getView().setCenter(fromLonLat(COG_CENTER))
+    map.getView().setZoom(14)
+  }, [map, visibleLayer])
+
+  return (
+    <GeoMapViewer onMapReady={setMap} tileLayers={tileLayers} />
+  )
+}
+
+export const WithMultipleLayers = {
+  args: { visibleLayer: 'osm' },
+  argTypes: {
+    visibleLayer: {
+      name: 'Visible layer',
+      description: 'Which configured basemap is shown (preview of layer switching)',
+      control: 'select',
+      options: MULTI_LAYERS.map(layer => layer.type),
+      labels: LAYER_LABELS
+    }
+  },
+  render: ({ visibleLayer }) => <MultiLayerStory visibleLayer={visibleLayer} />,
 }
 
 export const WithGeoDrawingTask = {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.jsx
@@ -8,7 +8,9 @@ import { useStores, useSubjectJSON } from '@hooks'
 import GeoMapViewer from './GeoMapViewer'
 import ReferenceData from './components/ReferenceData'
 
-function storeMapper(classifierStore) {
+const EMPTY_TILE_LAYERS = []
+
+export function storeMapper(classifierStore) {
   const {
     subjects: {
       active: subject
@@ -21,13 +23,16 @@ function storeMapper(classifierStore) {
     }
   } = classifierStore
 
+  const tileLayers = classifierStore.workflows?.active?.configuration?.subject_viewer_config?.tile_layers || EMPTY_TILE_LAYERS
+
   const latest = subject?.stepHistory.latest
 
   return {
     activeStepTasks,
     latest,
     loadingState,
-    subject
+    subject,
+    tileLayers
   }
 }
 
@@ -41,7 +46,8 @@ function GeoMapViewerContainer ({
     activeStepTasks,
     latest,
     loadingState,
-    subject
+    subject,
+    tileLayers
   } = useStores(storeMapper)
   const {
     data,
@@ -114,6 +120,7 @@ function GeoMapViewerContainer ({
         geoDrawingTask={geoDrawingTask}
         geoJSON={geoJSONData}
         subjectId={subject.id}
+        tileLayers={tileLayers}
         onFeaturesChange={handleFeaturesChange}
         onMapExtentChange={handleMapExtentChange}
         onSelectedFeatureChange={handleSelectedFeatureChange}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.spec.jsx
@@ -1,0 +1,79 @@
+import { storeMapper } from './GeoMapViewerContainer'
+
+function buildStore (overrides = {}) {
+  return {
+    subjects: { active: { id: 'subject-1', stepHistory: { latest: null } } },
+    subjectViewer: { loadingState: 'success' },
+    workflowSteps: { activeStepTasks: [] },
+    workflows: {
+      active: {
+        configuration: {
+          subject_viewer: 'geoMap',
+          subject_viewer_config: {}
+        }
+      }
+    },
+    ...overrides
+  }
+}
+
+describe('Component > GeoMapViewerContainer > storeMapper', function () {
+  it('forwards tile_layers from subject_viewer_config as the tileLayers prop', function () {
+    const tileLayers = [
+      { type: 'osm', label: 'OpenStreetMap' },
+      {
+        type: 'wms',
+        label: '2023 imagery',
+        url: 'https://imageserver.gisdata.mn.gov/cgi-bin/wms',
+        params: { LAYERS: 'fsa2023' }
+      }
+    ]
+    const store = buildStore({
+      workflows: {
+        active: {
+          configuration: {
+            subject_viewer: 'geoMap',
+            subject_viewer_config: { tile_layers: tileLayers }
+          }
+        }
+      }
+    })
+    const result = storeMapper(store)
+    expect(result.tileLayers).to.deep.equal(tileLayers)
+  })
+
+  it('returns an empty tileLayers array when subject_viewer_config has no tile_layers', function () {
+    const result = storeMapper(buildStore())
+    expect(result.tileLayers).to.deep.equal([])
+  })
+
+  it('returns an empty tileLayers array when subject_viewer_config is missing', function () {
+    const result = storeMapper(buildStore({
+      workflows: {
+        active: {
+          configuration: { subject_viewer: 'geoMap' }
+        }
+      }
+    }))
+    expect(result.tileLayers).to.deep.equal([])
+  })
+
+  it('returns an empty tileLayers array when no workflow is active', function () {
+    const result = storeMapper(buildStore({ workflows: { active: undefined } }))
+    expect(result.tileLayers).to.deep.equal([])
+  })
+
+  it('preserves the existing storeMapper outputs (subject, loadingState, activeStepTasks, latest)', function () {
+    const subject = { id: 'subject-2', stepHistory: { latest: { foo: 'bar' } } }
+    const activeStepTasks = [{ type: 'geoDrawing' }]
+    const result = storeMapper(buildStore({
+      subjects: { active: subject },
+      subjectViewer: { loadingState: 'loading' },
+      workflowSteps: { activeStepTasks }
+    }))
+    expect(result.subject).to.equal(subject)
+    expect(result.loadingState).to.equal('loading')
+    expect(result.activeStepTasks).to.equal(activeStepTasks)
+    expect(result.latest).to.deep.equal({ foo: 'bar' })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createTileLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createTileLayer.js
@@ -5,6 +5,8 @@ import GeoTIFF from 'ol/source/GeoTIFF'
 import TileWMS from 'ol/source/TileWMS'
 import XYZ from 'ol/source/XYZ'
 
+import './registerProjections'
+
 const DEFAULT_WMS_FORMAT = 'image/png'
 
 function createTileLayer (descriptor) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/registerProjections.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/registerProjections.js
@@ -1,0 +1,10 @@
+import proj4 from 'proj4'
+import { register } from 'ol/proj/proj4'
+
+// OL only ships EPSG:4326 and EPSG:3857; register the non-web-mercator CRS our COG tile layers use.
+const PROJ4_DEFS = {
+  'EPSG:26915': '+proj=utm +zone=15 +datum=NAD83 +units=m +no_defs'
+}
+
+Object.entries(PROJ4_DEFS).forEach(([code, definition]) => proj4.defs(code, definition))
+register(proj4)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/registerProjections.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/registerProjections.spec.js
@@ -1,0 +1,8 @@
+import { get as getProjection } from 'ol/proj'
+import './registerProjections'
+
+describe('helpers > registerProjections', function () {
+  it('registers EPSG:26915 (UTM 15N) so non-web-mercator COGs can reproject', function () {
+    expect(getProjection('EPSG:26915')).to.not.equal(null)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react'
 import { Map, View } from 'ol'
 import { defaults as defaultControls } from 'ol/control/defaults'
 import ScaleLine from 'ol/control/ScaleLine'
-import TileLayer from 'ol/layer/Tile'
 import VectorLayer from 'ol/layer/Vector'
-import OSM from 'ol/source/OSM'
 import VectorSource from 'ol/source/Vector'
 
-export default function useOLMap(containerRef) {
+import createTileLayer from '../helpers/createTileLayer'
+
+export default function useOLMap(containerRef, tileLayers = []) {
   const [state, setState] = useState({ map: null, source: null, layer: null, scaleLine: null })
 
   useEffect(() => {
@@ -16,12 +16,15 @@ export default function useOLMap(containerRef) {
     const source = new VectorSource({ features: [] })
     const layer = new VectorLayer({ source })
     const scaleLine = new ScaleLine()
+
+    const descriptors = tileLayers.length > 0 ? tileLayers : [{ type: 'osm' }]
+    const baseTileLayers = descriptors.map(createTileLayer)
+    const defaultLayerIndex = Math.max(0, descriptors.findIndex(descriptor => descriptor?.default))
+    baseTileLayers.forEach((tileLayer, index) => tileLayer.setVisible(index === defaultLayerIndex))
+
     const map = new Map({
       target: containerRef.current,
-      layers: [
-        new TileLayer({ preload: 1, source: new OSM() }),
-        layer
-      ],
+      layers: [...baseTileLayers, layer],
       view: new View({ center: [0, 0], zoom: 0 }),
       controls: defaultControls({ zoom: false }).extend([scaleLine])
     })
@@ -32,7 +35,7 @@ export default function useOLMap(containerRef) {
       map.setTarget(undefined)
       setState({ map: null, source: null, layer: null, scaleLine: null })
     }
-  }, [containerRef])
+  }, [containerRef, tileLayers])
 
   return state
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ~10.27.0
-        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.105.0)
       '@sindresorhus/string-hash':
         specifier: ~1.2.0
         version: 1.2.0
@@ -85,7 +85,7 @@ importers:
         version: 15.4.2(@types/react@19.2.7)(i18next@24.2.3(typescript@5.9.3))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       nuqs:
         specifier: ^2.8.5
-        version: 2.8.5(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 2.8.5(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       ol:
         specifier: ^10.7.0
         version: 10.7.0
@@ -119,7 +119,7 @@ importers:
         version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/nextjs':
         specifier: ~9.1.16
-        version: 9.1.16(esbuild@0.25.12)(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+        version: 9.1.16(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
       '@storybook/react':
         specifier: ~9.1.16
         version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
@@ -224,7 +224,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       nuqs:
         specifier: ^2.8.5
-        version: 2.8.5(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 2.8.5(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       panoptes-client:
         specifier: ~5.6.0
         version: 5.6.2
@@ -343,6 +343,9 @@ importers:
       ol:
         specifier: ^10.7.0
         version: 10.7.0
+      proj4:
+        specifier: ^2.20.8
+        version: 2.20.8
       react-i18next:
         specifier: ~14.1.0
         version: 14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -391,7 +394,7 @@ importers:
         version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+        version: 9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
       '@testing-library/dom':
         specifier: ~10.4.1
         version: 10.4.1
@@ -511,7 +514,7 @@ importers:
         version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
       webpack:
         specifier: ~5.104.1
-        version: 5.104.1(webpack-cli@6.0.1)
+        version: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ~6.0.1
         version: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
@@ -584,7 +587,7 @@ importers:
         version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/nextjs':
         specifier: ~9.1.16
-        version: 9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
+        version: 9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(postcss@8.5.6))
       '@storybook/react':
         specifier: ~9.1.16
         version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
@@ -758,7 +761,7 @@ importers:
         version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@testing-library/dom':
         specifier: ~10.4.1
         version: 10.4.1
@@ -824,7 +827,7 @@ importers:
         version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
       webpack:
         specifier: ~5.104.1
-        version: 5.104.1(webpack-cli@6.0.1)
+        version: 5.104.1
 
   packages/lib-subject-viewers:
     dependencies:
@@ -873,7 +876,7 @@ importers:
         version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ~4.4.1
         version: 4.4.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
@@ -6520,6 +6523,9 @@ packages:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
 
+  mgrs@1.0.0:
+    resolution: {integrity: sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -7266,6 +7272,9 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  proj4@2.20.8:
+    resolution: {integrity: sha512-1C8sfT4xY4PAPwk0MroFBTGF4R4bzDXdmPQTGYVLsoNssrZ9odzObxS2dTeGBty8jW8KO7h16C1Hs2JP+ctfFw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -8855,6 +8864,9 @@ packages:
   winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
     engines: {node: '>= 12.0.0'}
+
+  wkt-parser@1.5.5:
+    resolution: {integrity: sha512-/zMYi94/7D7fxcOSlVmWn6vnOMj3Gq5d1xvVjaYOS9n6h0qOJ4I7YYVxBWYcH1vq9+suhqzXkn05Yx47zQNUIA==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -10918,7 +10930,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(postcss@8.5.6))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.47.0
@@ -10928,10 +10940,10 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     optionalDependencies:
       type-fest: 4.41.0
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6))
       webpack-hot-middleware: 2.26.1
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)':
@@ -11193,7 +11205,7 @@ snapshots:
 
   '@sentry/core@10.27.0': {}
 
-  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))':
+  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.105.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -11205,7 +11217,7 @@ snapshots:
       '@sentry/opentelemetry': 10.27.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)
       '@sentry/react': 10.27.0(react@19.2.0)
       '@sentry/vercel-edge': 10.27.0
-      '@sentry/webpack-plugin': 4.6.1(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      '@sentry/webpack-plugin': 4.6.1(webpack@5.105.0)
       next: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       resolve: 1.22.8
       rollup: 4.53.3
@@ -11297,12 +11309,12 @@ snapshots:
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@sentry/core': 10.27.0
 
-  '@sentry/webpack-plugin@4.6.1(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))':
+  '@sentry/webpack-plugin@4.6.1(webpack@5.105.0)':
     dependencies:
       '@sentry/bundler-plugin-core': 4.6.1
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11352,22 +11364,22 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/builder-webpack5@9.1.16(esbuild@0.25.12)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@9.1.16(esbuild@0.25.12)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
     dependencies:
       '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 6.11.0(webpack@5.104.1(esbuild@0.25.12))
+      css-loader: 6.11.0(webpack@5.104.1)
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.12))
-      html-webpack-plugin: 5.6.5(webpack@5.104.1(esbuild@0.25.12))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1)
+      html-webpack-plugin: 5.6.5(webpack@5.104.1)
       magic-string: 0.30.21
       storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
-      style-loader: 3.3.4(webpack@5.104.1(esbuild@0.25.12))
-      terser-webpack-plugin: 5.3.14(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12))
+      style-loader: 3.3.4(webpack@5.104.1)
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.12)(webpack@5.104.1)
       ts-dedent: 2.2.0
-      webpack: 5.104.1(esbuild@0.25.12)
-      webpack-dev-middleware: 6.1.3(webpack@5.104.1(esbuild@0.25.12))
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
+      webpack-dev-middleware: 6.1.3(webpack@5.104.1)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -11379,7 +11391,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
+  '@storybook/builder-webpack5@9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
     dependencies:
       '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -11393,7 +11405,7 @@ snapshots:
       style-loader: 3.3.4(webpack@5.104.1)
       terser-webpack-plugin: 5.3.14(webpack@5.104.1)
       ts-dedent: 2.2.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1
       webpack-dev-middleware: 6.1.3(webpack@5.104.1)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
@@ -11418,7 +11430,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/nextjs@9.1.16(esbuild@0.25.12)(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))':
+  '@storybook/nextjs@9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(postcss@8.5.6))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
@@ -11433,33 +11445,33 @@ snapshots:
       '@babel/preset-react': 7.27.1(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/runtime': 7.28.4
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
-      '@storybook/builder-webpack5': 9.1.16(esbuild@0.25.12)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(postcss@8.5.6))
+      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
-      css-loader: 6.11.0(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0(postcss@8.5.6))
+      css-loader: 6.11.0(webpack@5.105.0(postcss@8.5.6))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      next: 14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.0(postcss@8.5.6))
       postcss: 8.5.6
-      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0(postcss@8.5.6))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 16.0.6(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      sass-loader: 16.0.6(webpack@5.105.0(postcss@8.5.6))
       semver: 7.7.3
       storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
-      style-loader: 3.3.4(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      style-loader: 3.3.4(webpack@5.105.0(postcss@8.5.6))
       styled-jsx: 5.1.7(@babel/core@7.28.5)(react@19.2.0)
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -11494,8 +11506,8 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/runtime': 7.28.4
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
-      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
-      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@types/semver': 7.7.1
       babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0)
@@ -11538,31 +11550,67 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
+  '@storybook/nextjs@9.1.16(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)':
     dependencies:
-      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.12))
+      '@babel/core': 7.28.5
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.28.5)
+      '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
+      '@babel/preset-react': 7.27.1(@babel/core@7.28.5)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
+      '@babel/runtime': 7.28.4
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
+      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@types/semver': 7.7.1
-      find-up: 7.0.0
-      magic-string: 0.30.21
+      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0)
+      css-loader: 6.11.0(webpack@5.105.0)
+      image-size: 2.0.2
+      loader-utils: 3.3.1
+      next: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.0)
+      postcss: 8.5.6
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0)
       react: 19.2.0
-      react-docgen: 7.1.1
       react-dom: 19.2.0(react@19.2.0)
-      resolve: 1.22.11
+      react-refresh: 0.14.2
+      resolve-url-loader: 5.0.0
+      sass-loader: 16.0.6(webpack@5.105.0)
       semver: 7.7.3
       storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      style-loader: 3.3.4(webpack@5.105.0)
+      styled-jsx: 5.1.7(@babel/core@7.28.5)(react@19.2.0)
       tsconfig-paths: 4.2.0
-      webpack: 5.104.1(esbuild@0.25.12)
+      tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
+      webpack: 5.105.0
     transitivePeerDependencies:
+      - '@rspack/core'
       - '@swc/core'
+      - '@types/webpack'
+      - babel-plugin-macros
       - esbuild
+      - node-sass
+      - sass
+      - sass-embedded
+      - sockjs-client
       - supports-color
+      - type-fest
       - uglify-js
       - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
+  '@storybook/preset-react-webpack@9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
     dependencies:
       '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)
@@ -11576,7 +11624,7 @@ snapshots:
       semver: 7.7.3
       storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       tsconfig-paths: 4.2.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11586,19 +11634,29 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.12))':
+  '@storybook/preset-react-webpack@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
     dependencies:
-      debug: 4.4.3
-      endent: 2.1.0
-      find-cache-dir: 3.3.2
-      flat-cache: 3.2.0
-      micromatch: 4.0.8
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      tslib: 2.8.1
+      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)
+      '@types/semver': 7.7.1
+      find-up: 7.0.0
+      magic-string: 0.30.21
+      react: 19.2.0
+      react-docgen: 7.1.1
+      react-dom: 19.2.0(react@19.2.0)
+      resolve: 1.22.11
+      semver: 7.7.3
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      tsconfig-paths: 4.2.0
+      webpack: 5.104.1
+    optionalDependencies:
       typescript: 5.9.3
-      webpack: 5.104.1(esbuild@0.25.12)
     transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
       - supports-color
+      - uglify-js
+      - webpack-cli
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)':
     dependencies:
@@ -11610,7 +11668,7 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11620,10 +11678,28 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
 
-  '@storybook/react-webpack5@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
+  '@storybook/react-webpack5@9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
     dependencies:
-      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
-      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+      '@storybook/builder-webpack5': 9.1.16(esbuild@0.25.12)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+      '@storybook/preset-react-webpack': 9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
+  '@storybook/react-webpack5@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -12424,17 +12500,17 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)':
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)':
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.104.1)':
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
     optionalDependencies:
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1)
@@ -12682,21 +12758,21 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       find-up: 5.0.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.104.1):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
-  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.105.0):
     dependencies:
@@ -13267,19 +13343,6 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
-  css-loader@6.11.0(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.3
-    optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
-
   css-loader@6.11.0(webpack@5.104.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
@@ -13291,9 +13354,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
-  css-loader@6.11.0(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  css-loader@6.11.0(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -13304,7 +13367,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   css-loader@6.11.0(webpack@5.105.0):
     dependencies:
@@ -13330,7 +13393,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   css-select@4.3.0:
     dependencies:
@@ -14491,23 +14554,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cosmiconfig: 7.1.0
-      deepmerge: 4.3.1
-      fs-extra: 10.1.0
-      memfs: 3.5.3
-      minimatch: 3.1.2
-      node-abort-controller: 3.1.1
-      schema-utils: 3.3.0
-      semver: 7.7.3
-      tapable: 2.3.0
-      typescript: 5.9.3
-      webpack: 5.104.1(esbuild@0.25.12)
-
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.104.1):
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -14523,7 +14569,7 @@ snapshots:
       semver: 7.7.3
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   form-data@4.0.5:
     dependencies:
@@ -14885,16 +14931,6 @@ snapshots:
 
   html-void-elements@1.0.5: {}
 
-  html-webpack-plugin@5.6.5(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.18.1
-      pretty-error: 4.0.0
-      tapable: 2.3.0
-    optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
-
   html-webpack-plugin@5.6.5(webpack@5.104.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -14903,7 +14939,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -15655,6 +15691,8 @@ snapshots:
 
   methods@1.1.2: {}
 
+  mgrs@1.0.0: {}
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -15947,7 +15985,7 @@ snapshots:
   node-gyp-build@4.8.4:
     optional: true
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -15974,7 +16012,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   node-polyfill-webpack-plugin@2.0.1(webpack@5.105.0):
     dependencies:
@@ -16031,7 +16069,7 @@ snapshots:
     optionalDependencies:
       next: 14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  nuqs@2.8.5(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0):
+  nuqs@2.8.5(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.0
@@ -16356,14 +16394,14 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
       postcss: 8.5.6
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     transitivePeerDependencies:
       - typescript
 
@@ -16473,6 +16511,11 @@ snapshots:
   process@0.11.10: {}
 
   progress@2.0.3: {}
+
+  proj4@2.20.8:
+    dependencies:
+      mgrs: 1.0.0
+      wkt-parser: 1.5.5
 
   prop-types@15.8.1:
     dependencies:
@@ -16971,11 +17014,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.6(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  sass-loader@16.0.6(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   sass-loader@16.0.6(webpack@5.105.0):
     dependencies:
@@ -17494,17 +17537,13 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  style-loader@3.3.4(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
-
   style-loader@3.3.4(webpack@5.104.1):
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
-  style-loader@3.3.4(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  style-loader@3.3.4(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   style-loader@3.3.4(webpack@5.105.0):
     dependencies:
@@ -17512,7 +17551,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.104.1):
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   style-to-object@0.3.0:
     dependencies:
@@ -17608,14 +17647,14 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
-  terser-webpack-plugin@5.3.14(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12)):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.12)(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.1
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     optionalDependencies:
       esbuild: 0.25.12
 
@@ -17626,16 +17665,16 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.1
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12)):
+  terser-webpack-plugin@5.3.16(esbuild@0.25.12)(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     optionalDependencies:
       esbuild: 0.25.12
 
@@ -17646,17 +17685,16 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1
 
-  terser-webpack-plugin@5.6.0(esbuild@0.25.12)(postcss@8.5.6)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  terser-webpack-plugin@5.6.0(postcss@8.5.6)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     optionalDependencies:
-      esbuild: 0.25.12
       postcss: 8.5.6
 
   terser-webpack-plugin@5.6.0(webpack@5.105.0):
@@ -18182,20 +18220,10 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1)
-
-  webpack-dev-middleware@6.1.3(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.3
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.3.3
-    optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
 
   webpack-dev-middleware@6.1.3(webpack@5.104.1):
     dependencies:
@@ -18205,7 +18233,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.104.1):
     dependencies:
@@ -18216,11 +18244,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.2(tslib@2.8.1)
@@ -18229,7 +18257,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     transitivePeerDependencies:
       - tslib
     optional: true
@@ -18279,7 +18307,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.104.1)
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
     transitivePeerDependencies:
       - bufferutil
@@ -18288,7 +18316,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18316,10 +18344,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18388,39 +18416,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.104.1(esbuild@0.25.12):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.104.1(webpack-cli@6.0.1):
+  webpack@5.104.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -18445,6 +18441,38 @@ snapshots:
       schema-utils: 4.3.3
       tapable: 2.3.0
       terser-webpack-plugin: 5.3.16(webpack@5.104.1)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.19.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(esbuild@0.25.12)(webpack@5.104.1)
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -18495,7 +18523,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6):
+  webpack@5.105.0(postcss@8.5.6):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -18519,7 +18547,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.25.12)(postcss@8.5.6)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      terser-webpack-plugin: 5.6.0(postcss@8.5.6)(webpack@5.105.0(postcss@8.5.6))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -18619,6 +18647,8 @@ snapshots:
       logform: 2.7.0
       readable-stream: 3.6.2
       triple-beam: 1.4.1
+
+  wkt-parser@1.5.5: {}
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #7383
- Closes #7384

## Describe your changes
- `storeMapper` reads `subject_viewer_config.tile_layers` and forwards it to `GeoMapViewer` as a flat `tileLayers` prop (default a stable empty array, so existing geoMap workflows are unchanged)
- `useOLMap` builds one base layer per descriptor via the `createTileLayer` factory, with the `default`-marked layer (else the first) visible
- falls back to a single OSM base layer when no `tile_layers` are configured
- adds `proj4` + registers `EPSG:26915` (UTM 15N) so COG tile layers in a non-web-mercator CRS reproject into the map (OL only ships EPSG:4326/3857)
- adds a `WithMultipleLayers` Storybook story exercising all four layer types (osm, xyz, wms, cog) with a "Visible layer" select control
- combines #7383 (storeMapper) and #7384 (render) in one PR, since the forwarded prop is only meaningful once the layers render

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- n/a for this PR. Configuring tile layers from the Lab editor lands with the editor PRs (#7462-#7464), so the Storybook story below is the user-facing surface. Switching between configured layers in the classifier is the next FEM PR (#7379 LayerControl); this PR renders the configured layers with the default visible.

What user actions should my reviewer step through to review this PR?
- [x] run `pnpm storybook` in `packages/lib-classifier`, open `Subject Viewers / GeoMapViewer` -> `WithMultipleLayers`
- [x] use the `Visible layer` control to switch through all four basemaps: `OpenStreetMap`, `OpenTopoMap`, `MnGeo 2023 imagery` (WMS), and `NAIP 2023` (COG); each should render (the COG reprojects from UTM into the map)
- [x] render `Default` (no tile_layers) and confirm it still shows a single OSM basemap (back-compat)
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `GeoMapViewer.spec.jsx` (the `configured tile layers` cases), `GeoMapViewerContainer.spec.jsx`, `createTileLayer.spec.js`, and `registerProjections.spec.js` pass

Which storybook stories should be reviewed?
- `Subject Viewers / GeoMapViewer` -> `WithMultipleLayers`: http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-multiple-layers

Are there plans for follow up PR's to further fix this bug or develop this feature?
- Yes. This is PR 2 in the Map Layers milestone (it closes #7383 and #7384). Sequential PRs that follow this one (in merge order):
- [#7379](https://github.com/zooniverse/front-end-monorepo/issues/7379) lib-classifier: Add LayerControl component for layer switching
- [#7380](https://github.com/zooniverse/front-end-monorepo/issues/7380) lib-classifier: Swap active layer visibility and filter features by activeLayerIndex
- [#7381](https://github.com/zooniverse/front-end-monorepo/issues/7381) lib-classifier: Clear selected features on layer switch
- [#7462 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7462) Panoptes-Front-End: Add tile layer entry editor to GeoDrawing workflow config
- [#7463 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7463) Panoptes-Front-End: Add WMS and XYZ URL validation for tile layer entries
- [#7464 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7464) Panoptes-Front-End: Add basemap selector to GeoDrawing workflow config

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
