### PR TITLE
lib-react-components: Refactor FavoritesIconButton checked state styling

### DIFF
--- a/packages/lib-react-components/src/FavoritesIconButton/FavoritesIconButton.jsx
+++ b/packages/lib-react-components/src/FavoritesIconButton/FavoritesIconButton.jsx
@@ -32,6 +32,7 @@ function FavoritesIconButton({
       aria-checked={checked}
       disabled={disabled}
       icon={<StyledFavorite $isFavorite={checked} />}
+      pressedWhenChecked={false}
       role='checkbox'
       onClick={toggleFavorite}
     />

--- a/packages/lib-react-components/src/IconActionButton/IconActionButton.jsx
+++ b/packages/lib-react-components/src/IconActionButton/IconActionButton.jsx
@@ -2,6 +2,16 @@ import { Box, Button as GrommetButton, Text, Tip } from 'grommet'
 import { bool, func, node, object, oneOfType, shape, string } from 'prop-types'
 import styled from 'styled-components'
 
+const getPressedStateSelector = (pressedWhenChecked) => {
+  if (pressedWhenChecked) {
+    return `&:active:not(:disabled),
+  &[aria-pressed='true'],
+  &[aria-checked='true']`
+  }
+  return `&:active:not(:disabled),
+  &[aria-pressed='true']`
+}
+
 const StyledButton = styled(GrommetButton)`
   align-items: center;
   aspect-ratio: 1;
@@ -62,9 +72,7 @@ const StyledButton = styled(GrommetButton)`
     outline: none;
   }
 
-  &:active:not(:disabled),
-  &[aria-pressed='true'],
-  &[aria-checked='true'] {
+  ${props => getPressedStateSelector(props.$pressedWhenChecked)} {
     background-color: ${props => props.theme.global.colors['neutral-1']};
 
     > svg {
@@ -116,6 +124,7 @@ function IconActionButton({
   onPointerOut = DEFAULT_HANDLER,
   onPointerOver = DEFAULT_HANDLER,
   onPointerUp = DEFAULT_HANDLER,
+  pressedWhenChecked = true,
   role,
   ...props
 }) {
@@ -148,6 +157,7 @@ function IconActionButton({
         icon={icon}
         plain
         role={role}
+        $pressedWhenChecked={pressedWhenChecked}
         {...eventHandlers}
         {...props}
       />
@@ -176,6 +186,7 @@ IconActionButton.propTypes = {
   onPointerOut: func,
   onPointerOver: func,
   onPointerUp: func,
+  pressedWhenChecked: bool,
   role: string,
   theme: shape({
     dark: bool


### PR DESCRIPTION
## Package
- lib-react-components

## Describe your changes
- update IconActionButton with `pressedWhenChecked` prop to conditionally show styling accordingly
- update FavoritesIconButton with `pressedWhenChecked` to `false` so checked (favorited) button state is just pink heart without pressed fill color

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - https://local.zooniverse.org:3000/projects/markb-panoptes/sltp-test-project-staging/talk/subjects/252638?env=staging
- What user actions should my reviewer step through to review this PR?
  - press an unfavorited subject's favorite button, note pressed state styling
  - release, note favorite button checked state
  - press favorited subject's favorite button, note pressed state styling
- Which storybook stories should be reviewed?
  - http://localhost:6007/?path=/story/components-favoritesiconbutton--checked
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected