### PR TITLE
lib-classifier: Support .wav files as an audio subject type for marywestwood/the-cricket-wing

### DIFF
--- a/packages/lib-classifier/src/helpers/constants/constants.js
+++ b/packages/lib-classifier/src/helpers/constants/constants.js
@@ -1,6 +1,6 @@
 const mimeTypesRegexes = {
   application: /^json/,
-  audio: /^[mp3|m4a|mpeg]+$/,
+  audio: /^[mp3|m4a|mpeg|wav]+$/, // .wav is only for marywestwood/the-cricket-wing. Not a recommended audio file type due to size.
   image: /^[jpeg|png|gif]+$/, // Can we deprecate gif support? Should we support svg+xml?
   text: /^plain/,
   video: /^[mp4|mpeg|x\-m4v]+$/

--- a/packages/lib-classifier/src/helpers/validateMimeType/validateMimeType.spec.js
+++ b/packages/lib-classifier/src/helpers/validateMimeType/validateMimeType.spec.js
@@ -9,6 +9,7 @@ const validMimeTypes = [
   'audio/mp3',
   'audio/m4a',
   'audio/mpeg',
+  'audio/wav',
   'video/mp4',
   'video/mpeg',
   'video/x-m4v'
@@ -19,7 +20,6 @@ const invalidMimeTypes = [
   'application/javascript',
   'application/xml',
   'audio/aac',
-  'audio/wav',
   'image/bmp',
   'image/tiff',
   'text/css',

--- a/packages/lib-classifier/src/store/subjects/Subject/SubjectLocation/SubjectLocation.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/SubjectLocation/SubjectLocation.js
@@ -5,6 +5,7 @@ const fileExtensions = {
   'audio/mp3': ['.mp3'],
   'audio/m4a': ['.m4a'],
   'audio/mpeg': ['.mp3', '.mpga'],
+  'audio/wav': ['.wav'], // Only for marywestwood/the-cricket-wing. Not a recommended audio file type due to size.
   'image/png': ['.png'],
   'image/jpeg': ['.jpg', '.jpeg'],
   'image/gif': ['.gif'],


### PR DESCRIPTION
## Package

## Linked Issue and/or Talk Post
This is only for marywestwood/the-cricket-wing. `.wav` is not a recommended audio file type due to size, and is not listed as a supported audio file type in the project builder. The audio file workflow for this project doesn't work in PFE either (see https://www.zooniverse.org/projects/marywestwood/the-cricket-wing/classify), but we'd like to move all audio & audio/spectrogram projects over to FEM, so this one is being included in the migration list.

## Describe your changes
- Add `wav` to the known mime types for subject `locations`.

## How to Review
- Run app-project: https://localhost.zooniverse.org:3000/projects/marywestwood/the-cricket-wing/classify/workflow/20859?env=production&demo=true
- Because a `wav` file has a mime type of `audio/*`, the subject preview cards already support it. If you make a classification in the above workflow with demo mode on, you can see a preview card in "Your Recent Classifications".

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out