### PR TITLE
lib-classifier: Constrain GeoMapViewer to the subject extent with a bounds mask

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -19,7 +19,7 @@ import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 import { GEOJSON_READ_OPTIONS, ZOOM_ANIMATION_DURATION_MS } from './helpers/constants'
 import loadGeoJSON from './helpers/loadGeoJSON'
-import { fitViewToFeatures } from './helpers/mapSelection'
+import { fitViewToExtent } from './helpers/mapSelection'
 
 import useMapCursor from './hooks/useMapCursor'
 import useMapInteractions from './hooks/useMapInteractions'
@@ -197,7 +197,7 @@ function GeoMapViewer({
 
   const handleRecenter = useCallback(() => {
     if (!map || !source || source.getFeatures().length === 0) return
-    fitViewToFeatures(map, source, ZOOM_ANIMATION_DURATION_MS)
+    fitViewToExtent(map, map.get('subjectExtent') || source.getExtent(), ZOOM_ANIMATION_DURATION_MS)
   }, [map, source])
 
   const handleReset = useCallback(() => {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringInteraction.js
@@ -3,6 +3,9 @@ import { unByKey } from 'ol/Observable'
 import Draw from 'ol/interaction/Draw'
 import { createEditingStyle } from 'ol/style/Style'
 
+import { isWithinSubjectExtent } from './extentConstraint'
+import isLineStringFeature from './isLineStringFeature'
+
 export const FEATURE_HIT_TOLERANCE_PX = 8
 
 const DEFAULT_DRAW_STYLES = createEditingStyle()
@@ -12,9 +15,10 @@ export function buildSketchStyleFn({ map, featuresLayer, getIsDrawing }) {
     const geometry = feature?.getGeometry?.()
     const geometryType = geometry?.getType?.()
     if (!geometryType) return DEFAULT_DRAW_STYLES.Point
-    if (geometryType === 'Point' && !getIsDrawing() && featuresLayer) {
+    if (geometryType === 'Point') {
       const coord = geometry.getCoordinates?.()
-      if (coord) {
+      if (coord && !isWithinSubjectExtent(map, coord)) return null
+      if (!getIsDrawing() && featuresLayer && coord) {
         const pixel = map.getPixelFromCoordinate(coord)
         if (pixel && map.hasFeatureAtPixel(pixel, {
           layerFilter: (layer) => layer === featuresLayer,
@@ -30,7 +34,7 @@ export function buildSketchStyleFn({ map, featuresLayer, getIsDrawing }) {
 
 function countLineStringFeaturesForTool(source, toolIndex) {
   return source.getFeatures().filter((feature) => {
-    if (feature.getGeometry?.()?.getType?.() !== 'LineString') return false
+    if (!isLineStringFeature(feature)) return false
     if (typeof toolIndex !== 'number') return true
     return feature.get?.('toolIndex') === toolIndex
   }).length
@@ -69,6 +73,7 @@ function createGeoLineStringInteraction({
     type: 'LineString',
     condition: (event) => {
       if (!primaryAction(event)) return false
+      if (!isWithinSubjectExtent(map, event.coordinate)) return false
       if (isDrawing) return !isDuplicateVertexClick(event)
       if (!featuresLayer) return true
       return !map.hasFeatureAtPixel(event.pixel, {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringModifyInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoLineStringModifyInteraction.js
@@ -1,9 +1,19 @@
 import { primaryAction } from 'ol/events/condition'
 import Modify from 'ol/interaction/Modify'
 
+import { clampToSubjectExtent } from './extentConstraint'
+import isLineStringFeature from './isLineStringFeature'
+
 export function hasLineStringFeature(features) {
-  if (!features || features.length === 0) return false
-  return features.some((feature) => feature.getGeometry?.()?.getType?.() === 'LineString')
+  return Boolean(features?.some(isLineStringFeature))
+}
+
+function clampFeaturesToSubjectExtent(map, features) {
+  features.filter(isLineStringFeature).forEach((feature) => {
+    const geometry = feature.getGeometry()
+    geometry.setCoordinates(geometry.getCoordinates().map((coordinate) => clampToSubjectExtent(map, coordinate)))
+    feature.changed()
+  })
 }
 
 function createGeoLineStringModifyInteraction({
@@ -15,8 +25,7 @@ function createGeoLineStringModifyInteraction({
   let isModifying = false
 
   function getSelectedLineStringVertexCount() {
-    const feature = selectInteraction.getFeatures().getArray()
-      .find((f) => f.getGeometry?.()?.getType?.() === 'LineString')
+    const feature = selectInteraction.getFeatures().getArray().find(isLineStringFeature)
     if (!feature) return null
     return feature.getGeometry().getCoordinates().length
   }
@@ -35,8 +44,9 @@ function createGeoLineStringModifyInteraction({
   })
 
   const startKey = modify.on('modifystart', () => { isModifying = true })
-  const endKey = modify.on('modifyend', () => {
+  const endKey = modify.on('modifyend', (event) => {
     isModifying = false
+    clampFeaturesToSubjectExtent(map, event.features.getArray())
     onModifyEnd?.()
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
@@ -2,6 +2,7 @@ import PointerInteraction from 'ol/interaction/Pointer'
 import { get as getProjection } from 'ol/proj'
 import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/features/models/Point/dragHandle'
 import asMSTFeature from './asMSTFeature'
+import { clampToSubjectExtent, isWithinSubjectExtent } from './extentConstraint'
 import getPixelDistance from './getPixelDistance'
 import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixelsAcrossWorldCopies } from './hitTesting'
 
@@ -102,6 +103,7 @@ function createMoveToClickInteraction({
   }
 
   function teleportFeatureTo(coordinate, projectionCode) {
+    if (!isWithinSubjectExtent(map, coordinate)) return
     const geometry = state.selectedFeature.getGeometry()
     if (!geometry || typeof geometry.setCoordinates !== 'function') return
 
@@ -239,9 +241,13 @@ function createMoveToClickInteraction({
 
     if (geometry && typeof geometry.setCoordinates === 'function') {
       const projectionCode = map.getView().getProjection().getCode()
-      geometry.setCoordinates([
-        normalizeCoordinateToWorld(state.featureCoordinate[0] + deltaX, projectionCode),
+      const clamped = clampToSubjectExtent(map, [
+        state.featureCoordinate[0] + deltaX,
         state.featureCoordinate[1] + deltaY
+      ])
+      geometry.setCoordinates([
+        normalizeCoordinateToWorld(clamped[0], projectionCode),
+        clamped[1]
       ])
       state.selectedFeature.changed()
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/extentConstraint.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/extentConstraint.js
@@ -1,0 +1,81 @@
+import { View } from 'ol'
+import Feature from 'ol/Feature'
+import { containsCoordinate, getHeight, getWidth } from 'ol/extent'
+import Polygon, { fromExtent } from 'ol/geom/Polygon'
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
+import { Fill, Stroke, Style } from 'ol/style'
+
+export const EXTENT_PADDING_FACTOR = 0.1
+// The outer mask ring only needs to outrun the pan range the padded view extent allows.
+export const MASK_COVERAGE_FACTOR = 50
+export const MASK_FILL_COLOR = 'rgba(0, 0, 0, 0.35)'
+export const MASK_STROKE_COLOR = 'rgba(255, 255, 255, 0.9)'
+export const MASK_STROKE_WIDTH = 2
+
+export function padExtent(extent, factor = EXTENT_PADDING_FACTOR) {
+  const dx = getWidth(extent) * factor
+  const dy = getHeight(extent) * factor
+  return [extent[0] - dx, extent[1] - dy, extent[2] + dx, extent[3] + dy]
+}
+
+export function isWithinSubjectExtent(map, coordinate) {
+  const extent = map?.get('subjectExtent')
+  if (!extent) return true
+  return containsCoordinate(extent, coordinate)
+}
+
+export function clampToSubjectExtent(map, coordinate) {
+  const extent = map?.get('subjectExtent')
+  if (!extent) return coordinate
+  return [
+    Math.min(Math.max(coordinate[0], extent[0]), extent[2]),
+    Math.min(Math.max(coordinate[1], extent[1]), extent[3])
+  ]
+}
+
+export function createExtentMaskLayer(extent) {
+  const outerRing = fromExtent(padExtent(extent, MASK_COVERAGE_FACTOR)).getCoordinates()[0]
+  const innerRing = fromExtent(extent).getCoordinates()[0]
+  const mask = new Feature(new Polygon([outerRing, innerRing]))
+  const layer = new VectorLayer({
+    source: new VectorSource({ features: [mask], wrapX: false }),
+    style: new Style({
+      fill: new Fill({ color: MASK_FILL_COLOR }),
+      stroke: new Stroke({ color: MASK_STROKE_COLOR, width: MASK_STROKE_WIDTH })
+    })
+  })
+  layer.set('extentMask', true)
+  return layer
+}
+
+// OL only accepts an extent constraint at View construction, so constraining swaps the view.
+function createConstrainedView(map, extent) {
+  const view = map.getView()
+  const size = map.getSize()
+  const constrained = new View({
+    center: view.getCenter(),
+    zoom: view.getZoom(),
+    projection: view.getProjection(),
+    extent,
+    constrainOnlyCenter: true
+  })
+  if (size) {
+    const fitResolution = Math.max(getWidth(extent) / size[0], getHeight(extent) / size[1])
+    constrained.setMinZoom(constrained.getZoomForResolution(fitResolution))
+  }
+  return constrained
+}
+
+export default function constrainMapToExtent(map, extent) {
+  // A lone point subject with no bbox has a zero-area extent; skip constraining.
+  if (!map || !extent || getWidth(extent) <= 0 || getHeight(extent) <= 0) return
+
+  map.set('subjectExtent', extent)
+  map.setView(createConstrainedView(map, padExtent(extent)))
+
+  const layers = map.getLayers()
+  const previousMask = layers.getArray().find(layer => layer.get('extentMask'))
+  if (previousMask) map.removeLayer(previousMask)
+  layers.insertAt(layers.getLength() - 1, createExtentMaskLayer(extent))
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/extentConstraint.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/extentConstraint.spec.js
@@ -1,0 +1,164 @@
+import { Map, View } from 'ol'
+import { createEmpty } from 'ol/extent'
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
+
+import constrainMapToExtent, {
+  EXTENT_PADDING_FACTOR,
+  MASK_COVERAGE_FACTOR,
+  clampToSubjectExtent,
+  createExtentMaskLayer,
+  isWithinSubjectExtent,
+  padExtent
+} from './extentConstraint'
+
+function buildMap() {
+  const source = new VectorSource({ features: [] })
+  const layer = new VectorLayer({ source })
+  const map = new Map({
+    layers: [layer],
+    view: new View({ center: [0, 0], zoom: 0 })
+  })
+  map.setSize([800, 600])
+  return { map, layer }
+}
+
+const EXTENT = [0, 0, 1000, 500]
+
+describe('helpers > extentConstraint', function () {
+  describe('padExtent', function () {
+    it('pads each axis by the padding factor', function () {
+      expect(padExtent(EXTENT, 0.1)).to.deep.equal([-100, -50, 1100, 550])
+    })
+
+    it('defaults to a 10% padding factor', function () {
+      expect(EXTENT_PADDING_FACTOR).to.equal(0.1)
+      expect(padExtent(EXTENT)).to.deep.equal(padExtent(EXTENT, 0.1))
+    })
+  })
+
+  describe('constrainMapToExtent', function () {
+    it('constrains the view center to the padded extent', function () {
+      const { map } = buildMap()
+      constrainMapToExtent(map, EXTENT)
+      const view = map.getView()
+      expect(view.getConstrainedCenter([50000, 50000])).to.deep.equal([1100, 550])
+      expect(view.getConstrainedCenter([-50000, -50000])).to.deep.equal([-100, -50])
+    })
+
+    it('allows the view center to reach an extent corner', function () {
+      const { map } = buildMap()
+      constrainMapToExtent(map, EXTENT)
+      expect(map.getView().getConstrainedCenter([0, 0])).to.deep.equal([0, 0])
+    })
+
+    it('caps zoom-out so the subject cannot shrink away', function () {
+      const { map } = buildMap()
+      constrainMapToExtent(map, EXTENT)
+      expect(map.getView().getMinZoom()).to.be.above(0)
+    })
+
+    it('preserves the current center and zoom', function () {
+      const { map } = buildMap()
+      map.getView().setCenter([500, 250])
+      map.getView().setZoom(18)
+      constrainMapToExtent(map, EXTENT)
+      expect(map.getView().getCenter()).to.deep.equal([500, 250])
+      expect(map.getView().getZoom()).to.equal(18)
+    })
+
+    it('adds a mask layer below the drawing layer', function () {
+      const { map, layer } = buildMap()
+      constrainMapToExtent(map, EXTENT)
+      const layers = map.getLayers().getArray()
+      const maskIndex = layers.findIndex(l => l.get('extentMask'))
+      expect(maskIndex).to.be.at.least(0)
+      expect(maskIndex).to.be.below(layers.indexOf(layer))
+    })
+
+    it('does not stack mask layers across repeated calls', function () {
+      const { map } = buildMap()
+      constrainMapToExtent(map, EXTENT)
+      constrainMapToExtent(map, EXTENT)
+      const masks = map.getLayers().getArray().filter(l => l.get('extentMask'))
+      expect(masks).to.have.lengthOf(1)
+    })
+
+    it('ignores an empty extent', function () {
+      const { map } = buildMap()
+      const view = map.getView()
+      constrainMapToExtent(map, createEmpty())
+      expect(map.getView()).to.equal(view)
+      expect(map.getLayers().getArray().some(l => l.get('extentMask'))).to.equal(false)
+    })
+
+    it('ignores a zero-area extent, e.g. a single point subject', function () {
+      const { map } = buildMap()
+      const view = map.getView()
+      constrainMapToExtent(map, [100, 200, 100, 200])
+      expect(map.getView()).to.equal(view)
+      expect(map.getLayers().getArray().some(l => l.get('extentMask'))).to.equal(false)
+    })
+  })
+
+  describe('createExtentMaskLayer', function () {
+    it('builds a polygon with a hole at the subject extent', function () {
+      const layer = createExtentMaskLayer(EXTENT)
+      const [feature] = layer.getSource().getFeatures()
+      const rings = feature.getGeometry().getCoordinates()
+      expect(rings).to.have.lengthOf(2)
+      const innerXs = rings[1].map(coord => coord[0])
+      const innerYs = rings[1].map(coord => coord[1])
+      expect(Math.min(...innerXs)).to.equal(EXTENT[0])
+      expect(Math.min(...innerYs)).to.equal(EXTENT[1])
+      expect(Math.max(...innerXs)).to.equal(EXTENT[2])
+      expect(Math.max(...innerYs)).to.equal(EXTENT[3])
+    })
+
+    it('covers far beyond the subject extent so panning never reveals a gap', function () {
+      const layer = createExtentMaskLayer(EXTENT)
+      const [feature] = layer.getSource().getFeatures()
+      const outerXs = feature.getGeometry().getCoordinates()[0].map(coord => coord[0])
+      const outerWidth = Math.max(...outerXs) - Math.min(...outerXs)
+      expect(outerWidth).to.be.at.least((EXTENT[2] - EXTENT[0]) * MASK_COVERAGE_FACTOR)
+    })
+  })
+
+  describe('subject extent gating', function () {
+    it('publishes the subject extent on the map', function () {
+      const { map } = buildMap()
+      constrainMapToExtent(map, EXTENT)
+      expect(map.get('subjectExtent')).to.deep.equal(EXTENT)
+    })
+
+    it('does not publish an extent when the constraint is skipped', function () {
+      const { map } = buildMap()
+      constrainMapToExtent(map, [100, 200, 100, 200])
+      expect(map.get('subjectExtent')).to.equal(undefined)
+    })
+
+    it('isWithinSubjectExtent allows everything when no extent is set', function () {
+      const { map } = buildMap()
+      expect(isWithinSubjectExtent(map, [99999, 99999])).to.equal(true)
+    })
+
+    it('isWithinSubjectExtent gates coordinates against the extent', function () {
+      const { map } = buildMap()
+      constrainMapToExtent(map, EXTENT)
+      expect(isWithinSubjectExtent(map, [500, 250])).to.equal(true)
+      expect(isWithinSubjectExtent(map, [1500, 250])).to.equal(false)
+    })
+
+    it('clampToSubjectExtent clamps outside coordinates to the extent edge', function () {
+      const { map } = buildMap()
+      constrainMapToExtent(map, EXTENT)
+      expect(clampToSubjectExtent(map, [1500, -300])).to.deep.equal([1000, 0])
+      expect(clampToSubjectExtent(map, [500, 250])).to.deep.equal([500, 250])
+    })
+
+    it('clampToSubjectExtent is identity when no extent is set', function () {
+      const { map } = buildMap()
+      expect(clampToSubjectExtent(map, [1500, -300])).to.deep.equal([1500, -300])
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.js
@@ -1,7 +1,14 @@
 import GeoJSON from 'ol/format/GeoJSON'
+import { transformExtent } from 'ol/proj'
 
 import { GEOJSON_READ_OPTIONS, ZOOM_ANIMATION_DURATION_MS } from './constants'
-import { fitViewToFeatures, selectFirstFeature } from './mapSelection'
+import constrainMapToExtent from './extentConstraint'
+import { fitViewToExtent, selectFirstFeature } from './mapSelection'
+
+function getSubjectExtent(data) {
+  if (!Array.isArray(data.bbox) || data.bbox.length !== 4) return null
+  return transformExtent(data.bbox, GEOJSON_READ_OPTIONS.dataProjection, GEOJSON_READ_OPTIONS.featureProjection)
+}
 
 export default function loadGeoJSON({ map, source, select, measure, data }) {
   if (!map || !source) return
@@ -13,7 +20,9 @@ export default function loadGeoJSON({ map, source, select, measure, data }) {
   const features = format.readFeatures(data, GEOJSON_READ_OPTIONS)
   source.addFeatures(features)
   if (source.getFeatures().length) {
-    fitViewToFeatures(map, source, ZOOM_ANIMATION_DURATION_MS)
+    const extent = getSubjectExtent(data) || source.getExtent()
+    constrainMapToExtent(map, extent)
+    fitViewToExtent(map, extent, ZOOM_ANIMATION_DURATION_MS)
     selectFirstFeature(select, features)
   }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/mapSelection.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/mapSelection.js
@@ -13,8 +13,8 @@ export function clearSelectedFeature(select) {
   select.dispatchEvent({ type: 'select', selected: [], deselected })
 }
 
-export function fitViewToFeatures(map, features, duration) {
-  map.getView().fit(features.getExtent(), {
+export function fitViewToExtent(map, extent, duration) {
+  map.getView().fit(extent, {
     padding: [32, 32, 32, 32],
     maxZoom: 12,
     duration

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapSelection.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapSelection.js
@@ -5,6 +5,7 @@ import { unByKey } from 'ol/Observable'
 
 import asMSTFeature from '../helpers/asMSTFeature'
 import { FEATURE_HIT_TOLERANCE_PX } from '../helpers/createGeoLineStringInteraction'
+import { clampToSubjectExtent } from '../helpers/extentConstraint'
 import { isPixelNearPointCenter, POINT_CENTER_HIT_RADIUS_PIXELS, getFeaturePixelsAcrossWorldCopies } from '../helpers/hitTesting'
 import { clearSelectedFeature, selectFirstFeature } from '../helpers/mapSelection'
 
@@ -42,11 +43,21 @@ export default function useMapSelection({
       }
     })
 
+    const translateEndKey = translate.on('translateend', (event) => {
+      event.features.forEach((feature) => {
+        const geometry = feature.getGeometry?.()
+        if (geometry?.getType?.() !== 'Point') return
+        geometry.setCoordinates(clampToSubjectExtent(map, geometry.getCoordinates()))
+        feature.changed()
+      })
+    })
+
     map.addInteraction(select)
     map.addInteraction(translate)
     setInteractions({ select, translate })
 
     return () => {
+      unByKey(translateEndKey)
       map.removeInteraction(translate)
       map.removeInteraction(select)
       setInteractions({ select: null, translate: null })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapSelection.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapSelection.js
@@ -49,6 +49,9 @@ export default function useMapSelection({
         if (geometry?.getType?.() !== 'Point') return
         geometry.setCoordinates(clampToSubjectExtent(map, geometry.getCoordinates()))
         feature.changed()
+        if (geoDrawingTask?.setActiveFeatureGeometry) {
+          geoDrawingTask.setActiveFeatureGeometry(geometry)
+        }
       })
     })
 

--- a/packages/lib-classifier/src/store/JSONData/GeoJSON.js
+++ b/packages/lib-classifier/src/store/JSONData/GeoJSON.js
@@ -14,6 +14,7 @@ const Feature = types.model('GeoJSONFeature', {
 
 export default types.model('GeoJSON', {
 	type: types.literal('FeatureCollection'),
+	bbox: types.maybe(types.frozen()),
 	features: types.array(Feature),
 	reference_data: types.maybe(types.frozen())
 })

--- a/packages/lib-classifier/src/store/JSONData/index.spec.js
+++ b/packages/lib-classifier/src/store/JSONData/index.spec.js
@@ -1,4 +1,4 @@
-import { getType } from 'mobx-state-tree'
+import { getSnapshot, getType } from 'mobx-state-tree'
 
 import JSONData from './'
 
@@ -79,6 +79,12 @@ describe('Models > JSONData', function () {
     const geoData = JSONData.create(geoJSONSnapshot)
     const dataType = getType(geoData).name
     expect(dataType).to.equal('GeoJSON')
+  })
+
+  it('should preserve the GeoJSON bbox', function () {
+    const bbox = [2.28, 48.85, 2.30, 48.86]
+    const geoData = JSONData.create({ ...geoJSONSnapshot, bbox })
+    expect(getSnapshot(geoData).bbox).to.deep.equal(bbox)
   })
 
   it('should load variable star data', async function () {


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #7373
- Closes #7374
- Closes #7375
- Closes #7376

## Describe your changes
- add `bbox` to the `GeoJSON` store model so a subject's RFC 7946 bbox survives into the viewer
- constrain the view to the subject bbox in `loadGeoJSON`, falling back to the features extent when a subject has no bbox
- mask the map beyond the subject extent with a grey overlay and a light outline
- cap zoom-out and clamp panning so the subject box never leaves the viewport
- clamp point drags, teleports, translates, and line vertex edits to the extent; draw clicks outside it place nothing
- recenter refits to the same extent as the initial fit

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- markbouslog/north-star-mapping-project, workflow 32087 "GeoDrawing SegmentedLine" (subject set 136882): `https://local.zooniverse.org:8080/?project=31513&workflow=32087&env=production`
- staging equivalent (kieftrav/geo-tools, subjects with an explicit bbox): `https://local.zooniverse.org:8080/?project=2050&workflow=3919&env=staging`

What user actions should my reviewer step through to review this PR?
- [x] run `pnpm dev` in `packages/lib-classifier`, open `https://local.zooniverse.org:8080/?project=31513&workflow=32087&env=production`
- [ ] the map loads fit to the subject box, with everything outside greyed behind a white outline
- [ ] pan hard in any direction; the subject box pins at the viewport edge and never leaves view
- [ ] zoom out; the view stops before the subject shrinks away
- [x] with a line tool active, click outside the box; no vertex is placed and no sketch dot renders there
- [x] draw a line inside, then drag a vertex outside and release; it snaps back to the boundary
- [x] drag the subject's point outside; it clamps at the edge. Click-teleport outside; the point stays put
- [x] pan away, then click recenter; the view refits to the subject box
- [x] confirm earlier-PR behaviors are intact: vertex grab/drag, line count and vertex bounds, delete affordance
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `extentConstraint.spec.js` and `store/JSONData/index.spec.js` pass

Which storybook stories should be reviewed?
- n/a for this PR. The behavior is driven by the subject's GeoJSON rather than a tool config, so there is no story control to exercise; the staging workflow above is the review surface.

Are there plans for follow up PR's to further fix this bug or develop this feature?
- Yes. This PR completes the Subject Definition milestone (#7373, #7374, #7375; #7376's plumbing is satisfied by reading the bbox at load time in `loadGeoJSON`). Sequential PRs that follow this one (in merge order):
- lib-classifier: geoDrawing Point tool subject-driven rendering with min/max creation bounds (branch ready, PR to follow)
- Panoptes-Front-End: Add "Number of points" Min/Max editor to the GeoDrawing Point tool config (branch ready, PR to follow)

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
