### PR TITLE
Revert build(deps-dev): bump vitest from 3.1.4 to 3.2.6

### DIFF
--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -68,7 +68,7 @@
     "sinon": "~21.0.0",
     "storybook": "~9.1.19",
     "storybook-react-i18next": "~4.0.11",
-    "vitest": "~3.2.6"
+    "vitest": "~3.1.3"
   },
   "engines": {
     "node": ">=20.5"

--- a/packages/lib-async-states/package.json
+++ b/packages/lib-async-states/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@zooniverse/standard": "~2.0.0",
     "snazzy": "~9.0.0",
-    "vitest": "~3.2.6"
+    "vitest": "~3.1.3"
   },
   "engines": {
     "node": ">=20.5"

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -118,7 +118,7 @@
     "storybook-react-i18next": "~4.0.11",
     "style-loader": "~4.0.0",
     "superagent": "~10.2.1",
-    "vitest": "~3.2.6",
+    "vitest": "~3.1.3",
     "webpack": "~5.104.1",
     "webpack-cli": "~6.0.1",
     "webpack-dev-server": "~5.2.4"

--- a/packages/lib-content/package.json
+++ b/packages/lib-content/package.json
@@ -65,7 +65,7 @@
     "jsdom": "~26.1.0",
     "storybook": "~9.1.19",
     "storybook-react-i18next": "~4.0.11",
-    "vitest": "~3.2.6"
+    "vitest": "~3.1.3"
   },
   "engines": {
     "node": ">=20.5"

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -27,7 +27,7 @@
     "mock-local-storage": "~1.1.19",
     "nock": "~13.5.1",
     "snazzy": "~9.0.0",
-    "vitest": "~3.2.6"
+    "vitest": "~3.1.3"
   },
   "engines": {
     "node": ">=20.5"

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -97,7 +97,7 @@
     "storybook": "~9.1.19",
     "storybook-react-i18next": "~4.0.11",
     "webpack": "~5.104.1",
-    "vitest": "~3.2.6"
+    "vitest": "~3.1.3"
   },
   "engines": {
     "node": ">=20.5"

--- a/packages/lib-subject-viewers/package.json
+++ b/packages/lib-subject-viewers/package.json
@@ -57,7 +57,7 @@
     "@storybook/react-webpack5": "~9.1.16",
     "@vitejs/plugin-react": "~4.4.1",
     "storybook": "~9.1.19",
-    "vitest": "~3.2.6"
+    "vitest": "~3.1.3"
   },
   "engines": {
     "node": ">=20.5"

--- a/packages/lib-user/package.json
+++ b/packages/lib-user/package.json
@@ -76,7 +76,7 @@
     "sinon": "~21.0.0",
     "snazzy": "~9.0.0",
     "storybook": "~9.1.19",
-    "vitest": "~3.2.6"
+    "vitest": "~3.1.3"
   },
   "msw": {
     "workerDirectory": "./storybook-public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ~10.27.0
-        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.105.0)
       '@sindresorhus/string-hash':
         specifier: ~1.2.0
         version: 1.2.0
@@ -85,7 +85,7 @@ importers:
         version: 15.4.2(@types/react@19.2.7)(i18next@24.2.3(typescript@5.9.3))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       nuqs:
         specifier: ^2.8.5
