### PR TITLE
lib-classifier: Add LayerControl for switching the visible map layer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -10,6 +10,7 @@ import { transform } from 'ol/proj'
 
 import { useTranslation } from '@translations/i18n'
 import CoordinateInput from './components/CoordinateInput'
+import LayerControl from './components/LayerControl'
 import MeasureButton from './components/MeasureButton'
 import RecenterButton from './components/RecenterButton'
 import ResetButton from './components/ResetButton'
@@ -78,6 +79,10 @@ function GeoMapViewer({
 }) {
   const [isMeasureModeActive, setIsMeasureModeActive] = useState(false)
   const [selectedUnit, setSelectedUnit] = useState('meters')
+  const [currentLayerIndex, setCurrentLayerIndex] = useState(() => {
+    const index = tileLayers.findIndex(tileLayer => tileLayer?.default)
+    return index >= 0 ? index : 0
+  })
   const { t } = useTranslation('components')
 
   const containerRef = useRef()
@@ -85,7 +90,7 @@ function GeoMapViewer({
   const hasGeoDrawingTask = !!(geoDrawingTask && geoDrawingTask.tools.length > 0)
   const activeToolType = geoDrawingTask?.activeTool?.type
 
-  const { map, source, layer, scaleLine } = useOLMap(containerRef, tileLayers)
+  const { map, source, layer, scaleLine, baseLayers } = useOLMap(containerRef, tileLayers)
 
   const { select, translate } = useMapSelection({
     map,
@@ -139,6 +144,11 @@ function GeoMapViewer({
   useEffect(() => {
     if (map && onMapReady) onMapReady(map)
   }, [map, onMapReady])
+
+  useEffect(() => {
+    if (!baseLayers.length) return
+    baseLayers.forEach((tileLayer, index) => tileLayer.setVisible(index === currentLayerIndex))
+  }, [baseLayers, currentLayerIndex])
 
   useEffect(() => {
     loadGeoJSON({ map, source, select, measure, data: geoJSON })
@@ -222,10 +232,15 @@ function GeoMapViewer({
 
   return (
     <StyledBox forwardedAs='section' fill>
-      <ControlsBox>
+      <ControlsBox align='end'>
         <ZoomInButton onClick={() => handleZoom(1)} />
         <ZoomOutButton onClick={() => handleZoom(-1)} />
         <MeasureButton active={isMeasureModeActive} onClick={handleToggleMeasureMode} />
+        <LayerControl
+          layers={tileLayers}
+          activeIndex={currentLayerIndex}
+          onChange={setCurrentLayerIndex}
+        />
         {geoJSON && (
           <>
             <RecenterButton onClick={handleRecenter} />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.spec.jsx
@@ -1,5 +1,6 @@
 import { composeStory } from '@storybook/react'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import TileLayer from 'ol/layer/Tile'
 import Meta, { Default, WithGeoDrawingTask, WithoutGeoDrawingTask } from './GeoMapViewer.stories'
 
@@ -122,6 +123,57 @@ describe('Component > GeoMapViewer', function () {
       render(<DefaultStory tileLayers={withDefault} onMapReady={(olMap) => { map = olMap }} />)
       await waitFor(() => expect(map).to.exist)
       expect(baseLayers(map).map(layer => layer.getVisible())).to.deep.equal([false, true])
+    })
+
+    it('does not render the LayerControl when only one layer is configured', async function () {
+      let map = null
+      render(<DefaultStory tileLayers={[{ type: 'osm', label: 'OpenStreetMap' }]} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      expect(screen.queryByRole('tablist')).to.not.exist
+    })
+  })
+
+  describe('layer switching (LayerControl)', function () {
+    const twoLayers = [
+      { type: 'osm', label: 'OpenStreetMap' },
+      { type: 'wms', label: 'imagery', url: 'https://example.org/wms', params: { LAYERS: 'foo' } }
+    ]
+
+    function baseLayers (map) {
+      return map.getLayers().getArray().filter(layer => layer instanceof TileLayer)
+    }
+
+    it('renders a tab per configured layer when more than one is configured', async function () {
+      let map = null
+      render(<DefaultStory tileLayers={twoLayers} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      const tablist = screen.getByRole('tablist')
+      expect(tablist.querySelectorAll('[role="tab"]')).to.have.lengthOf(2)
+    })
+
+    it('swaps which base tile layer is visible when a tab is clicked', async function () {
+      const user = userEvent.setup()
+      let map = null
+      render(<DefaultStory tileLayers={twoLayers} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      expect(baseLayers(map).map(layer => layer.getVisible())).to.deep.equal([true, false])
+
+      await user.click(screen.getByRole('tab', { name: 'imagery' }))
+      expect(baseLayers(map).map(layer => layer.getVisible())).to.deep.equal([false, true])
+    })
+
+    it('keeps the vector (features) layer visible across a layer switch', async function () {
+      const user = userEvent.setup()
+      let map = null
+      render(<DefaultStory tileLayers={twoLayers} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      const vectorLayer = map.getLayers().getArray().slice(-1)[0]
+      const featureCountBefore = vectorLayer.getSource()?.getFeatures().length ?? 0
+
+      await user.click(screen.getByRole('tab', { name: 'imagery' }))
+
+      expect(vectorLayer.getVisible()).to.equal(true)
+      expect(vectorLayer.getSource()?.getFeatures().length ?? 0).to.equal(featureCountBefore)
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { fromLonLat } from 'ol/proj'
 
 import GeoMapViewer from './GeoMapViewer'
@@ -38,40 +38,22 @@ const MULTI_LAYERS = [
   }
 ]
 
-const LAYER_LABELS = MULTI_LAYERS.reduce((labels, layer) => ({ ...labels, [layer.type]: layer.label }), {})
-
 const COG_CENTER = [-91.906, 48.156]
 
-function MultiLayerStory({ visibleLayer }) {
+function MultiLayerStory(props) {
   const [map, setMap] = useState(null)
-  const tileLayers = useMemo(
-    () => MULTI_LAYERS.map(layer => ({ ...layer, default: layer.type === visibleLayer })),
-    [visibleLayer]
-  )
 
   useEffect(() => {
     if (!map) return
     map.getView().setCenter(fromLonLat(COG_CENTER))
     map.getView().setZoom(14)
-  }, [map, visibleLayer])
+  }, [map])
 
-  return (
-    <GeoMapViewer onMapReady={setMap} tileLayers={tileLayers} />
-  )
+  return <GeoMapViewer {...props} onMapReady={setMap} tileLayers={MULTI_LAYERS} />
 }
 
 export const WithMultipleLayers = {
-  args: { visibleLayer: 'osm' },
-  argTypes: {
-    visibleLayer: {
-      name: 'Visible layer',
-      description: 'Which configured basemap is shown (preview of layer switching)',
-      control: 'select',
-      options: MULTI_LAYERS.map(layer => layer.type),
-      labels: LAYER_LABELS
-    }
-  },
-  render: ({ visibleLayer }) => <MultiLayerStory visibleLayer={visibleLayer} />,
+  render: () => <MultiLayerStory />,
 }
 
 export const WithGeoDrawingTask = {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.jsx
@@ -23,7 +23,8 @@ export function storeMapper(classifierStore) {
     }
   } = classifierStore
 
-  const tileLayers = classifierStore.workflows?.active?.configuration?.subject_viewer_config?.tile_layers || EMPTY_TILE_LAYERS
+  const configuredTileLayers = classifierStore.workflows?.active?.configuration?.subject_viewer_config?.tile_layers
+  const tileLayers = Array.isArray(configuredTileLayers) ? configuredTileLayers : EMPTY_TILE_LAYERS
 
   const latest = subject?.stepHistory.latest
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.spec.jsx
@@ -1,4 +1,5 @@
 import { storeMapper } from './GeoMapViewerContainer'
+import WorkflowConfiguration from '@store/WorkflowStore/Workflow/WorkflowConfiguration'
 
 function buildStore (overrides = {}) {
   return {
@@ -55,6 +56,13 @@ describe('Component > GeoMapViewerContainer > storeMapper', function () {
         }
       }
     }))
+    expect(result.tileLayers).to.deep.equal([])
+  })
+
+  it('coerces tileLayers to an array when a real WorkflowConfiguration omits subject_viewer_config', function () {
+    const configuration = WorkflowConfiguration.create({ subject_viewer: 'geoMap' })
+    const result = storeMapper(buildStore({ workflows: { active: { configuration } } }))
+    expect(Array.isArray(result.tileLayers)).to.equal(true)
     expect(result.tileLayers).to.deep.equal([])
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.jsx
@@ -1,0 +1,86 @@
+import { Box, Button } from 'grommet'
+import { arrayOf, func, number, shape, string } from 'prop-types'
+import styled from 'styled-components'
+
+import { useTranslation } from '@translations/i18n'
+
+const TabList = styled(Box).attrs({
+  direction: 'column',
+  gap: 'xxsmall',
+  role: 'tablist'
+})`
+  background: ${props => (props.theme.dark ? props.theme.global.colors['dark-3'] : '#fff')};
+  border: 1px solid ${props => props.theme.global.colors['light-5']};
+  border-radius: 4px;
+  padding: 2px;
+`
+
+const TabButton = styled(Button).attrs({ role: 'tab' })`
+  background: ${props => (props.active ? props.theme.global.colors['accent-1'] : 'transparent')};
+  border: none;
+  border-radius: 3px;
+  font-size: 12px;
+  padding: 4px 8px;
+
+  &:focus,
+  &:focus-visible {
+    outline: 2px solid ${props => props.theme.global.colors['accent-1']};
+    outline-offset: -2px;
+  }
+`
+
+function LayerControl ({ layers = [], activeIndex = 0, onChange }) {
+  const { t } = useTranslation('components')
+
+  if (!Array.isArray(layers) || layers.length <= 1) {
+    return null
+  }
+
+  function cycle (delta) {
+    const next = (activeIndex + delta + layers.length) % layers.length
+    onChange?.(next)
+  }
+
+  function handleKeyDown (event) {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+      event.preventDefault()
+      cycle(1)
+    } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+      event.preventDefault()
+      cycle(-1)
+    }
+  }
+
+  return (
+    <TabList
+      a11yTitle={t('SubjectViewer.GeoMapViewer.LayerControl.label')}
+      aria-orientation='vertical'
+      onKeyDown={handleKeyDown}
+    >
+      {layers.map((layer, idx) => {
+        const isActive = idx === activeIndex
+        return (
+          <TabButton
+            key={`${idx}-${layer?.label || layer?.type}`}
+            label={layer?.label || `${t('SubjectViewer.GeoMapViewer.LayerControl.fallbackLabel')} ${idx + 1}`}
+            active={isActive}
+            aria-selected={isActive ? 'true' : 'false'}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => onChange?.(idx)}
+          />
+        )
+      })}
+    </TabList>
+  )
+}
+
+LayerControl.propTypes = {
+  layers: arrayOf(shape({
+    label: string,
+    type: string
+  })),
+  activeIndex: number,
+  onChange: func
+}
+
+export default LayerControl

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.jsx
@@ -39,15 +39,18 @@ function LayerControl ({ layers = [], activeIndex = 0, onChange }) {
   function cycle (delta) {
     const next = (activeIndex + delta + layers.length) % layers.length
     onChange?.(next)
+    return next
   }
 
   function handleKeyDown (event) {
     if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
       event.preventDefault()
-      cycle(1)
+      const next = cycle(1)
+      event.currentTarget?.querySelectorAll('[role="tab"]')?.[next]?.focus()
     } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
       event.preventDefault()
-      cycle(-1)
+      const next = cycle(-1)
+      event.currentTarget?.querySelectorAll('[role="tab"]')?.[next]?.focus()
     }
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.spec.jsx
@@ -1,0 +1,133 @@
+import { composeStory } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import Meta, { TwoLayers, FiveLayers, SingleLayer, NoLayers } from './LayerControl.stories'
+
+const TwoLayersStory = composeStory(TwoLayers, Meta)
+const FiveLayersStory = composeStory(FiveLayers, Meta)
+const SingleLayerStory = composeStory(SingleLayer, Meta)
+const NoLayersStory = composeStory(NoLayers, Meta)
+
+describe('Component > LayerControl', function () {
+  describe('with 0 or 1 layers', function () {
+    it('renders nothing for an empty layers array', function () {
+      const { container } = render(<NoLayersStory />)
+      expect(container.querySelector('[role="tablist"]')).to.equal(null)
+    })
+
+    it('renders nothing for a single layer (no switching needed)', function () {
+      const { container } = render(<SingleLayerStory />)
+      expect(container.querySelector('[role="tablist"]')).to.equal(null)
+    })
+  })
+
+  describe('with multiple layers', function () {
+    it('renders one tab per layer inside a role="tablist"', function () {
+      render(<TwoLayersStory />)
+      const tablist = screen.getByRole('tablist')
+      const tabs = tablist.querySelectorAll('[role="tab"]')
+      expect(tabs.length).to.equal(2)
+    })
+
+    it('shows each layer label as the tab text', function () {
+      render(<TwoLayersStory />)
+      expect(screen.getByRole('tab', { name: 'OpenStreetMap' })).to.exist
+      expect(screen.getByRole('tab', { name: '2023 imagery' })).to.exist
+    })
+
+    it('marks the active tab with aria-selected="true" and the rest with "false"', function () {
+      render(<TwoLayersStory />)
+      const active = screen.getByRole('tab', { name: 'OpenStreetMap' })
+      const inactive = screen.getByRole('tab', { name: '2023 imagery' })
+      expect(active.getAttribute('aria-selected')).to.equal('true')
+      expect(inactive.getAttribute('aria-selected')).to.equal('false')
+    })
+
+    it('calls onChange with the new index when a tab is clicked', async function () {
+      let captured = null
+      const args = {
+        ...TwoLayers.args,
+        onChange: (idx) => { captured = idx }
+      }
+      const Story = composeStory({ ...TwoLayers, args }, Meta)
+      const user = userEvent.setup()
+      render(<Story />)
+      await user.click(screen.getByRole('tab', { name: '2023 imagery' }))
+      expect(captured).to.equal(1)
+    })
+
+    it('marks the tablist as vertically oriented', function () {
+      render(<TwoLayersStory />)
+      expect(screen.getByRole('tablist').getAttribute('aria-orientation')).to.equal('vertical')
+    })
+
+    it('cycles activeIndex with ArrowDown on the tablist', async function () {
+      let captured = null
+      const args = {
+        ...TwoLayers.args,
+        onChange: (idx) => { captured = idx }
+      }
+      const Story = composeStory({ ...TwoLayers, args }, Meta)
+      const user = userEvent.setup()
+      render(<Story />)
+      const activeTab = screen.getByRole('tab', { name: 'OpenStreetMap' })
+      activeTab.focus()
+      await user.keyboard('{ArrowDown}')
+      expect(captured).to.equal(1)
+    })
+
+    it('cycles activeIndex with ArrowUp on the tablist (wraps to end)', async function () {
+      let captured = null
+      const args = {
+        ...TwoLayers.args,
+        onChange: (idx) => { captured = idx }
+      }
+      const Story = composeStory({ ...TwoLayers, args }, Meta)
+      const user = userEvent.setup()
+      render(<Story />)
+      const activeTab = screen.getByRole('tab', { name: 'OpenStreetMap' })
+      activeTab.focus()
+      await user.keyboard('{ArrowUp}')
+      expect(captured).to.equal(1) // wraps to last index
+    })
+
+    it('cycles activeIndex with ArrowRight on the tablist', async function () {
+      let captured = null
+      const args = {
+        ...TwoLayers.args,
+        onChange: (idx) => { captured = idx }
+      }
+      const Story = composeStory({ ...TwoLayers, args }, Meta)
+      const user = userEvent.setup()
+      render(<Story />)
+      const activeTab = screen.getByRole('tab', { name: 'OpenStreetMap' })
+      activeTab.focus()
+      await user.keyboard('{ArrowRight}')
+      expect(captured).to.equal(1)
+    })
+
+    it('cycles activeIndex with ArrowLeft on the tablist (wraps to end)', async function () {
+      let captured = null
+      const args = {
+        ...TwoLayers.args,
+        onChange: (idx) => { captured = idx }
+      }
+      const Story = composeStory({ ...TwoLayers, args }, Meta)
+      const user = userEvent.setup()
+      render(<Story />)
+      const activeTab = screen.getByRole('tab', { name: 'OpenStreetMap' })
+      activeTab.focus()
+      await user.keyboard('{ArrowLeft}')
+      expect(captured).to.equal(1) // wraps to last index
+    })
+
+    it('renders many layers as tabs', function () {
+      render(<FiveLayersStory />)
+      const tablist = screen.getByRole('tablist')
+      expect(tablist.querySelectorAll('[role="tab"]').length).to.equal(5)
+      const active = tablist.querySelector('[aria-selected="true"]')
+      expect(active.textContent).to.equal('2021')
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.spec.jsx
@@ -122,6 +122,16 @@ describe('Component > LayerControl', function () {
       expect(captured).to.equal(1) // wraps to last index
     })
 
+    it('moves focus to the newly active tab on ArrowDown', async function () {
+      const user = userEvent.setup()
+      render(<TwoLayersStory />)
+      const activeTab = screen.getByRole('tab', { name: 'OpenStreetMap' })
+      const nextTab = screen.getByRole('tab', { name: '2023 imagery' })
+      activeTab.focus()
+      await user.keyboard('{ArrowDown}')
+      expect(document.activeElement).to.equal(nextTab)
+    })
+
     it('renders many layers as tabs', function () {
       render(<FiveLayersStory />)
       const tablist = screen.getByRole('tablist')

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/LayerControl.stories.jsx
@@ -1,0 +1,47 @@
+import LayerControl from './LayerControl'
+
+export default {
+  title: 'Subject Viewers / GeoMapViewer / LayerControl',
+  component: LayerControl,
+}
+
+export const TwoLayers = {
+  args: {
+    layers: [
+      { type: 'osm', label: 'OpenStreetMap' },
+      { type: 'wms', label: '2023 imagery' }
+    ],
+    activeIndex: 0,
+    onChange: (idx) => console.log('onChange', idx)
+  }
+}
+
+export const FiveLayers = {
+  args: {
+    layers: [
+      { type: 'osm', label: 'OpenStreetMap' },
+      { type: 'wms', label: '2023' },
+      { type: 'wms', label: '2021' },
+      { type: 'wms', label: '2019' },
+      { type: 'wms', label: 'Hillshade' }
+    ],
+    activeIndex: 2,
+    onChange: (idx) => console.log('onChange', idx)
+  }
+}
+
+export const SingleLayer = {
+  args: {
+    layers: [{ type: 'osm', label: 'OpenStreetMap' }],
+    activeIndex: 0,
+    onChange: (idx) => console.log('onChange', idx)
+  }
+}
+
+export const NoLayers = {
+  args: {
+    layers: [],
+    activeIndex: 0,
+    onChange: (idx) => console.log('onChange', idx)
+  }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/LayerControl/index.js
@@ -1,0 +1,1 @@
+export { default } from './LayerControl'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
@@ -8,7 +8,7 @@ import VectorSource from 'ol/source/Vector'
 import createTileLayer from '../helpers/createTileLayer'
 
 export default function useOLMap(containerRef, tileLayers = []) {
-  const [state, setState] = useState({ map: null, source: null, layer: null, scaleLine: null })
+  const [state, setState] = useState({ map: null, source: null, layer: null, scaleLine: null, baseLayers: [] })
 
   useEffect(() => {
     if (!containerRef.current) return undefined
@@ -29,11 +29,11 @@ export default function useOLMap(containerRef, tileLayers = []) {
       controls: defaultControls({ zoom: false }).extend([scaleLine])
     })
 
-    setState({ map, source, layer, scaleLine })
+    setState({ map, source, layer, scaleLine, baseLayers: baseTileLayers })
 
     return () => {
       map.setTarget(undefined)
-      setState({ map: null, source: null, layer: null, scaleLine: null })
+      setState({ map: null, source: null, layer: null, scaleLine: null, baseLayers: [] })
     }
   }, [containerRef, tileLayers])
 

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -187,6 +187,10 @@
       "DeleteOverlay": {
         "ariaLabel": "Delete selected feature"
       },
+      "LayerControl": {
+        "label": "Map layer",
+        "fallbackLabel": "Layer"
+      },
       "MeasureButton": {
         "ariaLabel": "Measure distance"
       },


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #7379
- Closes #7380

## Describe your changes
- Adds a layer switcher (a vertical tablist) to the GeoMapViewer controls so a volunteer can choose which configured basemap is visible
- The switcher only appears when a workflow configures more than one tile layer; with one layer (or none) there's nothing to switch and it stays hidden
- Switching the active layer changes the visible basemap; any features the volunteer has already drawn stay in place
- The active layer is keyboard-navigable (arrow keys) and announced through an `aria-selected` tablist
- Replaces the temporary "Visible layer" select in the `WithMultipleLayers` story (added in #7477) with this real control
- Combines #7379 (the control) and #7380 (wiring it to layer visibility), since the control does nothing on its own

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- n/a for this PR. Configuring tile layers from the Lab editor lands with the editor PRs (#7462-#7464), so the Storybook stories below are the user-facing surface. Once a workflow has multiple layers configured, the same control appears in the classifier.

What user actions should my reviewer step through to review this PR?
- [x] run `pnpm storybook` in `packages/lib-classifier`, open `Subject Viewers / GeoMapViewer / LayerControl`
- [ ] step through `TwoLayers` and `FiveLayers` and confirm the tablist marks the active layer and the arrow keys (Up/Down) cycle through layers
- [ ] open `SingleLayer` and `NoLayers` and confirm the control renders nothing (no switching needed)
- [ ] open `Subject Viewers / GeoMapViewer` -> `WithMultipleLayers`, then use the control to switch between `OpenStreetMap`, `OpenTopoMap`, `MnGeo 2023 imagery` (WMS), and `NAIP 2023` (COG); each should become the visible basemap
- [ ] in `WithMultipleLayers`, confirm switching layers leaves any drawn features in place
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `LayerControl.spec.jsx` and `GeoMapViewer.spec.jsx` (the `layer switching` cases) pass

Which storybook stories should be reviewed?
- `Subject Viewers / GeoMapViewer / LayerControl`: http://localhost:6006/?path=/story/subject-viewers-geomapviewer-layercontrol--two-layers
- `Subject Viewers / GeoMapViewer` -> `WithMultipleLayers`: http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-multiple-layers

Are there plans for follow up PR's to further fix this bug or develop this feature?
- Yes. This is PR 3 in the Map Layers milestone (it closes #7379 and #7380). Sequential PRs that follow this one (in merge order):
- [#7381](https://github.com/zooniverse/front-end-monorepo/issues/7381) lib-classifier: Clear selected features on layer switch
- [#7462 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7462) Panoptes-Front-End: Add tile layer entry editor to GeoDrawing workflow config
- [#7463 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7463) Panoptes-Front-End: Add WMS and XYZ URL validation for tile layer entries
- [#7464 Panoptes-Front-End](https://github.com/zooniverse/Panoptes-Front-End/issues/7464) Panoptes-Front-End: Add basemap selector to GeoDrawing workflow config

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
