### PR TITLE
lib-react-components: Update Media Video with poster property

### DIFF
--- a/packages/lib-react-components/src/Media/Media.stories.jsx
+++ b/packages/lib-react-components/src/Media/Media.stories.jsx
@@ -32,6 +32,8 @@ const TEXT_URL =
   'https://panoptes-uploads.zooniverse.org/subject_location/f5506d1c-a0e9-4aba-a418-6a6c46a7731a.txt'
 const VIDEO_URL =
   'https://static.zooniverse.org/fem-assets/home-video.mp4'
+const VIDEO_ZOONIVERSE_URL =
+  'https://panoptes-uploads.zooniverse.org/subject_location/6d83e7bd-14d1-41cb-8245-8d70a4d3921a.mp4'
 const VOLUMETRIC_URL = 
   'https://panoptes-uploads-staging.zooniverse.org/subject_location/3c56e6a7-be27-4ab3-93a7-c41a3c867baf.json'
 
@@ -97,6 +99,10 @@ export function Video() {
       <Box width='540px' height='540px'>
         <Media alt='Zooniverse in a nutshell' fit='cover' src={VIDEO_URL} />
       </Box>
+      <Text>Zooniverse video src with showPoster</Text>
+      <Media alt='Zooniverse src with showPoster' controls={false} showPoster src={VIDEO_ZOONIVERSE_URL} width={270} />
+      <Text>External video src with showPoster, fallback to default video behavior</Text>
+      <Media alt='External src with showPoster' controls={false} showPoster src={VIDEO_URL} width={270} />
     </Box>
   )
 }

--- a/packages/lib-react-components/src/Media/README.md
+++ b/packages/lib-react-components/src/Media/README.md
@@ -10,6 +10,7 @@ The Media component dynamically renders an appropriate child media component bas
 - height: _(number)_ height in CSS pixels.
 - origin: _(string)_ The origin for the Zooniverse thumbnail service. Defaults to `'https://thumbnails.zooniverse.org'`
 - placeholder: _(node)_ React component or HTML to render as a child of the placeholder container while the image is loading
+- showPoster: _(bool)_ whether to show a poster thumbnail for video media. Defaults to false. When true, preload is set to `'none'`; when false, preload is set to `'metadata'`.
 - src: _(string)_ the source of the media. Required.
   - NOTE: MIME type and the corresponding child media component is determined by this string. If a MIME type can't be guessed, consider specifying a `defaultMimeType`
 - width: _(number)_ width in CSS pixels.

--- a/packages/lib-react-components/src/Media/README.md
+++ b/packages/lib-react-components/src/Media/README.md
@@ -11,6 +11,7 @@ The Media component dynamically renders an appropriate child media component bas
 - origin: _(string)_ The origin for the Zooniverse thumbnail service. Defaults to `'https://thumbnails.zooniverse.org'`
 - placeholder: _(node)_ React component or HTML to render as a child of the placeholder container while the image is loading
 - showPoster: _(bool)_ whether to show a poster thumbnail for video media. Defaults to false. When true, preload is set to `'none'`; when false, preload is set to `'metadata'`.
