### PR TITLE
FlipbookViewer: add optional local state for 'current frame'

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButtonContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButtonContainer.jsx
@@ -18,14 +18,15 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ResetButtonContainer({ separateFrameResetView }) {
+function ResetButtonContainer({ overrideDisabled, separateFrameResetView }) {
   const { disabled, resetView } = useStores(storeMapper)
 
   const resetCallback = separateFrameResetView || resetView
+  const _disabled = overrideDisabled ?? disabled
 
   return (
     <ResetButton
-      disabled={disabled}
+      disabled={_disabled}
       onClick={resetCallback}
     />
   )
@@ -34,6 +35,8 @@ function ResetButtonContainer({ separateFrameResetView }) {
 export default observer(ResetButtonContainer)
 
 ResetButton.propTypes = {
+  /** Overrides the 'disabled' value, which is usually determined by the Subject Viewer Store's disableImageToolbar */
+  overrideDisabled: PropTypes.bool,
   /** Used when separate frames of a subject each have their own ImageToolbar */
   separateFrameResetView: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.jsx
@@ -21,10 +21,11 @@ function storeMapper (classifierStore) {
   }
 }
 
-function RotateButtonContainer({ separateFrameRotate }) {
+function RotateButtonContainer({ overrideDisabled, separateFrameRotate }) {
   const { disabled, rotate, show } = useStores(storeMapper)
 
   const rotateCallback = separateFrameRotate || rotate
+  const _disabled = overrideDisabled ?? disabled
 
   if (!show) {
     return null
@@ -32,13 +33,15 @@ function RotateButtonContainer({ separateFrameRotate }) {
 
   return (
     <RotateButton
-      disabled={disabled}
+      disabled={_disabled}
       onClick={rotateCallback}
     />
   )
 }
 
 RotateButtonContainer.propTypes = {
+  /** Overrides the 'disabled' value, which is usually determined by the Subject Viewer Store's disableImageToolbar */
+  overrideDisabled: PropTypes.bool,
   /** Used when separate frames of a subject each have their own ImageToolbar */
   separateFrameRotate: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.jsx
@@ -17,10 +17,11 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ZoomInButtonContainer({ separateFrameZoomIn }) {
+function ZoomInButtonContainer({ overrideDisabled, separateFrameZoomIn }) {
   const { disabled, zoomIn } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
   const zoomCallback = separateFrameZoomIn || zoomIn
+  const _disabled = overrideDisabled ?? disabled
 
   function onClick() {
     // Stop the zoom callback
@@ -47,7 +48,7 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
 
   return (
     <ZoomInButton
-      disabled={disabled}
+      disabled={_disabled}
       onClick={onClick}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
@@ -58,6 +59,8 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
 export default observer(ZoomInButtonContainer)
 
 ZoomInButtonContainer.propTypes = {
+  /** Overrides the 'disabled' value, which is usually determined by the Subject Viewer Store's disableImageToolbar */
+  overrideDisabled: PropTypes.bool,
   /** Used when separate frames of a subject each have their own ImageToolbar */
   separateFrameZoomIn: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.jsx
@@ -17,10 +17,11 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ZoomOutButtonContainer({ separateFrameZoomOut }) {
+function ZoomOutButtonContainer({ overrideDisabled, separateFrameZoomOut }) {
   const { disabled, zoomOut } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
   const zoomCallback = separateFrameZoomOut || zoomOut
+  const _disabled = overrideDisabled ?? disabled
 
   function onClick() {
     // stop the zoom callback
@@ -47,7 +48,7 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
 
   return (
     <ZoomOutButton
-      disabled={disabled}
+      disabled={_disabled}
       onClick={onClick}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
@@ -58,6 +59,8 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
 export default observer(ZoomOutButtonContainer)
 
 ZoomOutButtonContainer.propTypes = {
+  /** Overrides the 'disabled' value, which is usually determined by the Subject Viewer Store's disableImageToolbar */
+    overrideDisabled: PropTypes.bool,
   /** Used when separate frames of a subject each have their own ImageToolbar */
   separateFrameZoomOut: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -120,6 +120,7 @@ const FlipbookViewer = ({
           autoPlay={false}
           controls={true}
           invert={invert}
+          preload='metadata'
           ref={mediaElementRef}
           src={currentMediaUrl}
           width={viewerWidth}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -38,7 +38,19 @@ const FlipbookViewer = ({
   zoomControlFn = undefined,
   zooming = true
 }) => {
-  // const [currentFrame, setCurrentFrame] = useState(defaultFrame)
+  // Prior to Apr 2026, FlipbookViewer used to store the "current frame" value
+  // in local state, but this caused issues with the image toolbar which
+  // expected synced with the Subject Viewer Store's "current frame".
+  
+  // Also, Subject Viewer Store's resetSubject() ensures that the first `frame`
+  // fed to the FlipbookViewer will either be 0, or the default_frame as set by
+  // subject.metadata. As a result, the defaultFrame prop of FlipbookViewer is
+  // now ONLY used to determine the dimensions of the "subject frame". (i.e. to
+  // keep all images & videos displayed in a consistent width & height)
+  // Future devs, it should be fairly safe to that defaultFrame prop to a say
+  // const REFERENCE_FRAME = 0 ; it only matters that all frames are displayed
+  // in a consistent size.
+
   const [playing, setPlaying] = useState(false)
 
   useEffect(() => {
@@ -134,7 +146,7 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
-  /** Fetched from metadata.default_frame or initialized to zero ⚠️ WARNING: not actually implemented as of Apr 2026 */
+  /** Fetched from metadata.default_frame or initialized to zero. ONLY used to determine size of "subject frame" */
   defaultFrame: PropTypes.number,
   /** Determined per mobx store WorkflowStepStore via SubjectViewer. */
   enableInteractionLayer: PropTypes.bool,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -1,6 +1,7 @@
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
 import { useEffect, useState } from 'react'
+import styled, { css } from 'styled-components'
 
 import { useKeyZoom, useSubjectImageOrVideo } from '@hooks'
 
@@ -12,6 +13,10 @@ import FlipbookControls from './components/FlipbookControls'
 const DEFAULT_HANDLER = () => true
 const DEFAULT_WIDTH = 800
 const DEFAULT_HEIGHT = 600
+
+const StyledVideo = styled.video`
+  ${props => props.invert && css`filter: invert(1)`}
+`
 
 const FlipbookViewer = ({
   defaultFrame = 0,
@@ -102,9 +107,10 @@ const FlipbookViewer = ({
         />
       )}
       {currentMediaType === 'video' && (
-        <video
+        <StyledVideo
           autoPlay={false}
           controls={true}
+          invert={invert}
           ref={mediaElementRef}
           src={currentMediaUrl}
           width={viewerWidth}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -18,6 +18,7 @@ const FlipbookViewer = ({
   enableInteractionLayer = false,
   enableRotation = DEFAULT_HANDLER,
   flipbookAutoplay = false,
+  frame = 0,
   invert = false,
   limitSubjectHeight = false,
   move = false,
@@ -25,13 +26,14 @@ const FlipbookViewer = ({
   onReady = DEFAULT_HANDLER,
   playIterations,
   rotation = 0,
+  setFrame = DEFAULT_HANDLER,
   setOnPan = DEFAULT_HANDLER,
   setOnZoom = DEFAULT_HANDLER,
   subject,
   zoomControlFn = undefined,
   zooming = true
 }) => {
-  const [currentFrame, setCurrentFrame] = useState(defaultFrame)
+  // const [currentFrame, setCurrentFrame] = useState(defaultFrame)
   const [playing, setPlaying] = useState(false)
 
   useEffect(() => {
@@ -66,8 +68,8 @@ const FlipbookViewer = ({
   // only for the sake of determining a consistent viewer width/height for
   // all media files. 
   // --------------------------------
-  const currentMediaType = subject?.locations[currentFrame]?.type
-  const currentMediaUrl = subject?.locations[currentFrame]?.url
+  const currentMediaType = subject?.locations[frame]?.type
+  const currentMediaUrl = subject?.locations[frame]?.url
   // --------------------------------
 
   const onPlayPause = () => {
@@ -82,7 +84,7 @@ const FlipbookViewer = ({
         <SingleImageViewer
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}
-          frame={currentFrame}
+          frame={frame}
           imgRef={mediaElementRef}
           invert={invert}
           limitSubjectHeight={limitSubjectHeight}
@@ -114,9 +116,9 @@ const FlipbookViewer = ({
         />
       )}
       <FlipbookControls
-        currentFrame={currentFrame}
+        currentFrame={frame}
         locations={subject.locations}
-        onFrameChange={setCurrentFrame}
+        onFrameChange={setFrame}
         onPlayPause={onPlayPause}
         playing={playing}
         playIterations={playIterations}
@@ -126,12 +128,14 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
-  /** Fetched from metadata.default_frame or initialized to zero */
+  /** Fetched from metadata.default_frame or initialized to zero ⚠️ WARNING: not actually implemented as of Apr 2026 */
   defaultFrame: PropTypes.number,
   /** Determined per mobx store WorkflowStepStore via SubjectViewer. */
   enableInteractionLayer: PropTypes.bool,
   /** Function passed from Subject Viewer Store */
   enableRotation: PropTypes.func,
+  /** Passed from the subject viewer store. Determins the current frame of the Subject */
+  frame: PropTypes.number,
   /** Fetched from workflow configuration. Determines whether to autoplay the loop on viewer load */
   flipbookAutoplay: PropTypes.bool,
   /** Passed from Subject Viewer Store */
@@ -149,6 +153,8 @@ FlipbookViewer.propTypes = {
   /** Passed from the subject viewer store. Needed in SingleImageViewer to handle transforming (rotating) the image */
   rotation: PropTypes.number,
   /** Usually passed from the Subject Viewer Store. Can be overridden, such as when the FlipbookViewer is used in the DataImageViewer.  */
+  setFrame: PropTypes.func,
+  /** Passed from the Subject Viewer Store */
   setOnPan: PropTypes.func,
   /** Usually passed from the Subject Viewer Store. Can be overridden, such as when the FlipbookViewer is used in the DataImageViewer. */
   setOnZoom: PropTypes.func,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -45,11 +45,8 @@ const FlipbookViewer = ({
   // Also, Subject Viewer Store's resetSubject() ensures that the first `frame`
   // fed to the FlipbookViewer will either be 0, or the default_frame as set by
   // subject.metadata. As a result, the defaultFrame prop of FlipbookViewer is
-  // now ONLY used to determine the dimensions of the "subject frame". (i.e. to
-  // keep all images & videos displayed in a consistent width & height)
-  // Future devs, it should be fairly safe to that defaultFrame prop to a say
-  // const REFERENCE_FRAME = 0 ; it only matters that all frames are displayed
-  // in a consistent size.
+  // now mainly used to determine the dimensions of the "subject frame". (i.e.
+  // to keep all images & videos displayed in a consistent width & height)
 
   const [playing, setPlaying] = useState(false)
 
@@ -146,7 +143,7 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
-  /** Fetched from metadata.default_frame or initialized to zero. ONLY used to determine size of "subject frame" */
+  /** Fetched from metadata.default_frame or initialized to zero. Mainly used to determine size of "subject frame" */
   defaultFrame: PropTypes.number,
   /** Determined per mobx store WorkflowStepStore via SubjectViewer. */
   enableInteractionLayer: PropTypes.bool,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -38,17 +38,27 @@ const FlipbookViewer = ({
   zoomControlFn = undefined,
   zooming = true
 }) => {
-  // Prior to Apr 2026, FlipbookViewer used to store the "current frame" value
-  // in local state, but this caused issues with the image toolbar which
-  // expected synced with the Subject Viewer Store's "current frame".
-  
-  // Also, Subject Viewer Store's resetSubject() ensures that the first `frame`
-  // fed to the FlipbookViewer will either be 0, or the default_frame as set by
+  // Subject Viewer Store's resetSubject() ensures that the first `frame` fed to
+  // the FlipbookViewer will either be 0, or the default_frame as set by
   // subject.metadata. As a result, the defaultFrame prop of FlipbookViewer is
   // now mainly used to determine the dimensions of the "subject frame". (i.e.
   // to keep all images & videos displayed in a consistent width & height)
 
   const [playing, setPlaying] = useState(false)
+
+  // The "current frame" variable changes between using local state or global
+  // state (store) depending on whether the Flipbook is playing through all its
+  // items.
+  // - we use the global state to correctly sync the current Subject with the
+  //   rest of the Classifier, notably the Image Toolbar.
+  // - we use local state for performance reasons, to prevent the global store
+  //   updating too often.
+  // - note that this means when the Flipbook is playing, the rest of Classifier
+  //   is "desynced" (notably, the ImageToolbar's won't update, e.g. the Rotate
+  //   buttons won't disable when the current frame has a video file.)
+  const [localFrame, setLocalFrame] = useState(frame)
+  const effectiveFrame = (playing) ? localFrame : frame 
+  const effectiveSetFrame = (playing) ? setLocalFrame : setFrame
 
   useEffect(() => {
     const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -82,11 +92,17 @@ const FlipbookViewer = ({
   // only for the sake of determining a consistent viewer width/height for
   // all media files. 
   // --------------------------------
-  const currentMediaType = subject?.locations[frame]?.type
-  const currentMediaUrl = subject?.locations[frame]?.url
+  const currentMediaType = subject?.locations[effectiveFrame]?.type
+  const currentMediaUrl = subject?.locations[effectiveFrame]?.url
   // --------------------------------
 
   const onPlayPause = () => {
+    // If we're currently playing and going to pause, tell the global store's current frame to catch up to the local current frame.
+    if (playing) { setFrame(localFrame) }
+    // If we're currently paused and going to play, tell the local store's current frame to sync with the global state.
+    else { setLocalFrame(frame) }
+
+    // Toggle between Play/Pause.
     setPlaying(!playing)
   }
 
@@ -98,7 +114,7 @@ const FlipbookViewer = ({
         <SingleImageViewer
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}
-          frame={frame}
+          frame={effectiveFrame}
           imgRef={mediaElementRef}
           invert={invert}
           limitSubjectHeight={limitSubjectHeight}
@@ -132,9 +148,9 @@ const FlipbookViewer = ({
         />
       )}
       <FlipbookControls
-        currentFrame={frame}
+        currentFrame={effectiveFrame}
         locations={subject.locations}
-        onFrameChange={setFrame}
+        onFrameChange={effectiveSetFrame}
         onPlayPause={onPlayPause}
         playing={playing}
         playIterations={playIterations}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.jsx
@@ -43,6 +43,12 @@ describe('Component > FlipbookViewer', function () {
 
       const newButtonStyle = window.getComputedStyle(thumbnailButtons[1])
       expect(newButtonStyle.border).to.equal('2px solid rgb(0, 93, 105)')
+
+      // Reset
+      await user.pointer({
+        keys: '[MouseLeft]',
+        target: thumbnailButtons[0]
+      })
     })
 
     it('should handle using arrow keys on the tablist', async function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -67,8 +67,8 @@ function FlipbookViewerContainer({
     rotation,
     separateFramesView,
     setFrame,
-    setOnPan,
-    setOnZoom
+    setOnPan: storeSetOnPan,
+    setOnZoom: storeSetOnZoom
   } = useStores(storeMapper)
 
   const effectiveSetOnPan = propSetOnPan || storeSetOnPan

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -88,6 +88,15 @@ function FlipbookViewerContainer({
     return <div>Something went wrong.</div>
   }
 
+  // Figure out the default frame for this Subject, which is usually 0 but can
+  // be overridden by Subject metadata.
+  // This code matches SubjectViewerStore.js's resetSubject()
+  let defaultFrame = 0
+  if (subject?.metadata?.default_frame > 0) {
+    // To the research teams who set the default_frame value, the first item in a list is "1". Hence, we need to change that to Array index "0".
+    defaultFrame = parseInt(subject.metadata.default_frame - 1)
+  }
+
   return (
     <>
       {separateFramesView ? (
@@ -100,6 +109,7 @@ function FlipbookViewerContainer({
         />
       ) : (
         <FlipbookViewer
+          defaultFrame={defaultFrame}
           frame={frame}
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -11,11 +11,12 @@ import SeparateFramesViewer from '../SeparateFramesViewer/SeparateFramesViewer'
 function storeMapper(store) {
   const {
     enableRotation,
-    frame: defaultFrame,
+    frame,
     invert,
     move,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   } = store.subjectViewer
@@ -27,15 +28,16 @@ function storeMapper(store) {
   } = store.workflows?.active?.configuration
 
   return {
-    defaultFrame,
     enableRotation,
     flipbookAutoplay,
+    frame,
     invert,
     limitSubjectHeight,
     move,
     playIterations,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   }
@@ -55,17 +57,18 @@ function FlipbookViewerContainer({
   zooming = true
 }) {
   const {
-    defaultFrame,
     enableRotation,
     flipbookAutoplay,
+    frame,
     invert,
     limitSubjectHeight,
     move,
     playIterations,
     rotation,
     separateFramesView,
-    setOnZoom: storeSetOnZoom,
-    setOnPan: storeSetOnPan,
+    setFrame,
+    setOnPan,
+    setOnZoom
   } = useStores(storeMapper)
 
   const effectiveSetOnPan = propSetOnPan || storeSetOnPan
@@ -97,7 +100,7 @@ function FlipbookViewerContainer({
         />
       ) : (
         <FlipbookViewer
-          defaultFrame={defaultFrame}
+          frame={frame}
           enableInteractionLayer={enableInteractionLayer}
           enableRotation={enableRotation}
           flipbookAutoplay={flipbookAutoplay}
@@ -110,6 +113,7 @@ function FlipbookViewerContainer({
           rotation={rotation}
           setOnPan={effectiveSetOnPan}
           setOnZoom={effectiveSetOnZoom}
+          setFrame={setFrame}
           subject={subject}
           zoomControlFn={zoomControlFn}
           zooming={zooming}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.jsx
@@ -183,10 +183,10 @@ const SeparateFrame = ({
             separateFrameMove={separateFrameMove}
             separateFrameEnableMove={separateFrameEnableMove}
           />
-          <ZoomInButton separateFrameZoomIn={separateFrameZoomIn} />
-          <ZoomOutButton separateFrameZoomOut={separateFrameZoomOut} />
-          <RotateButton separateFrameRotate={separateFrameRotate} />
-          <ResetButton separateFrameResetView={separateFrameResetView} />
+          <ZoomInButton overrideDisabled={false} separateFrameZoomIn={separateFrameZoomIn} />
+          <ZoomOutButton overrideDisabled={false} separateFrameZoomOut={separateFrameZoomOut} />
+          <RotateButton overrideDisabled={false} separateFrameRotate={separateFrameRotate} />
+          <ResetButton overrideDisabled={false} separateFrameResetView={separateFrameResetView} />
           <InvertButton separateFrameInvert={separateFrameInvert} />
         </Box>
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.jsx
@@ -199,6 +199,7 @@ const SeparateFrame = ({
         <video
           autoPlay={false}
           controls={true}
+          preload='metadata'
           ref={mediaElementRef}
           src={frameUrl}
           width={mediaWidth}


### PR DESCRIPTION
## PR Overview

**OPTIONAL** (see Status)
Follows #7326

In 7326, we fixed an issue with the Flipbook Viewer, which was caused by the FV using _local state_ to track the "current frame". This was fixed by using the _classifier global state's_ (i.e. Subject Viewer Store's) "currant frame".

However, there was some concern that using global state  would be less performant than local state. This PR attempts to address the issue by switching between using local state and global state, depending on whether the Flipbook is playing or not.

Functional changes:

- Flipbook Viewer:
  - Nothing user-facing intended. Only changes should be improved performance.
  - That said, new quirk: Image Toolbar is "desynced" from "currently playing frame" while Flipbook is playing. (e.g. if the Flipbook started playing on an image frame, then when it enters a video frame, the Image Toolbar will STILL think it's looking at an image frame, so the Rotate buttons aren't correctly disabled.) (Local state and global state re-sync correctly after the Flipbook stops playing.)

Code changes:

- Flipbook Viewer:
  - Now switches between local state (`localFrame`, `setLocalFrame`) and global state (`frame`, `setFrame`) depending on whether Flipbook is playing.
  - `onPlayPause()` handler now syncs local state with global state (or vice versa)
  - 📖 Documentation updated.

### Testing

[See 7326's Testing section for full tests.](https://github.com/zooniverse/front-end-monorepo/pull/7326)

Additional tests:

- Load app-project, choose a project with image+video subjects, e.g. Chimp & See: https://local.zooniverse.org:8080/?project=sassydumbledore%2Fchimp-and-see&workflow=19226&env=production&demo=true
- Play the Flipbook. Confirm that the Flipbook plays from your current frame (i.e. local state syncs to global state first)
- Pause the Flipbook. Confirm that the current frame is still the one you paused on. (i.e. global state syncs to local state.)
  - Confirm that the Image Toolbar reflects the current media type. (If image, all buttons like rotate, zoom, reset, etc should be enabled and work. If video, only "invert colours" should be enabled.)


### Status

**OPTIONAL.**

This PR is meant to be an optional improvement on top of what was done in PR 7326. However, my performance tests have indicated that using global state for "current frame" is actually pretty OK. We may actually not need this PR (since it adds complexity to the FlipbookViewer component), but if I'm wrong about my measurements then it's good to have this in our pocket ready to go.

Feel free to review, but please don't merge until someone makes a case to do so.