-        version: 2.8.5(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 2.8.5(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       ol:
         specifier: ^10.7.0
         version: 10.7.0
@@ -116,13 +116,13 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: ~9.1.16
-        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/nextjs':
         specifier: ~9.1.16
-        version: 9.1.16(esbuild@0.25.12)(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+        version: 9.1.16(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
       '@storybook/react':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@testing-library/dom':
         specifier: ~10.4.1
         version: 10.4.1
@@ -134,7 +134,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitejs/plugin-react':
         specifier: ~4.4.1
-        version: 4.4.1(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 4.4.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       babel-plugin-styled-components:
         specifier: ~2.1.4
         version: 2.1.4(@babel/core@7.28.5)(styled-components@6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
@@ -164,13 +164,13 @@ importers:
         version: 21.0.0
       storybook:
         specifier: ~9.1.19
-        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       storybook-react-i18next:
         specifier: ~4.0.11
-        version: 4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       vitest:
-        specifier: ~3.2.6
-        version: 3.2.6(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
+        specifier: ~3.1.3
+        version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
 
   packages/app-root:
     dependencies:
@@ -224,7 +224,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       nuqs:
         specifier: ^2.8.5
-        version: 2.8.5(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 2.8.5(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       panoptes-client:
         specifier: ~5.6.0
         version: 5.6.2
@@ -260,8 +260,8 @@ importers:
         specifier: ~9.0.0
         version: 9.0.0
       vitest:
-        specifier: ~3.2.6
-        version: 3.2.6(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
+        specifier: ~3.1.3
+        version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
 
   packages/lib-classifier:
     dependencies:
@@ -385,16 +385,16 @@ importers:
         version: 7.27.1(@babel/core@7.28.5)
       '@storybook/addon-a11y':
         specifier: ~9.1.16
-        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ~3.0.0
         version: 3.0.6(webpack@5.104.1)
       '@storybook/react':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+        version: 9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
       '@testing-library/dom':
         specifier: ~10.4.1
         version: 10.4.1
@@ -409,7 +409,7 @@ importers:
         version: 3.12.0
       '@vitejs/plugin-react':
         specifier: ~4.4.1
-        version: 4.4.1(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 4.4.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       '@zooniverse/grommet-theme':
         specifier: ~4.0.0
         version: link:../lib-grommet-theme
@@ -499,10 +499,10 @@ importers:
         version: 9.0.0
       storybook:
         specifier: ~9.1.19
-        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       storybook-react-i18next:
         specifier: ~4.0.11
-        version: 4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       style-loader:
         specifier: ~4.0.0
         version: 4.0.0(webpack@5.104.1)
@@ -510,11 +510,11 @@ importers:
         specifier: ^10.2.0
         version: 10.2.3
       vitest:
-        specifier: ~3.2.6
-        version: 3.2.6(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
+        specifier: ~3.1.3
+        version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
       webpack:
         specifier: ~5.104.1
-        version: 5.104.1(webpack-cli@6.0.1)
+        version: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ~6.0.1
         version: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
@@ -584,13 +584,13 @@ importers:
         version: 7.27.1(@babel/core@7.28.5)
       '@storybook/addon-a11y':
         specifier: ~9.1.16
-        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/nextjs':
         specifier: ~9.1.16
-        version: 9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
+        version: 9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(postcss@8.5.6))
       '@storybook/react':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@testing-library/dom':
         specifier: ~10.4.1
         version: 10.4.1
@@ -602,7 +602,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitejs/plugin-react':
         specifier: ~4.4.1
-        version: 4.4.1(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 4.4.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       babel-plugin-module-resolver:
         specifier: ~5.0.0
         version: 5.0.2
@@ -620,13 +620,13 @@ importers:
         version: 26.1.0
       storybook:
         specifier: ~9.1.19
-        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       storybook-react-i18next:
         specifier: ~4.0.11
-        version: 4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       vitest:
-        specifier: ~3.2.6
-        version: 3.2.6(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
+        specifier: ~3.1.3
+        version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
 
   packages/lib-grommet-theme:
     dependencies:
@@ -669,8 +669,8 @@ importers:
         specifier: ~9.0.0
         version: 9.0.0
       vitest:
-        specifier: ~3.2.6
-        version: 3.2.6(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
+        specifier: ~3.1.3
+        version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
 
   packages/lib-react-components:
     dependencies:
@@ -752,16 +752,16 @@ importers:
         version: 7.27.1(@babel/core@7.28.5)
       '@storybook/addon-a11y':
         specifier: ~9.1.16
-        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ~3.0.0
         version: 3.0.6(webpack@5.104.1)
       '@storybook/react':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@testing-library/dom':
         specifier: ~10.4.1
         version: 10.4.1
@@ -773,7 +773,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitejs/plugin-react':
         specifier: ~4.4.1
-        version: 4.4.1(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 4.4.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       '@zooniverse/grommet-theme':
         specifier: ~4.0.0
         version: link:../lib-grommet-theme
@@ -818,16 +818,16 @@ importers:
         version: 9.0.0
       storybook:
         specifier: ~9.1.19
-        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       storybook-react-i18next:
         specifier: ~4.0.11
-        version: 4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       vitest:
-        specifier: ~3.2.6
-        version: 3.2.6(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
+        specifier: ~3.1.3
+        version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
       webpack:
         specifier: ~5.104.1
-        version: 5.104.1(webpack-cli@6.0.1)
+        version: 5.104.1
 
   packages/lib-subject-viewers:
     dependencies:
@@ -867,25 +867,25 @@ importers:
         version: 7.27.1(@babel/core@7.28.5)
       '@storybook/addon-a11y':
         specifier: ~9.1.16
-        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ~3.0.0
         version: 3.0.6(webpack@5.105.0)
       '@storybook/react':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ~4.4.1
-        version: 4.4.1(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 4.4.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       storybook:
         specifier: ~9.1.19
-        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       vitest:
-        specifier: ~3.2.6
-        version: 3.2.6(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
+        specifier: ~3.1.3
+        version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
 
   packages/lib-user:
     dependencies:
@@ -949,13 +949,13 @@ importers:
         version: 7.27.1(@babel/core@7.28.5)
       '@storybook/addon-a11y':
         specifier: ~9.1.16
-        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+        version: 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/nextjs':
         specifier: ~9.1.16
-        version: 9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
+        version: 9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
       '@storybook/react':
         specifier: ~9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@testing-library/dom':
         specifier: ~10.4.1
         version: 10.4.1
@@ -967,7 +967,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitejs/plugin-react':
         specifier: ~4.4.1
-        version: 4.4.1(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 4.4.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       '@zooniverse/grommet-theme':
         specifier: ~4.0.0
         version: link:../lib-grommet-theme
@@ -1012,10 +1012,10 @@ importers:
         version: 9.0.0
       storybook:
         specifier: ~9.1.19
-        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+        version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       vitest:
-        specifier: ~3.2.6
-        version: 3.2.6(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
+        specifier: ~3.1.3
+        version: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)
 
   packages/tools-standard:
     dependencies:
@@ -1733,20 +1733,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1757,20 +1745,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1781,20 +1757,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1805,20 +1769,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1829,20 +1781,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1853,20 +1793,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1877,20 +1805,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1901,20 +1817,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1925,20 +1829,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1949,20 +1841,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1973,20 +1853,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1997,20 +1865,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2021,20 +1877,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2119,105 +1963,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2490,56 +2318,48 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-gnu@15.5.18':
     resolution: {integrity: sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-arm64-musl@15.5.18':
     resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-gnu@15.5.18':
     resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-musl@15.5.18':
     resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -3020,18 +2840,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.62.0':
-    resolution: {integrity: sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm64@4.53.3':
     resolution: {integrity: sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.62.0':
-    resolution: {integrity: sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==}
     cpu: [arm64]
     os: [android]
 
@@ -3040,18 +2850,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.62.0':
-    resolution: {integrity: sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-x64@4.53.3':
     resolution: {integrity: sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.62.0':
-    resolution: {integrity: sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==}
     cpu: [x64]
     os: [darwin]
 
@@ -3060,18 +2860,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-arm64@4.62.0':
-    resolution: {integrity: sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-x64@4.53.3':
     resolution: {integrity: sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.62.0':
-    resolution: {integrity: sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==}
     cpu: [x64]
     os: [freebsd]
 
@@ -3079,158 +2869,59 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
-    resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.62.0':
-    resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-gnu@4.62.0':
-    resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-musl@4.62.0':
-    resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-gnu@4.62.0':
-    resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.62.0':
-    resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.62.0':
-    resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.62.0':
-    resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.62.0':
-    resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-riscv64-musl@4.62.0':
-    resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-s390x-gnu@4.62.0':
-    resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.62.0':
-    resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-x64-musl@4.62.0':
-    resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-openbsd-x64@4.62.0':
-    resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
-    cpu: [x64]
-    os: [openbsd]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-openharmony-arm64@4.62.0':
-    resolution: {integrity: sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -3239,18 +2930,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.62.0':
-    resolution: {integrity: sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.53.3':
     resolution: {integrity: sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.62.0':
-    resolution: {integrity: sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==}
     cpu: [ia32]
     os: [win32]
 
@@ -3259,18 +2940,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.62.0':
-    resolution: {integrity: sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-msvc@4.53.3':
     resolution: {integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.62.0':
-    resolution: {integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==}
     cpu: [x64]
     os: [win32]
 
@@ -3945,49 +3616,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4089,11 +3752,22 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
+  '@vitest/expect@3.1.4':
+    resolution: {integrity: sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@3.2.6':
-    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+  '@vitest/mocker@3.1.4':
+    resolution: {integrity: sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -4106,40 +3780,29 @@ packages:
       vite:
         optional: true
 
-  '@vitest/mocker@3.2.6':
-    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
+  '@vitest/pretty-format@3.1.4':
+    resolution: {integrity: sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==}
 
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@3.2.6':
-    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+  '@vitest/runner@3.1.4':
+    resolution: {integrity: sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==}
 
-  '@vitest/runner@3.2.6':
-    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+  '@vitest/snapshot@3.1.4':
+    resolution: {integrity: sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==}
 
-  '@vitest/snapshot@3.2.6':
-    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+  '@vitest/spy@3.1.4':
+    resolution: {integrity: sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/spy@3.2.6':
-    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+  '@vitest/utils@3.1.4':
+    resolution: {integrity: sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
-
-  '@vitest/utils@3.2.6':
-    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4254,8 +3917,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.17.0:
-    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -4483,8 +4146,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.10.37:
-    resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -4642,9 +4305,6 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
-  caniuse-lite@1.0.30001799:
-    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
-
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
     engines: {node: '>=4'}
@@ -4683,8 +4343,8 @@ packages:
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
   chokidar@3.6.0:
@@ -5344,8 +5004,8 @@ packages:
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
-  electron-to-chromium@1.5.372:
-    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+  electron-to-chromium@1.5.361:
+    resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
 
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
@@ -5385,8 +5045,8 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.24.0:
-    resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
+  enhanced-resolve@5.22.0:
+    resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
     engines: {node: '>=10.13.0'}
 
   entities@2.2.0:
@@ -5463,11 +5123,6 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5682,8 +5337,8 @@ packages:
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
   express@4.22.2:
@@ -6564,9 +6219,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -7163,8 +6815,8 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  node-releases@2.0.47:
-    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
 
   normalize-path@3.0.0:
@@ -7474,8 +7126,8 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pify@4.0.1:
@@ -7562,8 +7214,8 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -7990,11 +7642,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.62.0:
-    resolution: {integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rosie@2.1.1:
     resolution: {integrity: sha512-2AXB7WrIZXtKMZ6Q/PlozqPF5nu/x7NEvRJZOblrJuprrPfm5gL8JVvJPj9aaib9F8IUALnLUFhzXrwEtnI5cQ==}
     engines: {node: '>=10'}
@@ -8409,9 +8056,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
   style-loader@3.3.4:
     resolution: {integrity: sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==}
     engines: {node: '>= 12.13.0'}
@@ -8547,8 +8191,8 @@ packages:
       uglify-js:
         optional: true
 
-  terser-webpack-plugin@5.6.1:
-    resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
+  terser-webpack-plugin@5.6.0:
+    resolution: {integrity: sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@minify-html/node': '*'
@@ -8639,8 +8283,8 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -8649,6 +8293,10 @@ packages:
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -8962,24 +8610,24 @@ packages:
   vfile@4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+  vite-node@3.1.4:
+    resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.5:
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       jiti: '>=1.21.0'
-      less: ^4.0.0
+      less: '*'
       lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -9007,16 +8655,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.6:
-    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+  vitest@3.1.4:
+    resolution: {integrity: sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.6
-      '@vitest/ui': 3.2.6
+      '@vitest/browser': 3.1.4
+      '@vitest/ui': 3.1.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -9048,10 +8696,6 @@ packages:
 
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
-    engines: {node: '>=10.13.0'}
-
-  watchpack@2.5.2:
-    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
   wbuf@1.7.3:
@@ -10266,157 +9910,79 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/android-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
   '@esbuild/android-x64@0.25.12':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
   '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
   '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
   '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
   '@esbuild/win32-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
@@ -11364,7 +10930,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(postcss@8.5.6))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.47.0
@@ -11374,10 +10940,10 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     optionalDependencies:
       type-fest: 4.41.0
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6))
       webpack-hot-middleware: 2.26.1
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)':
@@ -11438,10 +11004,10 @@ snapshots:
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.3)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.4
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.53.3
 
@@ -11449,149 +11015,74 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.53.3
 
   '@rollup/rollup-android-arm-eabi@4.53.3':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.62.0':
-    optional: true
-
   '@rollup/rollup-android-arm64@4.53.3':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.62.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.53.3':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.62.0':
-    optional: true
-
   '@rollup/rollup-darwin-x64@4.53.3':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.62.0':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.53.3':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.62.0':
-    optional: true
-
   '@rollup/rollup-freebsd-x64@4.53.3':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.62.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.62.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-musl@4.53.3':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.62.0':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.0':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.62.0':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.62.0':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.62.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.62.0':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.62.0':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.62.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.53.3':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.62.0':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.62.0':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.62.0':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.53.3':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.62.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.53.3':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.62.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.62.0':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.62.0':
-    optional: true
-
   '@rollup/rollup-win32-x64-msvc@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.62.0':
     optional: true
 
   '@rtsao/scc@1.1.0': {}
@@ -11714,7 +11205,7 @@ snapshots:
 
   '@sentry/core@10.27.0': {}
 
-  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))':
+  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.105.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -11726,7 +11217,7 @@ snapshots:
       '@sentry/opentelemetry': 10.27.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)
       '@sentry/react': 10.27.0(react@19.2.0)
       '@sentry/vercel-edge': 10.27.0
-      '@sentry/webpack-plugin': 4.6.1(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      '@sentry/webpack-plugin': 4.6.1(webpack@5.105.0)
       next: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       resolve: 1.22.8
       rollup: 4.53.3
@@ -11818,12 +11309,12 @@ snapshots:
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@sentry/core': 10.27.0
 
-  '@sentry/webpack-plugin@4.6.1(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))':
+  '@sentry/webpack-plugin@4.6.1(webpack@5.105.0)':
     dependencies:
       '@sentry/bundler-plugin-core': 4.6.1
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11851,11 +11342,11 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@storybook/addon-a11y@9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))':
+  '@storybook/addon-a11y@9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.0
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
 
   '@storybook/addon-webpack5-compiler-babel@3.0.6(webpack@5.104.1)':
     dependencies:
@@ -11873,36 +11364,9 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/builder-webpack5@9.1.16(esbuild@0.25.12)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@9.1.16(esbuild@0.25.12)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
     dependencies:
-      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      cjs-module-lexer: 1.4.3
-      css-loader: 6.11.0(webpack@5.104.1(esbuild@0.25.12))
-      es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.12))
-      html-webpack-plugin: 5.6.5(webpack@5.104.1(esbuild@0.25.12))
-      magic-string: 0.30.21
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
-      style-loader: 3.3.4(webpack@5.104.1(esbuild@0.25.12))
-      terser-webpack-plugin: 5.3.14(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12))
-      ts-dedent: 2.2.0
-      webpack: 5.104.1(esbuild@0.25.12)
-      webpack-dev-middleware: 6.1.3(webpack@5.104.1(esbuild@0.25.12))
-      webpack-hot-middleware: 2.26.1
-      webpack-virtual-modules: 0.6.2
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@storybook/builder-webpack5@9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
-    dependencies:
-      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
       css-loader: 6.11.0(webpack@5.104.1)
@@ -11910,11 +11374,11 @@ snapshots:
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1)
       html-webpack-plugin: 5.6.5(webpack@5.104.1)
       magic-string: 0.30.21
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       style-loader: 3.3.4(webpack@5.104.1)
-      terser-webpack-plugin: 5.3.14(webpack@5.104.1)
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.12)(webpack@5.104.1)
       ts-dedent: 2.2.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-dev-middleware: 6.1.3(webpack@5.104.1)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
@@ -11927,9 +11391,36 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/core-webpack@9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))':
+  '@storybook/builder-webpack5@9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
     dependencies:
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      cjs-module-lexer: 1.4.3
+      css-loader: 6.11.0(webpack@5.104.1)
+      es-module-lexer: 1.7.0
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1)
+      html-webpack-plugin: 5.6.5(webpack@5.104.1)
+      magic-string: 0.30.21
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      style-loader: 3.3.4(webpack@5.104.1)
+      terser-webpack-plugin: 5.3.14(webpack@5.104.1)
+      ts-dedent: 2.2.0
+      webpack: 5.104.1
+      webpack-dev-middleware: 6.1.3(webpack@5.104.1)
+      webpack-hot-middleware: 2.26.1
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@storybook/core-webpack@9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))':
+    dependencies:
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       ts-dedent: 2.2.0
 
   '@storybook/global@5.0.0': {}
@@ -11939,7 +11430,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/nextjs@9.1.16(esbuild@0.25.12)(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))':
+  '@storybook/nextjs@9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(postcss@8.5.6))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
@@ -11954,33 +11445,33 @@ snapshots:
       '@babel/preset-react': 7.27.1(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/runtime': 7.28.4
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
-      '@storybook/builder-webpack5': 9.1.16(esbuild@0.25.12)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
-      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(postcss@8.5.6))
+      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
-      css-loader: 6.11.0(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0(postcss@8.5.6))
+      css-loader: 6.11.0(webpack@5.105.0(postcss@8.5.6))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      next: 14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.0(postcss@8.5.6))
       postcss: 8.5.6
-      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0(postcss@8.5.6))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 16.0.6(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      sass-loader: 16.0.6(webpack@5.105.0(postcss@8.5.6))
       semver: 7.7.3
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
-      style-loader: 3.3.4(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      style-loader: 3.3.4(webpack@5.105.0(postcss@8.5.6))
       styled-jsx: 5.1.7(@babel/core@7.28.5)(react@19.2.0)
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -11999,7 +11490,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/nextjs@9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)':
+  '@storybook/nextjs@9.1.16(next@14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
@@ -12015,9 +11506,9 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/runtime': 7.28.4
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
-      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
-      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
-      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@types/semver': 7.7.1
       babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0)
       css-loader: 6.11.0(webpack@5.105.0)
@@ -12033,7 +11524,7 @@ snapshots:
       resolve-url-loader: 5.0.0
       sass-loader: 16.0.6(webpack@5.105.0)
       semver: 7.7.3
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       style-loader: 3.3.4(webpack@5.105.0)
       styled-jsx: 5.1.7(@babel/core@7.28.5)(react@19.2.0)
       tsconfig-paths: 4.2.0
@@ -12059,33 +11550,69 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
+  '@storybook/nextjs@9.1.16(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)':
     dependencies:
-      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.12))
+      '@babel/core': 7.28.5
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.28.5)
+      '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
+      '@babel/preset-react': 7.27.1(@babel/core@7.28.5)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
+      '@babel/runtime': 7.28.4
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0))(webpack-hot-middleware@2.26.1)(webpack@5.105.0)
+      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       '@types/semver': 7.7.1
-      find-up: 7.0.0
-      magic-string: 0.30.21
+      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0)
+      css-loader: 6.11.0(webpack@5.105.0)
+      image-size: 2.0.2
+      loader-utils: 3.3.1
+      next: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.0)
+      postcss: 8.5.6
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0)
       react: 19.2.0
-      react-docgen: 7.1.1
       react-dom: 19.2.0(react@19.2.0)
-      resolve: 1.22.11
+      react-refresh: 0.14.2
+      resolve-url-loader: 5.0.0
+      sass-loader: 16.0.6(webpack@5.105.0)
       semver: 7.7.3
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      style-loader: 3.3.4(webpack@5.105.0)
+      styled-jsx: 5.1.7(@babel/core@7.28.5)(react@19.2.0)
       tsconfig-paths: 4.2.0
-      webpack: 5.104.1(esbuild@0.25.12)
+      tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
+      webpack: 5.105.0
     transitivePeerDependencies:
+      - '@rspack/core'
       - '@swc/core'
+      - '@types/webpack'
+      - babel-plugin-macros
       - esbuild
+      - node-sass
+      - sass
+      - sass-embedded
+      - sockjs-client
       - supports-color
+      - type-fest
       - uglify-js
       - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
+  '@storybook/preset-react-webpack@9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
     dependencies:
-      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)
       '@types/semver': 7.7.1
       find-up: 7.0.0
@@ -12095,9 +11622,9 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.11
       semver: 7.7.3
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       tsconfig-paths: 4.2.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12107,19 +11634,29 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.12))':
+  '@storybook/preset-react-webpack@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
     dependencies:
-      debug: 4.4.3
-      endent: 2.1.0
-      find-cache-dir: 3.3.2
-      flat-cache: 3.2.0
-      micromatch: 4.0.8
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      tslib: 2.8.1
+      '@storybook/core-webpack': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)
+      '@types/semver': 7.7.1
+      find-up: 7.0.0
+      magic-string: 0.30.21
+      react: 19.2.0
+      react-docgen: 7.1.1
+      react-dom: 19.2.0(react@19.2.0)
+      resolve: 1.22.11
+      semver: 7.7.3
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      tsconfig-paths: 4.2.0
+      webpack: 5.104.1
+    optionalDependencies:
       typescript: 5.9.3
-      webpack: 5.104.1(esbuild@0.25.12)
     transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
       - supports-color
+      - uglify-js
+      - webpack-cli
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)':
     dependencies:
@@ -12131,24 +11668,24 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))':
+  '@storybook/react-dom-shim@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
 
-  '@storybook/react-webpack5@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
+  '@storybook/react-webpack5@9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)':
     dependencies:
-      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
-      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
-      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 9.1.16(esbuild@0.25.12)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+      '@storybook/preset-react-webpack': 9.1.16(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)(webpack-cli@6.0.1)
+      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12159,13 +11696,31 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
+  '@storybook/react-webpack5@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
     dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+      '@storybook/builder-webpack5': 9.1.16(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
+      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
+  '@storybook/react@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
     optionalDependencies:
       typescript: 5.9.3
 
@@ -12557,7 +12112,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 9.0.5
       semver: 7.8.0
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.15
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12784,16 +12339,23 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.0
 
-  '@vitejs/plugin-react@4.4.1(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))':
+  '@vitejs/plugin-react@4.4.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@3.1.4':
+    dependencies:
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -12803,69 +12365,60 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/expect@3.2.6':
+  '@vitest/mocker@3.1.4(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))':
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.6
-      '@vitest/utils': 3.2.6
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 3.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.7.6(@types/node@25.9.1)(typescript@5.9.3)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
 
-  '@vitest/mocker@3.2.4(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))':
+  '@vitest/mocker@3.2.4(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.7.6(@types/node@25.9.1)(typescript@5.9.3)
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
 
-  '@vitest/mocker@3.2.6(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))':
+  '@vitest/pretty-format@3.1.4':
     dependencies:
-      '@vitest/spy': 3.2.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.7.6(@types/node@25.9.1)(typescript@5.9.3)
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
+      tinyrainbow: 2.0.0
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@3.2.6':
+  '@vitest/runner@3.1.4':
     dependencies:
-      tinyrainbow: 2.0.0
-
-  '@vitest/runner@3.2.6':
-    dependencies:
-      '@vitest/utils': 3.2.6
+      '@vitest/utils': 3.1.4
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.6':
+  '@vitest/snapshot@3.1.4':
     dependencies:
-      '@vitest/pretty-format': 3.2.6
+      '@vitest/pretty-format': 3.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
+
+  '@vitest/spy@3.1.4':
+    dependencies:
+      tinyspy: 3.0.2
 
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/spy@3.2.6':
+  '@vitest/utils@3.1.4':
     dependencies:
-      tinyspy: 4.0.4
+      '@vitest/pretty-format': 3.1.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
-
-  '@vitest/utils@3.2.6':
-    dependencies:
-      '@vitest/pretty-format': 3.2.6
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -12947,17 +12500,17 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)':
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)':
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.104.1)':
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
     optionalDependencies:
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1)
@@ -12988,9 +12541,9 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-import-phases@1.0.4(acorn@8.17.0):
+  acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.16.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -13002,7 +12555,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  acorn@8.17.0: {}
+  acorn@8.16.0: {}
 
   adjust-sourcemap-loader@4.0.0:
     dependencies:
@@ -13205,21 +12758,21 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       find-up: 5.0.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.104.1):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
-  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.105.0):
     dependencies:
@@ -13287,7 +12840,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.30: {}
 
-  baseline-browser-mapping@2.10.37: {}
+  baseline-browser-mapping@2.10.32: {}
 
   basic-auth@2.0.1:
     dependencies:
@@ -13423,10 +12976,10 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.37
-      caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.372
-      node-releases: 2.0.47
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.361
+      node-releases: 2.0.46
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
@@ -13494,8 +13047,6 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
-  caniuse-lite@1.0.30001799: {}
-
   case-sensitive-paths-webpack-plugin@2.4.0: {}
 
   ccount@1.1.0: {}
@@ -13517,7 +13068,7 @@ snapshots:
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
-      check-error: 2.1.3
+      check-error: 2.1.1
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
@@ -13537,7 +13088,7 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
-  check-error@2.1.3: {}
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -13792,19 +13343,6 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
-  css-loader@6.11.0(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.3
-    optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
-
   css-loader@6.11.0(webpack@5.104.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
@@ -13816,9 +13354,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
-  css-loader@6.11.0(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  css-loader@6.11.0(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -13829,7 +13367,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   css-loader@6.11.0(webpack@5.105.0):
     dependencies:
@@ -13855,7 +13393,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   css-select@4.3.0:
     dependencies:
@@ -14282,7 +13820,7 @@ snapshots:
 
   electron-to-chromium@1.5.286: {}
 
-  electron-to-chromium@1.5.372: {}
+  electron-to-chromium@1.5.361: {}
 
   elliptic@6.6.1:
     dependencies:
@@ -14337,7 +13875,7 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
-  enhanced-resolve@5.24.0:
+  enhanced-resolve@5.22.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -14503,35 +14041,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
-
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -14586,7 +14095,7 @@ snapshots:
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
@@ -14821,7 +14330,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -14838,7 +14347,7 @@ snapshots:
       md5.js: 1.3.5
       safe-buffer: 5.2.1
 
-  expect-type@1.3.0: {}
+  expect-type@1.2.2: {}
 
   express@4.22.2:
     dependencies:
@@ -14939,9 +14448,9 @@ snapshots:
     dependencies:
       websocket-driver: 0.7.4
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.3
 
   fecha@4.2.3: {}
 
@@ -15045,23 +14554,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cosmiconfig: 7.1.0
-      deepmerge: 4.3.1
-      fs-extra: 10.1.0
-      memfs: 3.5.3
-      minimatch: 3.1.2
-      node-abort-controller: 3.1.1
-      schema-utils: 3.3.0
-      semver: 7.7.3
-      tapable: 2.3.0
-      typescript: 5.9.3
-      webpack: 5.104.1(esbuild@0.25.12)
-
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.104.1):
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -15077,7 +14569,7 @@ snapshots:
       semver: 7.7.3
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   form-data@4.0.5:
     dependencies:
@@ -15439,16 +14931,6 @@ snapshots:
 
   html-void-elements@1.0.5: {}
 
-  html-webpack-plugin@5.6.5(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.18.1
-      pretty-error: 4.0.0
-      tapable: 2.3.0
-    optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
-
   html-webpack-plugin@5.6.5(webpack@5.104.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -15457,7 +14939,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -15872,8 +15354,6 @@ snapshots:
   jose@5.9.6: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -16431,7 +15911,7 @@ snapshots:
       '@next/env': 14.2.33
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001799
+      caniuse-lite: 1.0.30001793
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 19.2.0
@@ -16505,7 +15985,7 @@ snapshots:
   node-gyp-build@4.8.4:
     optional: true
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -16532,7 +16012,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   node-polyfill-webpack-plugin@2.0.1(webpack@5.105.0):
     dependencies:
@@ -16565,7 +16045,7 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  node-releases@2.0.47: {}
+  node-releases@2.0.46: {}
 
   normalize-path@3.0.0: {}
 
@@ -16589,7 +16069,7 @@ snapshots:
     optionalDependencies:
       next: 14.2.33(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  nuqs@2.8.5(next@15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0):
+  nuqs@2.8.5(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.0
@@ -16878,7 +16358,7 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.4: {}
+  picomatch@4.0.3: {}
 
   pify@4.0.1: {}
 
@@ -16914,14 +16394,14 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
       postcss: 8.5.6
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     transitivePeerDependencies:
       - typescript
 
@@ -16976,7 +16456,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.15:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -17485,37 +16965,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.53.3
       fsevents: 2.3.3
 
-  rollup@4.62.0:
-    dependencies:
-      '@types/estree': 1.0.9
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.62.0
-      '@rollup/rollup-android-arm64': 4.62.0
-      '@rollup/rollup-darwin-arm64': 4.62.0
-      '@rollup/rollup-darwin-x64': 4.62.0
-      '@rollup/rollup-freebsd-arm64': 4.62.0
-      '@rollup/rollup-freebsd-x64': 4.62.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.62.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.62.0
-      '@rollup/rollup-linux-arm64-gnu': 4.62.0
-      '@rollup/rollup-linux-arm64-musl': 4.62.0
-      '@rollup/rollup-linux-loong64-gnu': 4.62.0
-      '@rollup/rollup-linux-loong64-musl': 4.62.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.62.0
-      '@rollup/rollup-linux-ppc64-musl': 4.62.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.62.0
-      '@rollup/rollup-linux-riscv64-musl': 4.62.0
-      '@rollup/rollup-linux-s390x-gnu': 4.62.0
-      '@rollup/rollup-linux-x64-gnu': 4.62.0
-      '@rollup/rollup-linux-x64-musl': 4.62.0
-      '@rollup/rollup-openbsd-x64': 4.62.0
-      '@rollup/rollup-openharmony-arm64': 4.62.0
-      '@rollup/rollup-win32-arm64-msvc': 4.62.0
-      '@rollup/rollup-win32-ia32-msvc': 4.62.0
-      '@rollup/rollup-win32-x64-gnu': 4.62.0
-      '@rollup/rollup-win32-x64-msvc': 4.62.0
-      fsevents: 2.3.3
-
   rosie@2.1.1: {}
 
   router@2.2.0:
@@ -17565,11 +17014,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.6(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  sass-loader@16.0.6(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   sass-loader@16.0.6(webpack@5.105.0):
     dependencies:
@@ -17924,33 +17373,33 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-i18n@4.0.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))):
+  storybook-i18n@4.0.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))):
     dependencies:
       '@storybook/icons': 1.6.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  storybook-react-i18next@4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))):
+  storybook-react-i18next@4.0.12(i18next-browser-languagedetector@8.2.0)(i18next-http-backend@3.0.2)(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react-i18next@14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))):
     dependencies:
       i18next: 24.2.3(typescript@5.9.3)
       i18next-browser-languagedetector: 8.2.0
       i18next-http-backend: 3.0.2
       react: 19.2.0
       react-i18next: 14.1.3(i18next@24.2.3(typescript@5.9.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
-      storybook-i18n: 4.0.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      storybook-i18n: 4.0.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)))
     transitivePeerDependencies:
       - react-dom
 
-  storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)):
+  storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(prettier@2.8.8)(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      '@vitest/mocker': 3.2.4(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.12
@@ -18088,21 +17537,13 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
-
-  style-loader@3.3.4(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
-
   style-loader@3.3.4(webpack@5.104.1):
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
-  style-loader@3.3.4(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  style-loader@3.3.4(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
 
   style-loader@3.3.4(webpack@5.105.0):
     dependencies:
@@ -18110,7 +17551,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.104.1):
     dependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   style-to-object@0.3.0:
     dependencies:
@@ -18206,14 +17647,14 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
-  terser-webpack-plugin@5.3.14(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12)):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.12)(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.1
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     optionalDependencies:
       esbuild: 0.25.12
 
@@ -18224,16 +17665,16 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.1
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12)):
+  terser-webpack-plugin@5.3.16(esbuild@0.25.12)(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     optionalDependencies:
       esbuild: 0.25.12
 
@@ -18244,20 +17685,19 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1
 
-  terser-webpack-plugin@5.6.1(esbuild@0.25.12)(postcss@8.5.6)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  terser-webpack-plugin@5.6.0(postcss@8.5.6)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     optionalDependencies:
-      esbuild: 0.25.12
       postcss: 8.5.6
 
-  terser-webpack-plugin@5.6.1(webpack@5.105.0):
+  terser-webpack-plugin@5.6.0(webpack@5.105.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -18282,7 +17722,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.17.0
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -18310,14 +17750,16 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyglobby@0.2.17:
+  tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
 
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   tinyspy@4.0.4: {}
 
@@ -18645,13 +18087,13 @@ snapshots:
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
 
-  vite-node@3.2.4(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0):
+  vite-node@3.1.4(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -18666,44 +18108,42 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0):
+  vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0):
     dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.62.0
-      tinyglobby: 0.2.17
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.14
+      rollup: 4.53.3
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.48.0
 
-  vitest@3.2.6(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0):
+  vitest@3.1.4(@types/node@25.9.1)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
-      '@vitest/pretty-format': 3.2.6
-      '@vitest/runner': 3.2.6
-      '@vitest/snapshot': 3.2.6
-      '@vitest/spy': 3.2.6
-      '@vitest/utils': 3.2.6
+      '@vitest/expect': 3.1.4
+      '@vitest/mocker': 3.1.4(msw@2.7.6(@types/node@25.9.1)(typescript@5.9.3))(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.1.4
+      '@vitest/snapshot': 3.1.4
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
       chai: 5.3.3
       debug: 4.4.3
-      expect-type: 1.3.0
+      expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
-      vite-node: 3.2.4(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
+      vite-node: 3.1.4(@types/node@25.9.1)(jiti@2.6.1)(terser@5.48.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
@@ -18733,10 +18173,6 @@ snapshots:
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-
-  watchpack@2.5.2:
-    dependencies:
       graceful-fs: 4.2.11
 
   wbuf@1.7.3:
@@ -18784,20 +18220,10 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1)
-
-  webpack-dev-middleware@6.1.3(webpack@5.104.1(esbuild@0.25.12)):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.3
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.3.3
-    optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
 
   webpack-dev-middleware@6.1.3(webpack@5.104.1):
     dependencies:
@@ -18807,7 +18233,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.104.1):
     dependencies:
@@ -18818,11 +18244,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.2(tslib@2.8.1)
@@ -18831,7 +18257,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     transitivePeerDependencies:
       - tslib
     optional: true
@@ -18881,7 +18307,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.104.1)
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@6.0.1)
+      webpack: 5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
     transitivePeerDependencies:
       - bufferutil
@@ -18890,7 +18316,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6)):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18918,10 +18344,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.6))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.12)(postcss@8.5.6)
+      webpack: 5.105.0(postcss@8.5.6)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18990,39 +18416,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.104.1(esbuild@0.25.12):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.104.1(webpack-cli@6.0.1):
+  webpack@5.104.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -19049,6 +18443,38 @@ snapshots:
       terser-webpack-plugin: 5.3.16(webpack@5.104.1)
       watchpack: 2.5.1
       webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.104.1(esbuild@0.25.12)(webpack-cli@6.0.1):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.19.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(esbuild@0.25.12)(webpack@5.104.1)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.3
     optionalDependencies:
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
     transitivePeerDependencies:
@@ -19064,11 +18490,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.0
+      enhanced-resolve: 5.22.0
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -19080,8 +18506,8 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(webpack@5.105.0)
-      watchpack: 2.5.2
+      terser-webpack-plugin: 5.6.0(webpack@5.105.0)
+      watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -19097,7 +18523,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6):
+  webpack@5.105.0(postcss@8.5.6):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -19105,11 +18531,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.0
+      enhanced-resolve: 5.22.0
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -19121,8 +18547,8 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(esbuild@0.25.12)(postcss@8.5.6)(webpack@5.105.0(esbuild@0.25.12)(postcss@8.5.6))
-      watchpack: 2.5.2
+      terser-webpack-plugin: 5.6.0(postcss@8.5.6)(webpack@5.105.0(postcss@8.5.6))
+      watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
       - '@minify-html/node'


### PR DESCRIPTION
Reverts zooniverse/front-end-monorepo#7481

Merging this PR caused the run tests Action to be flaky in the LRC > Text.spec.

Failed runs:
https://github.com/zooniverse/front-end-monorepo/actions/runs/27565428112
https://github.com/zooniverse/front-end-monorepo/actions/runs/27545230616/attempts/2
https://github.com/zooniverse/front-end-monorepo/actions/runs/27545230616/attempts/1