+  - NOTE: poster thumbnails are generated using the Zooniverse thumbnail service, and ensures the preview images downloaded are very small (compared to downloading the video metadata). This will only work if the video files are hosted on the Zooniverse, however - see the [Zooniverse thumbnailer repo](https://github.com/zooniverse/thumbnailer) for acceptable file hosts. If the video is hosted elsewhere, the poster will not be generated and the default video behavior will be used.
 - src: _(string)_ the source of the media. Required.
   - NOTE: MIME type and the corresponding child media component is determined by this string. If a MIME type can't be guessed, consider specifying a `defaultMimeType`
 - width: _(number)_ width in CSS pixels.

--- a/packages/lib-react-components/src/Media/components/Video/Video.jsx
+++ b/packages/lib-react-components/src/Media/components/Video/Video.jsx
@@ -15,12 +15,17 @@ export default function Video({
   flex = defaultProps.flex,
   height,
   origin = defaultProps.origin,
+  showPoster = defaultProps.poster,
   src = defaultProps.src,
   width,
   ...rest
 }) {
   const controlsOption = (controls) ? 'below' : false
-  const poster = getThumbnailSrc({ height, origin, src, width })
+  
+  let posterSrc = null
+  if (showPoster) {
+    posterSrc = getThumbnailSrc({ height, origin, src, width })
+  }
 
   const cssHeight = height > 0 ? `${height}px` : height
   const cssWidth = width > 0 ? `${width}px` : width
@@ -43,8 +48,8 @@ export default function Video({
         a11yTitle={alt}
         controls={controlsOption}
         fit={fit}
-        poster={poster}
-        preload={poster ? 'none' : 'metadata'}
+        poster={posterSrc}
+        preload={showPoster ? 'none' : 'metadata'}
         src={src}
       />
     </StyledBox>

--- a/packages/lib-react-components/src/Media/components/Video/Video.jsx
+++ b/packages/lib-react-components/src/Media/components/Video/Video.jsx
@@ -1,5 +1,6 @@
 import { Box, Video as GrommetVideo } from 'grommet'
 import styled, { css } from 'styled-components'
+import getThumbnailSrc from '../../helpers/getThumbnailSrc.js'
 import { propTypes, defaultProps } from '../../helpers/mediaPropTypes'
 
 const StyledBox = styled(Box)`
@@ -13,11 +14,13 @@ export default function Video({
   fit = defaultProps.fit,
   flex = defaultProps.flex,
   height,
+  origin = defaultProps.origin,
   src = defaultProps.src,
   width,
   ...rest
 }) {
   const controlsOption = (controls) ? 'below' : false
+  const poster = getThumbnailSrc({ height, origin, src, width })
 
   const cssHeight = height > 0 ? `${height}px` : height
   const cssWidth = width > 0 ? `${width}px` : width
@@ -40,8 +43,9 @@ export default function Video({
         a11yTitle={alt}
         controls={controlsOption}
         fit={fit}
-        preload='metadata'
-        src={src} 
+        poster={poster}
+        preload={poster ? 'none' : 'metadata'}
+        src={src}
       />
     </StyledBox>
   )

--- a/packages/lib-react-components/src/Media/components/Video/Video.jsx
+++ b/packages/lib-react-components/src/Media/components/Video/Video.jsx
@@ -8,6 +8,22 @@ const StyledBox = styled(Box)`
   ${props => props.maxWidth && css`max-width: ${props.maxWidth}px;`}
 `
 
+const THUMBNAILER_SUPPORTED_HOSTS = [
+  'panoptes-uploads-staging.zooniverse.org',
+  'panoptes-uploads.zooniverse.org'
+]
+
+function canGeneratePosterFromSrc(src) {
+  if (!src) return false
+
+  try {
+    const parsedUrl = new URL(src)
+    return THUMBNAILER_SUPPORTED_HOSTS.includes(parsedUrl.hostname)
+  } catch {
+    return false
+  }
+}
+
 export default function Video({
   alt = defaultProps.alt,
   controls = defaultProps.controls,
@@ -21,10 +37,13 @@ export default function Video({
   ...rest
 }) {
   const controlsOption = (controls) ? 'below' : false
-  
+  const shouldShowPoster = showPoster && canGeneratePosterFromSrc(src)
+
   let posterSrc = null
-  if (showPoster) {
-    posterSrc = getThumbnailSrc({ height, origin, src, width })
+  if (shouldShowPoster) {
+    const posterWidth = width > 0 ? width : 999
+    const posterHeight = height > 0 ? height : posterWidth
+    posterSrc = getThumbnailSrc({ height: posterHeight, origin, src, width: posterWidth })
   }
 
   const cssHeight = height > 0 ? `${height}px` : height
@@ -49,7 +68,7 @@ export default function Video({
         controls={controlsOption}
         fit={fit}
         poster={posterSrc}
-        preload={showPoster ? 'none' : 'metadata'}
+        preload={shouldShowPoster ? 'none' : 'metadata'}
         src={src}
       />
     </StyledBox>

--- a/packages/lib-react-components/src/Media/components/Video/Video.spec.jsx
+++ b/packages/lib-react-components/src/Media/components/Video/Video.spec.jsx
@@ -13,8 +13,8 @@ describe('Video', function () {
     expect(videoElement).toBeTruthy()
   })
 
-  it('should set the video poster to the thumbnailer src', function () {
-    render(<Video src={videoSrc} />)
+  it('should set the video poster to the thumbnailer src when showPoster is true', function () {
+    render(<Video src={videoSrc} showPoster />)
     const videoElement = document.querySelector('video')
     const expectedPoster = getThumbnailSrc({ origin: defaultProps.origin, src: videoSrc })
     expect(videoElement.getAttribute('poster')).to.equal(expectedPoster)

--- a/packages/lib-react-components/src/Media/components/Video/Video.spec.jsx
+++ b/packages/lib-react-components/src/Media/components/Video/Video.spec.jsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react'
 
 import Video from './Video'
+import getThumbnailSrc from '../../helpers/getThumbnailSrc'
+import { defaultProps } from '../../helpers/mediaPropTypes'
 
 const videoSrc = 'https://static.zooniverse.org/fem-assets/home-video.mp4'
 
@@ -9,6 +11,13 @@ describe('Video', function () {
     render(<Video src={videoSrc} />)
     const videoElement = document.querySelector('video')
     expect(videoElement).toBeTruthy()
+  })
+
+  it('should set the video poster to the thumbnailer src', function () {
+    render(<Video src={videoSrc} />)
+    const videoElement = document.querySelector('video')
+    const expectedPoster = getThumbnailSrc({ origin: defaultProps.origin, src: videoSrc })
+    expect(videoElement.getAttribute('poster')).to.equal(expectedPoster)
   })
 
   it('should show the video controls', function () {

--- a/packages/lib-react-components/src/Media/components/Video/Video.spec.jsx
+++ b/packages/lib-react-components/src/Media/components/Video/Video.spec.jsx
@@ -5,6 +5,7 @@ import getThumbnailSrc from '../../helpers/getThumbnailSrc'
 import { defaultProps } from '../../helpers/mediaPropTypes'
 
 const videoSrc = 'https://static.zooniverse.org/fem-assets/home-video.mp4'
+const panoptesVideoSrc = 'https://panoptes-uploads.zooniverse.org/subject_location/6d83e7bd-14d1-41cb-8245-8d70a4d3921a.mp4'
 
 describe('Video', function () {
   it('should show a video element', function () {
@@ -14,10 +15,31 @@ describe('Video', function () {
   })
 
   it('should set the video poster to the thumbnailer src when showPoster is true', function () {
-    render(<Video src={videoSrc} showPoster />)
+    render(<Video src={panoptesVideoSrc} showPoster />)
     const videoElement = document.querySelector('video')
-    const expectedPoster = getThumbnailSrc({ origin: defaultProps.origin, src: videoSrc })
+    const expectedPoster = getThumbnailSrc({ height: 999, origin: defaultProps.origin, src: panoptesVideoSrc, width: 999 })
     expect(videoElement.getAttribute('poster')).to.equal(expectedPoster)
+  })
+
+  it('should set a default poster height when showPoster is true and only width is provided', function () {
+    render(<Video src={panoptesVideoSrc} showPoster width={270} />)
+    const videoElement = document.querySelector('video')
+    const expectedPoster = getThumbnailSrc({ height: 270, origin: defaultProps.origin, src: panoptesVideoSrc, width: 270 })
+    expect(videoElement.getAttribute('poster')).to.equal(expectedPoster)
+  })
+
+  it('should fall back to metadata preload and no poster for static.zooniverse.org videos', function () {
+    render(<Video src={videoSrc} showPoster width={270} />)
+    const videoElement = document.querySelector('video')
+    expect(videoElement.getAttribute('poster')).to.equal(null)
+    expect(videoElement.getAttribute('preload')).to.equal('metadata')
+  })
+
+  it('should fall back to metadata preload and no poster for unsupported video hosts', function () {
+    render(<Video src='https://example.com/video.mp4' showPoster width={270} />)
+    const videoElement = document.querySelector('video')
+    expect(videoElement.getAttribute('poster')).to.equal(null)
+    expect(videoElement.getAttribute('preload')).to.equal('metadata')
   })
 
   it('should show the video controls', function () {

--- a/packages/lib-react-components/src/Media/helpers/mediaPropTypes.js
+++ b/packages/lib-react-components/src/Media/helpers/mediaPropTypes.js
@@ -8,6 +8,7 @@ export const propTypes = {
   height: number,
   origin: string,
   placeholder: oneOfType([node, object]),
+  showPoster: bool,
   src: string.isRequired,
   width: number
 }
@@ -19,5 +20,6 @@ export const defaultProps = {
   fit: 'cover',
   flex: 'grow',
   origin: 'https://thumbnails.zooniverse.org',
+  showPoster: false,
   placeholder: null
 }

--- a/packages/lib-react-components/src/SubjectCard/SubjectCard.jsx
+++ b/packages/lib-react-components/src/SubjectCard/SubjectCard.jsx
@@ -149,6 +149,7 @@ function SubjectCard({
                 fit='cover'
                 height={previewHeight}
                 placeholder={placeholder}
+                showPoster={true}
                 src={mediaSrc}
                 width={width}
                 aria-hidden='true'
@@ -163,6 +164,7 @@ function SubjectCard({
               controls={false}
               fit='contain'
               placeholder={placeholder}
+              showPoster={true}
               height={previewHeight}
               src={mediaSrc}
               width={width}


### PR DESCRIPTION
## Package
- lib-react-components

## Linked Issue and/or Talk Post
- currently, often subject videos are downloaded in their entirety when only a single frame is shown
- videos can be large in kb size
- based on new Thumbnailer service that takes a Zooniverse video file and returns the first frame as an image
- we can utilize the video element poster property to show the first frame image and not download the video

## Describe your changes
- update Media Video with `showPoster` property to use src with origin as [video element poster property](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video#poster) url, with [new Thumbnailer functionality](https://github.com/zooniverse/thumbnailer/pull/28)
- refactor SubjectCard with `showPoster={true}`

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a until SubjectCard implemented
- What user actions should my reviewer step through to review this PR?
  - currently, https://zooniverse.github.io/front-end-monorepo/@zooniverse/react-components/index.html?path=/story/components-subjectcard-video--florida-keys: load SubjectCard with videos, inspect network tab, filter by media, note videos loaded
  - on this branch, http://localhost:6007/?path=/story/components-subjectcard-video--florida-keys: same as above, note NO videos loaded only images 
- Which storybook stories should be reviewed?
  - http://localhost:6007/?path=/story/components-subjectcard-video--woodpecker-cavity-cam
- Are there plans for follow up PR’s to further fix this bug or develop this feature? maybe there are other instances

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected