### PR TITLE
lib-classifier: Support subjects with multiple images and text media

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.spec.jsx
@@ -41,13 +41,13 @@ describe('ImageAndTextViewer', function () {
       const thumbnailButtons = document.querySelectorAll('[role=tab]')
       const { border } = window.getComputedStyle(thumbnailButtons[0])
 
-      expect(border).to.equal('2px solid rgb(240, 178, 0)') // neutral-2 in theme
+      expect(border).to.equal('2px solid rgb(0, 93, 105)') // neutral-2 in theme
     })
 
     it('should have previous and next buttons', function () {
       render(<DefaultStory />)
-      const nextButton = screen.getByText('Next')
-      const prevButton = screen.getByText('Previous')
+      const nextButton = screen.getByLabelText('Next')
+      const prevButton = screen.getByLabelText('Previous')
 
       expect(nextButton).to.exist
       expect(prevButton).to.exist
@@ -69,7 +69,7 @@ describe('ImageAndTextViewer', function () {
       const thumbnailButtons = document.querySelectorAll('[role=tab]')
       const buttonStyle = window.getComputedStyle(thumbnailButtons[0])
 
-      expect(buttonStyle.border).to.equal('2px solid rgb(240, 178, 0)') // neutral-2 in theme
+      expect(buttonStyle.border).to.equal('2px solid rgb(0, 93, 105)') // neutral-2 in theme
 
       await user.pointer({
         keys: '[MouseLeft]',
@@ -77,7 +77,7 @@ describe('ImageAndTextViewer', function () {
       })
       const newButtonStyle = window.getComputedStyle(thumbnailButtons[1])
 
-      expect(newButtonStyle.border).to.equal('2px solid rgb(240, 178, 0)')
+      expect(newButtonStyle.border).to.equal('2px solid rgb(0, 93, 105)')
     })
 
     it('should handle using arrow keys on the tablist', async function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.stories.jsx
@@ -49,12 +49,34 @@ const textLocationFirstSubjectSnapshot = SubjectFactory.build({
   ]
 })
 
+const twoImagesOneTextMedia = SubjectFactory.build({
+  id: '5678',
+  locations: [
+    {
+      'image/png':
+        'https://panoptes-uploads.zooniverse.org/subject_location/80a5c359-71ae-4dc1-b3ac-49329a6da2c9.png'
+    },
+        {
+      'image/png':
+        'https://panoptes-uploads.zooniverse.org/subject_location/bca62260-9543-49d6-8535-86140f4ea6ff.png'
+    },
+    {
+      'text/plain':
+        'https://panoptes-uploads-staging.zooniverse.org/subject_location/9d03230b-7ef0-42b5-aa99-996b0394cc9e.txt'
+    }
+  ]
+})
+
 const store = mockStore({
   subject: subjectSnapshot
 })
 
 const storeWithSubjectTextLocationFirst = mockStore({
   subject: textLocationFirstSubjectSnapshot
+})
+
+const storeWithMoreThanTwoLocations = mockStore({
+  subject: twoImagesOneTextMedia
 })
 
 export function Default({ loadingState }) {
@@ -70,6 +92,16 @@ export function Default({ loadingState }) {
 export function TextLocationFirst({ loadingState }) {
   return (
     <Provider classifierStore={storeWithSubjectTextLocationFirst}>
+      <Box width='large'>
+        <ImageAndTextViewerConnector loadingState={loadingState} />
+      </Box>
+    </Provider>
+  )
+}
+
+export function MoreThanTwoLocations({ loadingState }) {
+  return (
+    <Provider classifierStore={storeWithMoreThanTwoLocations}>
       <Box width='large'>
         <ImageAndTextViewerConnector loadingState={loadingState} />
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerConnector.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerConnector.jsx
@@ -10,14 +10,21 @@ function storeMapper (store) {
       dimensions,
       frame,
       loadingState,
+      separateFramesView,
       setFrame
     }
   } = store
 
+  const {
+    enable_switching_flipbook_and_separate: enableSwitchView
+  } = store.workflows?.active?.configuration
+
   return {
     dimensions,
+    enableSwitchView,
     frame,
     loadingState,
+    separateFramesView,
     setFrame,
     subject
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.jsx
@@ -1,81 +1,102 @@
 import { Box } from 'grommet'
-import PropTypes from 'prop-types'
+import { arrayOf, bool, func, number, shape, string } from 'prop-types'
 import asyncStates from '@zooniverse/async-states'
 
 import locationValidator from '../../helpers/locationValidator'
 import ImageAndTextControls from './components/ImageAndTextControls'
+import SeparateFramesViewer from '../SeparateFramesViewer/SeparateFramesViewer'
 import SingleImageViewer from '../SingleImageViewer'
 import SingleTextViewer from '../SingleTextViewer'
 
-const DEFAULT_DIMENSIONS = [{
-  clientHeight: 400
-}]
+const DEFAULT_DIMENSIONS = [
+  {
+    clientHeight: 400
+  }
+]
 
 const DEFAULT_HANDLER = () => true
 
-function ImageAndTextViewerContainer ({
+function ImageAndTextViewerContainer({
   dimensions = DEFAULT_DIMENSIONS,
+  enableSwitchView = false,
   frame = 0,
   loadingState = asyncStates.initialized,
   onError = DEFAULT_HANDLER,
   onReady = DEFAULT_HANDLER,
   setFrame = DEFAULT_HANDLER,
+  separateFramesView = false,
   subject
 }) {
-  function handleFrameChange (newFrame) {
+  function handleFrameChange(newFrame) {
     setFrame(newFrame)
   }
 
   if (loadingState === asyncStates.error) {
-    return (
-      <div>Something went wrong.</div>
-    )
+    return <div>Something went wrong.</div>
   }
 
   const { type } = subject.locations[frame]
 
+
+  // Note that enableInteractionLayer is false for this subject type. There's no reason we can't
+  // enable drawing tools on top of an ImageAndText subject, but at that point it might be worth
+  // feeding this subject type into the FlipbookViewer, and modifying FlipbookControls as needed.
   if (loadingState !== asyncStates.initialized) {
     return (
-      <Box>
-        {(type === 'text')
-          ? (
-            <SingleTextViewer
-              frame={frame}
-              height={dimensions[0]?.clientHeight ? `${dimensions[0]?.clientHeight}px` : ''}
-              onError={onError}
-              onReady={onReady}
-            />)
-          : (
-            <SingleImageViewer
-              enableInteractionLayer={false}
-              loadingState={loadingState}
-              onError={onError}
-              onReady={onReady}
-            />)}
-        <ImageAndTextControls
-          currentFrame={frame}
-          locations={subject.locations}
-          onFrameChange={handleFrameChange}
-        />
-      </Box>
+      <>
+        {separateFramesView ? (
+          <SeparateFramesViewer
+            enableInteractionLayer={false}
+            onError={onError}
+            onReady={onReady}
+            subject={subject}
+          />
+        ) : (
+          <Box>
+            {type === 'text' ? (
+              <SingleTextViewer
+                height={dimensions[0]?.clientHeight ?? ''}
+                onError={onError}
+                onReady={onReady}
+              />
+            ) : (
+              <SingleImageViewer
+                enableInteractionLayer={false}
+                loadingState={loadingState}
+                onError={onError}
+                onReady={onReady}
+              />
+            )}
+            <ImageAndTextControls
+              currentFrame={frame}
+              enableSwitchView={enableSwitchView}
+              locations={subject.locations}
+              onFrameChange={handleFrameChange}
+            />
+          </Box>
+        )}
+      </>
     )
   }
   return null
 }
 
 ImageAndTextViewerContainer.propTypes = {
-  dimensions: PropTypes.arrayOf(
-    PropTypes.shape({
-      clientHeight: PropTypes.number
+  dimensions: arrayOf(
+    shape({
+      clientHeight: number
     })
   ),
-  frame: PropTypes.number,
-  loadingState: PropTypes.string,
-  onError: PropTypes.func,
-  onReady: PropTypes.func,
-  setFrame: PropTypes.func,
-  subject: PropTypes.shape({
-    locations: PropTypes.arrayOf(locationValidator)
+  enableSwitchView: bool,
+  frame: number,
+  limitSubjectHeight: bool,
+  loadingState: string,
+  onError: func,
+  onReady: func,
+  separateFramesView: bool,
+  setFrame: func,
+  subject: shape({
+    locations: arrayOf(locationValidator)
   })
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.jsx
@@ -55,7 +55,8 @@ function ImageAndTextViewerContainer({
           <Box>
             {type === 'text' ? (
               <SingleTextViewer
-                height={dimensions[0]?.clientHeight ?? ''}
+                frame={frame} // Needed so onReady is called with the correct frame index, otherwise SingleTextViewerContainer assumes frame = 0 unless its connector is refactored to read it from the store.
+                height={dimensions[0]?.clientHeight ? `${dimensions[0]?.clientHeight}px` : ''}
                 onError={onError}
                 onReady={onReady}
               />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.jsx
@@ -36,9 +36,7 @@ function ImageAndTextViewerContainer ({
 
   if (loadingState !== asyncStates.initialized) {
     return (
-      <Box
-        fill='horizontal'
-      >
+      <Box>
         {(type === 'text')
           ? (
             <SingleTextViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/components/ImageAndTextControls.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/components/ImageAndTextControls.jsx
@@ -20,7 +20,8 @@ const DirectionButton = styled(Button)`
     }
 `
 
-const ThumbnailButton = styled(Button)`
+// For image files, show a thumbnail of the image
+const ImageThumbnailButton = styled(Button)`
   display: flex;
   ${props => css`height: ${props.thumbnailDimension};`}
   ${props => css`width: ${props.thumbnailDimension};`}
@@ -31,11 +32,12 @@ const ThumbnailButton = styled(Button)`
   background-position: center;
   ${props => css`background-image: url(${props.thumbnailerUrl});`}
   &[aria-selected=true] {
-    border: solid 2px ${props => props.theme.global.colors['neutral-2']};
+    border: solid 2px ${props => props.theme.dark ? props.theme.global.colors['accent-1'] : props.theme.global.colors['neutral-1']};
   }
 `
 
-const TextButton = styled(Button)`
+// For text files, show a "text" icon
+const TextThumbnailButton = styled(Button)`
   align-items: center;
   border: solid 1px ${props => props.theme.global.colors['light-3']};
   display: flex;
@@ -43,14 +45,27 @@ const TextButton = styled(Button)`
   padding: 0;
   ${props => css`height: ${props.thumbnailDimension};`}
   ${props => css`width: ${props.thumbnailDimension};`}
-  &:hover {
+  border: solid 1px ${props => props.theme.global.colors['light-5']};
+
+  &[aria-selected=true] {
+    border: solid 2px ${props => props.theme.dark ? props.theme.global.colors['accent-1'] : props.theme.global.colors['neutral-1']};
+  }
+
+  &:hover:not([aria-selected=true]) {
     box-shadow: 0px 0px 0px 2px ${props => props.theme.global.colors['brand']};
   }
-  &[aria-selected=true] {
-    border: solid 2px ${props => props.theme.global.colors['neutral-2']};
+
+  > svg {
+    max-width: 80%;
+    stroke: ${props => props.theme.dark ? props.theme.global.colors['neutral-6'] : props.theme.global.colors['dark-5']};
+  }
+
+  &[aria-selected=true] > svg {
+    stroke: ${props => props.theme.dark ? props.theme.global.colors['accent-1'] : props.theme.global.colors['neutral-1']};
   }
 `
 
+const foreColors = { dark: 'neutral-6', light: 'dark-5' }
 const backgrounds = { dark: 'dark-3', light: 'neutral-6' }
 
 const ImageAndTextControls = ({
@@ -151,9 +166,8 @@ const ImageAndTextControls = ({
         >
           <Box direction='row' justify='center' gap={smallScreenStyle ? 'xsmall' : 'small'}>
             <DirectionButton
-              a11yTitle={smallScreenStyle ? t('SubjectViewer.MultiFrameViewer.FrameCarousel.previousFrameLabel') : ''}
-              icon={<FormPrevious />}
-              label={smallScreenStyle ? '' : t('SubjectViewer.MultiFrameViewer.FrameCarousel.previousFrameLabel')}
+              a11yTitle={t('SubjectViewer.MultiFrameViewer.FrameCarousel.previousFrameLabel')}
+              icon={<FormPrevious color={foreColors} />}
               onClick={handlePrevious}
             />
             <Box
@@ -175,7 +189,7 @@ const ImageAndTextControls = ({
                       url.length
                     )}`
                     return (
-                      <ThumbnailButton
+                      <ImageThumbnailButton
                         key={`${url}-${index}`}
                         id={`thumbnail-${index}`}
                         aria-controls='image-and-text-tab-panel'
@@ -193,7 +207,7 @@ const ImageAndTextControls = ({
                     )
                   } else {
                     return (
-                      <TextButton
+                      <TextThumbnailButton
                         key={`${url}-${index}`}
                         id={`thumbnail-${index}`}
                         aria-controls='image-and-text-tab-panel'
@@ -213,9 +227,8 @@ const ImageAndTextControls = ({
                 })}
             </Box>
             <DirectionButton
-              a11yTitle={smallScreenStyle ? t('SubjectViewer.MultiFrameViewer.FrameCarousel.nextFrameLabel') : ''}
-              icon={<FormNext />}
-              label={smallScreenStyle ? '' : t('SubjectViewer.MultiFrameViewer.FrameCarousel.nextFrameLabel')}
+              a11yTitle={t('SubjectViewer.MultiFrameViewer.FrameCarousel.nextFrameLabel')}
+              icon={<FormNext color={foreColors} />}
               onClick={handleNext}
             />
           </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/components/ImageAndTextControls.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/components/ImageAndTextControls.jsx
@@ -1,16 +1,17 @@
-import { Button, Box, ThemeContext } from 'grommet'
+import { Button, Box, Grid, ThemeContext } from 'grommet'
 import {
   DocumentText,
   FormNext,
   FormPrevious
 } from 'grommet-icons'
-import PropTypes from 'prop-types'
+import { arrayOf, bool, func, number } from 'prop-types'
 import { useEffect, useRef, useState } from 'react'
-import styled, { withTheme, css } from 'styled-components'
+import styled, { css } from 'styled-components'
 import { useTranslation } from '@translations/i18n'
 
 import controlsTheme from './theme'
 import locationValidator from '../../../helpers/locationValidator'
+import ViewModeButton from '../../../../SubjectViewer/components/SeparateFramesViewer/components/ViewModeButton/ViewModeButton'
 
 const DirectionButton = styled(Button)`
   border: none;
@@ -70,6 +71,7 @@ const backgrounds = { dark: 'dark-3', light: 'neutral-6' }
 
 const ImageAndTextControls = ({
   currentFrame = 0,
+  enableSwitchView = false,
   locations = [],
   onFrameChange = () => true
 }) => {
@@ -159,11 +161,12 @@ const ImageAndTextControls = ({
   return (
     <ThemeContext.Extend value={controlsTheme}>
       <Box background={backgrounds} ref={controlsContainer}>
-        <Box
-          fill
+        <Grid
+          columns={['25px', 'flex', '25px']}
           pad={smallScreenStyle ? { horizontal: '10px', vertical: '5px' } : { horizontal: '20px', vertical: '10px' }}
           gap={smallScreenStyle ? 'xsmall' : 'small'}
         >
+          <Box />
           <Box direction='row' justify='center' gap={smallScreenStyle ? 'xsmall' : 'small'}>
             <DirectionButton
               a11yTitle={t('SubjectViewer.MultiFrameViewer.FrameCarousel.previousFrameLabel')}
@@ -232,16 +235,20 @@ const ImageAndTextControls = ({
               onClick={handleNext}
             />
           </Box>
-        </Box>
+          <Box fill justify='center'>
+          {enableSwitchView && <ViewModeButton smallScreenStyle={smallScreenStyle} />}
+          </Box>
+        </Grid>
       </Box>
     </ThemeContext.Extend>
   )
 }
 
 ImageAndTextControls.propTypes = {
-  currentFrame: PropTypes.number,
-  locations: PropTypes.arrayOf(locationValidator).isRequired,
-  onFrameChange: PropTypes.func
+  currentFrame: number,
+  enableSwitchView: bool,
+  locations: arrayOf(locationValidator).isRequired,
+  onFrameChange: func
 }
 
-export default withTheme(ImageAndTextControls)
+export default ImageAndTextControls

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.jsx
@@ -8,6 +8,7 @@ import { useStores } from '@hooks'
 import locationValidator from '../../helpers/locationValidator'
 import SeparateFrame from './components/SeparateFrame/SeparateFrame'
 import ViewModeButton from './components/ViewModeButton/ViewModeButton'
+import SingleTextViewer from '../SingleTextViewer'
 
 function storeMapper(store) {
   const {
@@ -32,10 +33,7 @@ function SeparateFramesViewer({
   onReady = DEFAULT_HANDLER,
   subject
 }) {
-  const {
-    limitSubjectHeight,
-    multiImageLayout
-  } = useStores(storeMapper)
+  const { limitSubjectHeight, multiImageLayout } = useStores(storeMapper)
 
   const [forceColLayout, setForceColLayout] = useState(false)
   const [numFramesHorizontally, setNumFramesHorizontally] = useState(1)
@@ -85,19 +83,28 @@ function SeparateFramesViewer({
         columns={forceColLayout ? 'auto' : [`repeat(${numFramesHorizontally}, 1fr)`]}
         rows='auto'
       >
-        {subject.locations?.map((location, index) => (
-          <SeparateFrame
-            key={location.url}
-            enableInteractionLayer={enableInteractionLayer}
-            enableRotation={enableRotation}
-            frame={index}
-            frameUrl={location.url}
-            limitSubjectHeight={limitSubjectHeight}
-            onError={onError}
-            onReady={onReady}
-            subject={subject}
-          />
-        ))}
+        {subject.locations?.map((location, index) =>
+          location?.type === 'text' ? (
+            <SingleTextViewer
+              key={location.url}
+              frame={index}
+              onError={onError}
+              onReady={onReady}
+            />
+          ) : (
+            <SeparateFrame
+              key={location.url}
+              enableInteractionLayer={enableInteractionLayer}
+              enableRotation={enableRotation}
+              frame={index}
+              frameUrl={location.url}
+              limitSubjectHeight={limitSubjectHeight}
+              onError={onError}
+              onReady={onReady}
+              subject={subject}
+            />
+          )
+        )}
       </Grid>
       <Box justify='center' pad='xsmall'>
         <ViewModeButton />

--- a/packages/lib-classifier/src/store/subjects/ImageAndTextSubject/ImageAndTextSubject.js
+++ b/packages/lib-classifier/src/store/subjects/ImageAndTextSubject/ImageAndTextSubject.js
@@ -8,7 +8,7 @@ const ImageAndTextSubject = types
     Subject.named('ImageAndTextSubject'),
     subject => {
       const counts = createLocationCounts(subject)
-      return counts.total === 2 && counts.images === 1 && counts.text === 1
+      return counts.images >= 1 && counts.text >= 1 && counts.total === counts.images + counts.text
     })
 
 export default ImageAndTextSubject

--- a/packages/lib-classifier/src/store/subjects/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/Subject.js
@@ -60,7 +60,7 @@ const Subject = types
         // Volumetric Viewer is set at the Project level
         if (!viewer && self.project?.isVolumetricViewer)
           viewer = subjectViewers.volumetric
-      
+
         if (!viewer && counts.total === 1) {
           if (counts.audio) {
             viewer = subjectViewers.singleAudio
@@ -84,15 +84,15 @@ const Subject = types
           if (counts.total === 2 && counts.audio === 1 && counts.images === 1) {
             viewer = subjectViewers.audioSpectrogram
           }
-          // This is a subject pattern for the flipbook - Note that projects that want to use the multiFrame viewer should specify in workflow config
-          if (counts.total === (counts.images + counts.videos)) {
-            viewer = subjectViewers.flipbook
-          }
           // This is a subject pattern for the image and text viewer
           // Note that workflows with subjects that have the same subject pattern that want to use a different viewer (i.e. light curve viewer)
           // should specify which viewer in the workflow configuration
-          if (counts.total === 2 && counts.images === 1 && counts.text === 1) {
+          if (counts.images >= 1 && counts.text >= 1 && counts.total === (counts.images + counts.text)) {
             viewer = subjectViewers.imageAndText
+          }
+          // This is a subject pattern for the flipbook - Note that projects that want to use the multiFrame viewer should specify in workflow config
+          if (counts.total === (counts.images + counts.videos)) {
+            viewer = subjectViewers.flipbook
           }
         }
       }


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Freshdesk ticket: https://zooniverse.freshdesk.com/a/tickets/27296
-  A project owner uploaded subjects with two images and one text media. The classifier doesn't yet support this subject type, but it's a fairly straightforward adaptation to the ImageAndTextViewer originally developed for Digileap.

## Describe your changes
- Allow the ImageAndTextSubject to be more than two `locations` as long as all are image and text
- Adapt the ImageAndTextViewer to observe `separateFramesMode`
- Adapt the viewer's controls to observe `enableSwitchView`
- Arrows and outline of thumbnails in the text/image controls should match the flipbook controls

## How to Review
1. Try out various text + image workflows in the classifer
- Digileap staging project loads in the dev classifier: https://local.zooniverse.org:8080/?project=1952&env=staging&workflow=3602
- A workflow with the highlighter task still works: https://local.zooniverse.org:8080/?project=18920&env=production&workflow=24093
- Flipbook workflow should be unaffected: https://local.zooniverse.org:8080/?project=19645&env=production&workflow=27409
- Example workflow of 2 images and 1 text media (feel free to edit this config in the lab if you want to play around with separate frames vs flipbook first): https://local.zooniverse.org:8080/?project=14974&env=production&workflow=32169
- (You can also classify one of the test project’s subjects to gain a subject preview in your personal recents, but not necessary to approve this PR): https://local.zooniverse.org:3000/projects/goplayoutside3/fem-test-project/classify/workflow/32169?env=production
2. The test project’s SLTP displays the subject preview: https://www.zooniverse.org/projects/goplayoutside3/fem-test-project/talk/subjects/121763133
3. Look at the ImageAndTextViewer in lib-classifier’s Storybook


## Checklist

### General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/main/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

### Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
