### PR TITLE
Enable Persian locale (fa) in app-project

### DIFF
--- a/packages/app-project/next-i18next.config.js
+++ b/packages/app-project/next-i18next.config.js
@@ -11,6 +11,7 @@ const locales = [
   'el', // Greek
   'en', // English
   'es', // Spanish
+  'fa', // Persian / Farsi
   'fi', // Finnish
   'fr', // French
   'ha', // Hausa

--- a/packages/app-project/src/helpers/localeMenu.js
+++ b/packages/app-project/src/helpers/localeMenu.js
@@ -10,6 +10,7 @@ const localeMenu = {
   el: 'Ελληνικά', // Greek
   en: 'English', // English
   es: 'Español', // Spanish
+  fa: 'فارسی', // Persian / Farsi
   fi: 'Suomi', // Finnish
   fr: 'Français', // French
   ha: 'Hausa', // Hausa

--- a/packages/lib-classifier/dev/components/App/localeMenu.js
+++ b/packages/lib-classifier/dev/components/App/localeMenu.js
@@ -10,6 +10,7 @@ export default {
   el: 'Ελληνικά', // Greek
   en: 'English', // English
   es: 'Español', // Spanish
+  fa: 'فارسی', // Persian / Farsi
   fi: 'Suomi', // Finnish
   fr: 'Français', // French
   ha: 'Hausa', // Hausa

--- a/packages/lib-content/src/screens/Projects/components/Projects/localeMenu.js
+++ b/packages/lib-content/src/screens/Projects/components/Projects/localeMenu.js
@@ -10,6 +10,7 @@ const localeMenu = {
   el: 'Ελληνικά', // Greek
   en: 'English', // English
   es: 'Español', // Spanish
+  fa: 'فارسی', // Persian / Farsi
   fi: 'Suomi', // Finnish
   fr: 'Français', // French
   ha: 'Hausa', // Hausa


### PR DESCRIPTION
## Package
app-project
lib-classifier (dev app)
lib-content (for the /projects page)

## Linked Issue and/or Talk Post
By request of Sunspot Detectives: https://zooniverse.freshdesk.com/a/tickets/27734
PFE PR: https://github.com/zooniverse/Panoptes-Front-End/pull/7503

## Describe your changes
- Enable the `fa` locale code
- Note that the main website does not have platform-level `fa` dictionaries, but this is ok for enabling this locale for one project

## How to Review
- When app-project is run locally you can see Sunspot Detectives with `fa` in the URL: https://local.zooniverse.org:3000/projects/fa/teolixx/sunspot-detectives?env=production

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
