### PR TITLE
lib-classifier: Add optional point creation with min/max bounds to the geoDrawing Point tool

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -89,6 +89,8 @@ function GeoMapViewer({
 
   const hasGeoDrawingTask = !!(geoDrawingTask && geoDrawingTask.tools.length > 0)
   const activeToolType = geoDrawingTask?.activeTool?.type
+  // Subject features are only auto-selected in move-only workflows (no creatable point tool).
+  const autoSelect = !geoDrawingTask?.tools?.some(tool => tool.canCreate)
 
   const { map, source, layer, scaleLine, baseLayers } = useOLMap(containerRef, tileLayers)
 
@@ -102,7 +104,7 @@ function GeoMapViewer({
     onSelectedFeatureChange
   })
 
-  const { draw, modify, moveToClick, measure } = useMapInteractions({
+  const { draw, modify, moveToClick, pointDraw, measure } = useMapInteractions({
     map,
     source,
     layer,
@@ -135,6 +137,7 @@ function GeoMapViewer({
     draw,
     modify,
     moveToClick,
+    pointDraw,
     geoDrawingTask,
     hasGeoDrawingTask,
     activeToolType,
@@ -151,8 +154,8 @@ function GeoMapViewer({
   }, [baseLayers, currentLayerIndex])
 
   useEffect(() => {
-    loadGeoJSON({ map, source, select, measure, data: geoJSON })
-  }, [map, source, select, measure, geoJSON])
+    loadGeoJSON({ map, source, select, measure, data: geoJSON, autoSelect })
+  }, [map, source, select, measure, geoJSON, autoSelect])
 
   useEffect(() => {
     if (!source || !onFeaturesChange) return undefined
@@ -203,8 +206,8 @@ function GeoMapViewer({
   const handleReset = useCallback(() => {
     if (!map || !source || !geoJSON) return
     setIsMeasureModeActive(false)
-    loadGeoJSON({ map, source, select, measure, data: geoJSON })
-  }, [map, source, select, measure, geoJSON])
+    loadGeoJSON({ map, source, select, measure, data: geoJSON, autoSelect })
+  }, [map, source, select, measure, geoJSON, autoSelect])
 
   const handleZoom = useCallback((delta) => {
     if (!map) return

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -157,6 +157,69 @@ export const WithGeoDrawingLineStringTask = {
   }
 }
 
+export const WithGeoDrawingPointCreationTask = {
+  argTypes: {
+    min: {
+      control: { type: 'number', min: 0, step: 1 },
+      description: 'Minimum number of points a volunteer must create for the task to report complete. 0 = no minimum.'
+    },
+    max: {
+      control: { type: 'number', min: 0, step: 1 },
+      description: 'Maximum number of points a volunteer can create. 0 or blank = creation disabled (move-only).'
+    },
+    seedSubjectPoint: {
+      control: 'boolean',
+      description: 'Include a point in the subject GeoJSON (auto-drawn, excluded from min/max counts).'
+    }
+  },
+  args: {
+    min: 1,
+    max: 3,
+    seedSubjectPoint: false,
+    onFeaturesChange: (featureCollection) => {
+      if (typeof window !== 'undefined') {
+        window.__geoFeatureCount = featureCollection?.features?.length ?? 0
+        window.__geoFeatures = featureCollection?.features ?? []
+      }
+    }
+  },
+  render: ({ min, max, seedSubjectPoint, ...rest }) => {
+    const pointTool = {
+      type: 'Point',
+      label: 'Point',
+      color: '#E65252'
+    }
+    if (min !== undefined && min !== '') pointTool.min = min
+    if (max !== undefined && max !== '') pointTool.max = max
+
+    const geoDrawingTask = GeoDrawingTask.create({
+      taskKey: 'T0',
+      activeToolIndex: 0,
+      tools: [pointTool],
+      type: 'geoDrawing'
+    })
+
+    const geoJSON = {
+      type: 'FeatureCollection',
+      features: seedSubjectPoint
+        ? [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [-91.0125, 47.9847]
+              },
+              properties: {
+                name: 'Knife Lake center pin (test seed)'
+              }
+            }
+          ]
+        : []
+    }
+    return <GeoMapViewer {...rest} geoDrawingTask={geoDrawingTask} geoJSON={geoJSON} />
+  }
+}
+
 export const WithoutGeoDrawingTask = {
   args: {
     geoJSON: {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -201,6 +201,7 @@ export const WithGeoDrawingPointCreationTask = {
 
     const geoJSON = {
       type: 'FeatureCollection',
+      bbox: [-91.05, 47.96, -90.97, 48.01],
       features: seedSubjectPoint
         ? [
             {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
@@ -1,8 +1,10 @@
 import { primaryAction } from 'ol/events/condition'
 import { unByKey } from 'ol/Observable'
 import Draw from 'ol/interaction/Draw'
+import { createEditingStyle } from 'ol/style/Style'
 
 import { FEATURE_HIT_TOLERANCE_PX } from './createGeoLineStringInteraction'
+import { isWithinSubjectExtent } from './extentConstraint'
 import isPointFeature from './isPointFeature'
 
 // Subject-provided points carry no toolIndex, so they never count toward the cap.
@@ -10,6 +12,30 @@ function countPointFeaturesForTool(source, toolIndex) {
   return source.getFeatures().filter((feature) => (
     isPointFeature(feature) && feature.get?.('toolIndex') === toolIndex
   )).length
+}
+
+export function createSketchStyle({ map }) {
+  const editingStyles = createEditingStyle()
+  return (feature) => {
+    const geometry = feature.getGeometry()
+    if (!geometry) return null
+    if (geometry.getType() === 'Point' && !isWithinSubjectExtent(map, geometry.getCoordinates())) {
+      return null
+    }
+    return editingStyles[geometry.getType()]
+  }
+}
+
+export function createDrawCondition({ map, featuresLayer }) {
+  return (event) => {
+    if (!primaryAction(event)) return false
+    if (!isWithinSubjectExtent(map, event.coordinate)) return false
+    if (!featuresLayer) return true
+    return !map.hasFeatureAtPixel(event.pixel, {
+      layerFilter: (layer) => layer === featuresLayer,
+      hitTolerance: FEATURE_HIT_TOLERANCE_PX
+    })
+  }
 }
 
 function createGeoPointInteraction({
@@ -26,14 +52,8 @@ function createGeoPointInteraction({
   const draw = new Draw({
     source,
     type: 'Point',
-    condition: (event) => {
-      if (!primaryAction(event)) return false
-      if (!featuresLayer) return true
-      return !map.hasFeatureAtPixel(event.pixel, {
-        layerFilter: (layer) => layer === featuresLayer,
-        hitTolerance: FEATURE_HIT_TOLERANCE_PX
-      })
-    }
+    condition: createDrawCondition({ map, featuresLayer }),
+    style: createSketchStyle({ map })
   })
 
   map.addInteraction(draw)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
@@ -1,0 +1,100 @@
+import { primaryAction } from 'ol/events/condition'
+import { unByKey } from 'ol/Observable'
+import Draw from 'ol/interaction/Draw'
+
+import { FEATURE_HIT_TOLERANCE_PX } from './createGeoLineStringInteraction'
+import isPointFeature from './isPointFeature'
+
+// Subject-provided points carry no toolIndex, so they never count toward the cap.
+function countPointFeaturesForTool(source, toolIndex) {
+  return source.getFeatures().filter((feature) => (
+    isPointFeature(feature) && feature.get?.('toolIndex') === toolIndex
+  )).length
+}
+
+function createGeoPointInteraction({
+  map,
+  source,
+  featuresLayer,
+  geoDrawingTask,
+  selectInteraction
+}) {
+  const activeTool = geoDrawingTask?.activeTool
+  const activeToolIndex = geoDrawingTask?.activeToolIndex
+  const featureCountMax = activeTool?.type === 'Point' ? activeTool.max : 0
+
+  const draw = new Draw({
+    source,
+    type: 'Point',
+    condition: (event) => {
+      if (!primaryAction(event)) return false
+      if (!featuresLayer) return true
+      return !map.hasFeatureAtPixel(event.pixel, {
+        layerFilter: (layer) => layer === featuresLayer,
+        hitTolerance: FEATURE_HIT_TOLERANCE_PX
+      })
+    }
+  })
+
+  map.addInteraction(draw)
+  draw.setActive(false)
+
+  // Remember the caller's desired active state so cap-recovery (delete) can re-enable Draw.
+  let lastRequestedActive = false
+
+  function isCapped() {
+    if (featureCountMax <= 0) return true
+    return countPointFeaturesForTool(source, activeToolIndex) >= featureCountMax
+  }
+
+  function syncActive() {
+    const target = lastRequestedActive && !isCapped()
+    if (draw.getActive() !== target) draw.setActive(target)
+  }
+
+  const sourceAddKey = source.on('addfeature', syncActive)
+  const sourceRemoveKey = source.on('removefeature', syncActive)
+
+  const drawEndKey = draw.on('drawend', (event) => {
+    const feature = event.feature
+    if (!feature) return
+
+    if (typeof activeToolIndex === 'number') {
+      feature.set('toolIndex', activeToolIndex)
+    }
+
+    if (selectInteraction) {
+      Promise.resolve().then(() => {
+        selectInteraction.getFeatures().clear()
+        selectInteraction.getFeatures().push(feature)
+        selectInteraction.dispatchEvent({
+          type: 'select',
+          selected: [feature],
+          deselected: []
+        })
+      })
+    }
+
+    // drawend fires before source.addFeature, so include the in-flight feature.
+    if (countPointFeaturesForTool(source, activeToolIndex) + 1 >= featureCountMax) {
+      draw.setActive(false)
+    }
+  })
+
+  return {
+    isCapped,
+    setActive(active) {
+      lastRequestedActive = active
+      syncActive()
+    },
+    destroy() {
+      unByKey(drawEndKey)
+      unByKey(sourceAddKey)
+      unByKey(sourceRemoveKey)
+      draw.setActive(false)
+      map.removeInteraction(draw)
+    }
+  }
+}
+
+export default createGeoPointInteraction

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
@@ -1,0 +1,205 @@
+import { Map, View, Feature } from 'ol'
+import PointGeom from 'ol/geom/Point'
+import LineStringGeom from 'ol/geom/LineString'
+import { Select } from 'ol/interaction'
+import VectorSource from 'ol/source/Vector'
+import VectorLayer from 'ol/layer/Vector'
+import createGeoPointInteraction from './createGeoPointInteraction'
+
+function buildMap(source) {
+  const layer = new VectorLayer({ source })
+  const map = new Map({
+    layers: [layer],
+    view: new View({ center: [0, 0], zoom: 1 })
+  })
+  return { map, layer }
+}
+
+function taggedPoint(coordinates, toolIndex) {
+  const feature = new Feature({ geometry: new PointGeom(coordinates) })
+  if (typeof toolIndex === 'number') feature.set('toolIndex', toolIndex)
+  return feature
+}
+
+describe('helpers > createGeoPointInteraction', function () {
+  let source, map, geoDrawingTask, selectInteraction
+
+  beforeEach(function () {
+    source = new VectorSource()
+    const built = buildMap(source)
+    map = built.map
+    geoDrawingTask = { activeToolIndex: 0, activeTool: { type: 'Point', max: 3 } }
+    selectInteraction = new Select({ layers: [built.layer] })
+    map.addInteraction(selectInteraction)
+  })
+
+  afterEach(function () {
+    map.setTarget(undefined)
+  })
+
+  it('returns a closure with setActive and destroy', function () {
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask, selectInteraction })
+    expect(interaction).to.have.property('setActive').that.is.a('function')
+    expect(interaction).to.have.property('destroy').that.is.a('function')
+    interaction.destroy()
+  })
+
+  it('starts inactive', function () {
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask, selectInteraction })
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction).to.exist
+    expect(drawInteraction.getActive()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('setActive(true) activates the underlying Draw', function () {
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask, selectInteraction })
+    interaction.setActive(true)
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction.getActive()).to.equal(true)
+    interaction.destroy()
+  })
+
+  it('refuses to activate when the tool max is 0 (creation disabled)', function () {
+    const moveOnlyTask = { activeToolIndex: 0, activeTool: { type: 'Point', max: 0 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: moveOnlyTask, selectInteraction })
+    interaction.setActive(true)
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction.getActive()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('tags new features with toolIndex on drawend', function () {
+    const task = { activeToolIndex: 2, activeTool: { type: 'Point', max: 3 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: task, selectInteraction })
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+
+    const feature = new Feature({ geometry: new PointGeom([5, 5]) })
+    drawInteraction.dispatchEvent({ type: 'drawend', feature })
+
+    expect(feature.get('toolIndex')).to.equal(2)
+    interaction.destroy()
+  })
+
+  it('dispatches select on the new feature after drawend (microtask)', async function () {
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask, selectInteraction })
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+
+    const feature = new Feature({ geometry: new PointGeom([5, 5]) })
+    source.addFeature(feature)
+
+    let selectedFeatures
+    selectInteraction.on('select', (event) => { selectedFeatures = event.selected })
+
+    drawInteraction.dispatchEvent({ type: 'drawend', feature })
+
+    await Promise.resolve()
+
+    expect(selectedFeatures).to.have.length(1)
+    expect(selectedFeatures[0]).to.equal(feature)
+    interaction.destroy()
+  })
+
+  it('refuses to activate when source already holds activeTool.max Points for the active tool', function () {
+    source.addFeature(taggedPoint([0, 0], 0))
+    source.addFeature(taggedPoint([1, 1], 0))
+
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 2 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+
+    interaction.setActive(true)
+
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction.getActive()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('deactivates after drawend brings the count to activeTool.max', function () {
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 1 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+    interaction.setActive(true)
+
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction.getActive()).to.equal(true)
+
+    const feature = new Feature({ geometry: new PointGeom([5, 5]) })
+    drawInteraction.dispatchEvent({ type: 'drawend', feature })
+
+    expect(drawInteraction.getActive()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('reactivates when a point is removed below the cap', function () {
+    const f1 = taggedPoint([0, 0], 0)
+    source.addFeature(f1)
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 1 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+    interaction.setActive(true)
+
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    expect(drawInteraction.getActive()).to.equal(false)
+
+    source.removeFeature(f1)
+    expect(drawInteraction.getActive()).to.equal(true)
+    interaction.destroy()
+  })
+
+  it('exposes isCapped() reflecting whether the active tool has hit its max', function () {
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 2 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+
+    expect(interaction.isCapped()).to.equal(false)
+    source.addFeature(taggedPoint([0, 0], 0))
+    expect(interaction.isCapped()).to.equal(false)
+    source.addFeature(taggedPoint([1, 1], 0))
+    expect(interaction.isCapped()).to.equal(true)
+    interaction.destroy()
+  })
+
+  it('isCapped() returns true when max is 0 (creation disabled)', function () {
+    const moveOnlyTask = { activeToolIndex: 0, activeTool: { type: 'Point', max: 0 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: moveOnlyTask, selectInteraction })
+    expect(interaction.isCapped()).to.equal(true)
+    interaction.destroy()
+  })
+
+  it('isCapped() ignores subject-provided points (no toolIndex)', function () {
+    source.addFeature(taggedPoint([0, 0]))
+
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 1 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+
+    expect(interaction.isCapped()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('isCapped() ignores features tagged for another tool', function () {
+    source.addFeature(taggedPoint([0, 0], 1))
+    source.addFeature(taggedPoint([1, 1], 1))
+
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 2 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+
+    expect(interaction.isCapped()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('isCapped() ignores non-Point geometries', function () {
+    const line = new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) })
+    line.set('toolIndex', 0)
+    source.addFeature(line)
+
+    const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 1 } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+
+    expect(interaction.isCapped()).to.equal(false)
+    interaction.destroy()
+  })
+
+  it('destroy() removes the Draw from the map', function () {
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask, selectInteraction })
+    expect(map.getInteractions().getArray().some(i => i.constructor.name === 'Draw')).to.equal(true)
+    interaction.destroy()
+    expect(map.getInteractions().getArray().some(i => i.constructor.name === 'Draw')).to.equal(false)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
@@ -4,7 +4,7 @@ import LineStringGeom from 'ol/geom/LineString'
 import { Select } from 'ol/interaction'
 import VectorSource from 'ol/source/Vector'
 import VectorLayer from 'ol/layer/Vector'
-import createGeoPointInteraction from './createGeoPointInteraction'
+import createGeoPointInteraction, { createDrawCondition, createSketchStyle } from './createGeoPointInteraction'
 
 function buildMap(source) {
   const layer = new VectorLayer({ source })
@@ -201,5 +201,63 @@ describe('helpers > createGeoPointInteraction', function () {
     expect(map.getInteractions().getArray().some(i => i.constructor.name === 'Draw')).to.equal(true)
     interaction.destroy()
     expect(map.getInteractions().getArray().some(i => i.constructor.name === 'Draw')).to.equal(false)
+  })
+
+  describe('createDrawCondition', function () {
+    const primaryEvent = (coordinate) => ({
+      coordinate,
+      pixel: [10, 10],
+      originalEvent: { pointerId: 1, isPrimary: true, button: 0, pointerType: 'mouse' }
+    })
+
+    it('accepts a primary click when no subject extent is set', function () {
+      const condition = createDrawCondition({ map })
+      expect(condition(primaryEvent([5, 5]))).to.equal(true)
+    })
+
+    it('accepts a primary click inside the subject extent', function () {
+      map.set('subjectExtent', [0, 0, 100, 100])
+      const condition = createDrawCondition({ map })
+      expect(condition(primaryEvent([50, 50]))).to.equal(true)
+    })
+
+    it('rejects a click outside the subject extent', function () {
+      map.set('subjectExtent', [0, 0, 100, 100])
+      const condition = createDrawCondition({ map })
+      expect(condition(primaryEvent([150, 50]))).to.equal(false)
+    })
+
+    it('rejects a non-primary click', function () {
+      const condition = createDrawCondition({ map })
+      const event = {
+        coordinate: [5, 5],
+        pixel: [10, 10],
+        originalEvent: { pointerId: 1, isPrimary: true, button: 2, pointerType: 'mouse' }
+      }
+      expect(condition(event)).to.equal(false)
+    })
+  })
+
+  describe('createSketchStyle', function () {
+    function sketchPoint(coordinates) {
+      return new Feature({ geometry: new PointGeom(coordinates) })
+    }
+
+    it('styles the sketch point when no subject extent is set', function () {
+      const style = createSketchStyle({ map })
+      expect(style(sketchPoint([5, 5]))).to.exist
+    })
+
+    it('styles the sketch point inside the subject extent', function () {
+      map.set('subjectExtent', [0, 0, 100, 100])
+      const style = createSketchStyle({ map })
+      expect(style(sketchPoint([50, 50]))).to.exist
+    })
+
+    it('hides the sketch point outside the subject extent', function () {
+      map.set('subjectExtent', [0, 0, 100, 100])
+      const style = createSketchStyle({ map })
+      expect(style(sketchPoint([150, 50]))).to.equal(null)
+    })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createMoveToClickInteraction.js
@@ -22,7 +22,8 @@ function createMoveToClickInteraction({
   map,
   selectInteraction,
   geoDrawingTask,
-  featuresLayer
+  featuresLayer,
+  isPointDrawBelowCap = () => false
 }) {
   const state = {
     downCoordinate: null,
@@ -214,6 +215,11 @@ function createMoveToClickInteraction({
     })
 
     if (clickedOtherFeatureCenter) {
+      return false
+    }
+
+    // Empty-map clicks create a point while capacity remains; teleport only resumes at the cap.
+    if (isPointDrawBelowCap()) {
       return false
     }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.js
@@ -2,6 +2,7 @@ import { isPixelNearDragHandle } from '@plugins/tasks/experimental/geoDrawing/fe
 
 import asMSTFeature from './asMSTFeature'
 import { FEATURE_HIT_TOLERANCE_PX } from './createGeoLineStringInteraction'
+import { isWithinSubjectExtent } from './extentConstraint'
 import getDrawModeCursor from './getDrawModeCursor'
 import getInteractionStates from './getInteractionStates'
 import getPixelDistance from './getPixelDistance'
@@ -130,7 +131,9 @@ export default function getCursorFromState({
     return getDrawCursor({ map, layer, select, draw, modify, pixel, dragging })
   }
 
-  const pointDrawReady = !!(states.pointDraw && pointDraw && !pointDraw.isCapped())
+  const pointerCoordinate = map.getCoordinateFromPixel?.(pixel) ?? null
+  const pointerInExtent = pointerCoordinate ? isWithinSubjectExtent(map, pointerCoordinate) : true
+  const pointDrawReady = !!(states.pointDraw && pointDraw && !pointDraw.isCapped()) && pointerInExtent
 
   const selected = select.getFeatures().item(0)
   if (selected) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.js
@@ -113,6 +113,7 @@ export default function getCursorFromState({
   select,
   draw,
   modify,
+  pointDraw,
   geoDrawingTask,
   activeToolType,
   isMeasureModeActive,
@@ -121,12 +122,15 @@ export default function getCursorFromState({
   dragging,
   cachedFeatureHit
 }) {
-  const states = getInteractionStates({ activeToolType, isMeasureModeActive })
+  const canCreatePoints = !!geoDrawingTask?.activeTool?.canCreate
+  const states = getInteractionStates({ activeToolType, isMeasureModeActive, canCreatePoints })
 
   if (states.measure) return ''
   if (states.lineStringDraw) {
     return getDrawCursor({ map, layer, select, draw, modify, pixel, dragging })
   }
+
+  const pointDrawReady = !!(states.pointDraw && pointDraw && !pointDraw.isCapped())
 
   const selected = select.getFeatures().item(0)
   if (selected) {
@@ -138,8 +142,12 @@ export default function getCursorFromState({
       isDraggingPoint
     })
     if (selectedCursor) return selectedCursor
-    return getOtherCenterCursor({ map, layer, selectedFeature: selected, pixel })
+    const otherCursor = getOtherCenterCursor({ map, layer, selectedFeature: selected, pixel })
+    if (otherCursor === 'default' && pointDrawReady) return dragging ? '' : 'crosshair'
+    return otherCursor
   }
 
-  return cachedFeatureHit ? 'pointer' : 'default'
+  if (cachedFeatureHit) return 'pointer'
+  if (pointDrawReady) return dragging ? '' : 'crosshair'
+  return 'default'
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.spec.js
@@ -50,4 +50,39 @@ describe('helpers > getCursorFromState > point creation mode', function () {
     const cursor = cursorFor({ geoDrawingTask: creatableTask, pointDraw: { isCapped: () => false }, dragging: true })
     expect(cursor).to.equal('')
   })
+
+  describe('with a subject extent', function () {
+    function extentMap(coordinate) {
+      return {
+        get: (key) => (key === 'subjectExtent' ? [0, 0, 100, 100] : undefined),
+        getCoordinateFromPixel: () => coordinate
+      }
+    }
+
+    function cursorAt(coordinate) {
+      return getCursorFromState({
+        map: extentMap(coordinate),
+        layer: {},
+        select: fakeSelect(),
+        draw: null,
+        modify: null,
+        pointDraw: { isCapped: () => false },
+        geoDrawingTask: creatableTask,
+        activeToolType: 'Point',
+        isMeasureModeActive: false,
+        isDraggingPoint: false,
+        pixel: [0, 0],
+        dragging: false,
+        cachedFeatureHit: false
+      })
+    }
+
+    it('returns crosshair when the pointer is inside the subject extent', function () {
+      expect(cursorAt([50, 50])).to.equal('crosshair')
+    })
+
+    it('returns default when the pointer is outside the subject extent', function () {
+      expect(cursorAt([150, 50])).to.equal('default')
+    })
+  })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getCursorFromState.spec.js
@@ -1,0 +1,53 @@
+import getCursorFromState from './getCursorFromState'
+
+function fakeSelect(selectedFeature = null) {
+  return { getFeatures: () => ({ item: () => selectedFeature }) }
+}
+
+describe('helpers > getCursorFromState > point creation mode', function () {
+  const creatableTask = { activeToolIndex: 0, activeTool: { type: 'Point', max: 3, canCreate: true } }
+  const moveOnlyTask = { activeToolIndex: 0, activeTool: { type: 'Point', max: 0, canCreate: false } }
+
+  function cursorFor({ geoDrawingTask, pointDraw, cachedFeatureHit = false, dragging = false }) {
+    return getCursorFromState({
+      map: {},
+      layer: {},
+      select: fakeSelect(),
+      draw: null,
+      modify: null,
+      pointDraw,
+      geoDrawingTask,
+      activeToolType: 'Point',
+      isMeasureModeActive: false,
+      isDraggingPoint: false,
+      pixel: [0, 0],
+      dragging,
+      cachedFeatureHit
+    })
+  }
+
+  it('returns crosshair over empty map when point draw is below cap', function () {
+    const cursor = cursorFor({ geoDrawingTask: creatableTask, pointDraw: { isCapped: () => false } })
+    expect(cursor).to.equal('crosshair')
+  })
+
+  it('returns pointer over an existing feature even when below cap', function () {
+    const cursor = cursorFor({ geoDrawingTask: creatableTask, pointDraw: { isCapped: () => false }, cachedFeatureHit: true })
+    expect(cursor).to.equal('pointer')
+  })
+
+  it('returns default when the point tool is at its cap', function () {
+    const cursor = cursorFor({ geoDrawingTask: creatableTask, pointDraw: { isCapped: () => true } })
+    expect(cursor).to.equal('default')
+  })
+
+  it('returns default when creation is disabled (move-only)', function () {
+    const cursor = cursorFor({ geoDrawingTask: moveOnlyTask, pointDraw: null })
+    expect(cursor).to.equal('default')
+  })
+
+  it('suppresses the crosshair while the map is being dragged', function () {
+    const cursor = cursorFor({ geoDrawingTask: creatableTask, pointDraw: { isCapped: () => false }, dragging: true })
+    expect(cursor).to.equal('')
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getInteractionStates.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getInteractionStates.js
@@ -1,10 +1,12 @@
-function getInteractionStates({ activeToolType, isMeasureModeActive }) {
+function getInteractionStates({ activeToolType, isMeasureModeActive, canCreatePoints = false }) {
   const isDrawing = activeToolType === 'SegmentedLine' && !isMeasureModeActive
+  const isPointDrawing = activeToolType === 'Point' && canCreatePoints && !isMeasureModeActive
 
   return {
     measure: isMeasureModeActive,
     lineStringDraw: isDrawing,
     lineStringModify: isDrawing,
+    pointDraw: isPointDrawing,
     select: !isMeasureModeActive,
     translate: !isMeasureModeActive && !isDrawing,
     modifyUncertainty: !isMeasureModeActive && !isDrawing,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getInteractionStates.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/getInteractionStates.spec.js
@@ -7,6 +7,7 @@ describe('helpers > getInteractionStates', function () {
         measure: false,
         lineStringDraw: true,
         lineStringModify: true,
+        pointDraw: false,
         select: true,
         translate: false,
         modifyUncertainty: false,
@@ -21,6 +22,7 @@ describe('helpers > getInteractionStates', function () {
         measure: true,
         lineStringDraw: false,
         lineStringModify: false,
+        pointDraw: false,
         select: false,
         translate: false,
         modifyUncertainty: false,
@@ -29,10 +31,11 @@ describe('helpers > getInteractionStates', function () {
     })
 
     it('disables every feature interaction even when the tool is not SegmentedLine', function () {
-      expect(getInteractionStates({ activeToolType: 'Point', isMeasureModeActive: true })).to.deep.equal({
+      expect(getInteractionStates({ activeToolType: 'Point', isMeasureModeActive: true, canCreatePoints: true })).to.deep.equal({
         measure: true,
         lineStringDraw: false,
         lineStringModify: false,
+        pointDraw: false,
         select: false,
         translate: false,
         modifyUncertainty: false,
@@ -41,12 +44,28 @@ describe('helpers > getInteractionStates', function () {
     })
   })
 
-  describe('when the active tool is not SegmentedLine and measure mode is off', function () {
+  describe('when the Point tool is active with creation enabled and measure mode is off', function () {
+    it('activates PointDraw alongside the point-feature interactions', function () {
+      expect(getInteractionStates({ activeToolType: 'Point', isMeasureModeActive: false, canCreatePoints: true })).to.deep.equal({
+        measure: false,
+        lineStringDraw: false,
+        lineStringModify: false,
+        pointDraw: true,
+        select: true,
+        translate: true,
+        modifyUncertainty: true,
+        moveToClick: true
+      })
+    })
+  })
+
+  describe('when the Point tool is active with creation disabled (move-only) and measure mode is off', function () {
     it('enables Select and the point-feature interactions; disables Draw, Modify, Measure', function () {
       expect(getInteractionStates({ activeToolType: 'Point', isMeasureModeActive: false })).to.deep.equal({
         measure: false,
         lineStringDraw: false,
         lineStringModify: false,
+        pointDraw: false,
         select: true,
         translate: true,
         modifyUncertainty: true,
@@ -59,10 +78,24 @@ describe('helpers > getInteractionStates', function () {
         measure: false,
         lineStringDraw: false,
         lineStringModify: false,
+        pointDraw: false,
         select: true,
         translate: true,
         modifyUncertainty: true,
         moveToClick: true
+      })
+    })
+
+    it('does not activate PointDraw for a non-Point tool even when canCreatePoints is passed', function () {
+      expect(getInteractionStates({ activeToolType: 'SegmentedLine', isMeasureModeActive: false, canCreatePoints: true })).to.deep.equal({
+        measure: false,
+        lineStringDraw: true,
+        lineStringModify: true,
+        pointDraw: false,
+        select: true,
+        translate: false,
+        modifyUncertainty: false,
+        moveToClick: false
       })
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/isPointFeature.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/isPointFeature.js
@@ -1,0 +1,3 @@
+export default function isPointFeature(feature) {
+  return feature?.getGeometry?.()?.getType?.() === 'Point'
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.js
@@ -10,7 +10,7 @@ function getSubjectExtent(data) {
   return transformExtent(data.bbox, GEOJSON_READ_OPTIONS.dataProjection, GEOJSON_READ_OPTIONS.featureProjection)
 }
 
-export default function loadGeoJSON({ map, source, select, measure, data }) {
+export default function loadGeoJSON({ map, source, select, measure, data, autoSelect = true }) {
   if (!map || !source) return
   measure?.clear?.()
   source.clear()
@@ -19,10 +19,9 @@ export default function loadGeoJSON({ map, source, select, measure, data }) {
   const format = new GeoJSON()
   const features = format.readFeatures(data, GEOJSON_READ_OPTIONS)
   source.addFeatures(features)
-  if (source.getFeatures().length) {
-    const extent = getSubjectExtent(data) || source.getExtent()
-    constrainMapToExtent(map, extent)
-    fitViewToExtent(map, extent, ZOOM_ANIMATION_DURATION_MS)
-    selectFirstFeature(select, features)
-  }
+  const extent = getSubjectExtent(data) || (features.length ? source.getExtent() : null)
+  if (!extent) return
+  constrainMapToExtent(map, extent)
+  fitViewToExtent(map, extent, ZOOM_ANIMATION_DURATION_MS)
+  if (autoSelect) selectFirstFeature(select, features)
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.js
@@ -19,9 +19,10 @@ export default function loadGeoJSON({ map, source, select, measure, data, autoSe
   const format = new GeoJSON()
   const features = format.readFeatures(data, GEOJSON_READ_OPTIONS)
   source.addFeatures(features)
-  const extent = getSubjectExtent(data) || (features.length ? source.getExtent() : null)
-  if (!extent) return
-  constrainMapToExtent(map, extent)
-  fitViewToExtent(map, extent, ZOOM_ANIMATION_DURATION_MS)
+  const subjectExtent = getSubjectExtent(data)
+  const viewExtent = subjectExtent || (features.length ? source.getExtent() : null)
+  if (!viewExtent) return
+  if (subjectExtent) constrainMapToExtent(map, subjectExtent)
+  fitViewToExtent(map, viewExtent, ZOOM_ANIMATION_DURATION_MS)
   if (autoSelect) selectFirstFeature(select, features)
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.spec.js
@@ -78,4 +78,34 @@ describe('helpers > loadGeoJSON', function () {
     expect(map.get('subjectExtent')).to.equal(undefined)
     expect(map.getLayers().getArray().some(layer => layer.get('extentMask'))).to.equal(false)
   })
+
+  it('does not constrain when the FeatureCollection has features but no bbox', function () {
+    const spreadPoints = {
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', geometry: { type: 'Point', coordinates: [151.2768, -33.89155] }, properties: {} },
+        { type: 'Feature', geometry: { type: 'Point', coordinates: [151.28849, -33.79645] }, properties: {} }
+      ]
+    }
+    loadGeoJSON({ map, source, select, data: spreadPoints })
+    expect(source.getFeatures()).to.have.length(2)
+    expect(map.get('subjectExtent')).to.equal(undefined)
+    expect(map.getLayers().getArray().some(layer => layer.get('extentMask'))).to.equal(false)
+    expect(select.getFeatures().getLength()).to.equal(1)
+  })
+
+  it('constrains to the bbox, not the features extent, when both are present', function () {
+    const bbox = [-91.05, 47.96, -90.97, 48.01]
+    const data = {
+      type: 'FeatureCollection',
+      bbox,
+      features: [
+        { type: 'Feature', geometry: { type: 'Point', coordinates: [-91.0, 47.98] }, properties: {} }
+      ]
+    }
+    loadGeoJSON({ map, source, select, data })
+    const expected = transformExtent(bbox, GEOJSON_READ_OPTIONS.dataProjection, GEOJSON_READ_OPTIONS.featureProjection)
+    expect(map.get('subjectExtent')).to.deep.equal(expected)
+    expect(map.getLayers().getArray().some(layer => layer.get('extentMask'))).to.equal(true)
+  })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/loadGeoJSON.spec.js
@@ -1,0 +1,81 @@
+import { Map, View } from 'ol'
+import { Select } from 'ol/interaction'
+import { transformExtent } from 'ol/proj'
+import VectorSource from 'ol/source/Vector'
+import VectorLayer from 'ol/layer/Vector'
+import { GEOJSON_READ_OPTIONS } from './constants'
+import loadGeoJSON from './loadGeoJSON'
+
+const pointCollection = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [2.2944810, 48.8583701] },
+      properties: {}
+    }
+  ]
+}
+
+describe('helpers > loadGeoJSON', function () {
+  let source, map, select
+
+  beforeEach(function () {
+    source = new VectorSource()
+    const layer = new VectorLayer({ source })
+    map = new Map({
+      layers: [layer],
+      view: new View({ center: [0, 0], zoom: 1 })
+    })
+    map.setSize([800, 600])
+    select = new Select({ layers: [layer] })
+    map.addInteraction(select)
+  })
+
+  afterEach(function () {
+    map.setTarget(undefined)
+  })
+
+  it('adds the subject features to the source', function () {
+    loadGeoJSON({ map, source, select, data: pointCollection })
+    expect(source.getFeatures()).to.have.length(1)
+  })
+
+  it('selects the first feature by default', function () {
+    loadGeoJSON({ map, source, select, data: pointCollection })
+    expect(select.getFeatures().getLength()).to.equal(1)
+  })
+
+  it('does not select any feature when autoSelect is false', function () {
+    loadGeoJSON({ map, source, select, data: pointCollection, autoSelect: false })
+    expect(source.getFeatures()).to.have.length(1)
+    expect(select.getFeatures().getLength()).to.equal(0)
+  })
+
+  it('clears the source and selects nothing when data is null', function () {
+    loadGeoJSON({ map, source, select, data: pointCollection })
+    loadGeoJSON({ map, source, select, data: null })
+    expect(source.getFeatures()).to.have.length(0)
+  })
+
+  it('handles an empty FeatureCollection without selecting', function () {
+    loadGeoJSON({ map, source, select, data: { type: 'FeatureCollection', features: [] } })
+    expect(source.getFeatures()).to.have.length(0)
+    expect(select.getFeatures().getLength()).to.equal(0)
+  })
+
+  it('constrains the view to the bbox when the FeatureCollection is empty', function () {
+    const bbox = [-91.05, 47.96, -90.97, 48.01]
+    loadGeoJSON({ map, source, select, data: { type: 'FeatureCollection', bbox, features: [] } })
+    const expected = transformExtent(bbox, GEOJSON_READ_OPTIONS.dataProjection, GEOJSON_READ_OPTIONS.featureProjection)
+    expect(map.get('subjectExtent')).to.deep.equal(expected)
+    expect(map.getLayers().getArray().some(layer => layer.get('extentMask'))).to.equal(true)
+    expect(select.getFeatures().getLength()).to.equal(0)
+  })
+
+  it('does not constrain when there is no bbox and no features', function () {
+    loadGeoJSON({ map, source, select, data: { type: 'FeatureCollection', features: [] } })
+    expect(map.get('subjectExtent')).to.equal(undefined)
+    expect(map.getLayers().getArray().some(layer => layer.get('extentMask'))).to.equal(false)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapCursor.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapCursor.js
@@ -12,6 +12,7 @@ export default function useMapCursor({
   draw,
   modify,
   moveToClick,
+  pointDraw,
   geoDrawingTask,
   hasGeoDrawingTask,
   activeToolType,
@@ -63,6 +64,7 @@ export default function useMapCursor({
           select,
           draw,
           modify,
+          pointDraw,
           geoDrawingTask,
           activeToolType,
           isMeasureModeActive,
@@ -98,5 +100,5 @@ export default function useMapCursor({
       map.un('pointerdown', onPointerDown)
       if (rafId !== null) cancelAnimationFrame(rafId)
     }
-  }, [map, layer, select, draw, modify, moveToClick, geoDrawingTask, hasGeoDrawingTask, activeToolType, isMeasureModeActive])
+  }, [map, layer, select, draw, modify, moveToClick, pointDraw, geoDrawingTask, hasGeoDrawingTask, activeToolType, isMeasureModeActive])
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapInteractions.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useMapInteractions.js
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { UNIT_OPTION_TO_SCALE_LINE_UNITS } from '../helpers/constants'
 import createGeoLineStringInteraction from '../helpers/createGeoLineStringInteraction'
 import createGeoLineStringModifyInteraction from '../helpers/createGeoLineStringModifyInteraction'
+import createGeoPointInteraction from '../helpers/createGeoPointInteraction'
 import createMeasureInteraction from '../helpers/createMeasureInteraction'
 import createModifyUncertaintyInteraction from '../helpers/createModifyUncertaintyInteraction'
 import createMoveToClickInteraction from '../helpers/createMoveToClickInteraction'
@@ -26,12 +27,15 @@ export default function useMapInteractions({
   const [interactions, setInteractions] = useState({
     draw: null,
     modify: null,
+    pointDraw: null,
     uncertaintyModify: null,
     moveToClick: null,
     measure: null
   })
   const activeToolType = geoDrawingTask?.activeTool?.type
   const activeToolIndex = geoDrawingTask?.activeToolIndex
+  const canCreatePoints = !!geoDrawingTask?.activeTool?.canCreate
+  const pointDrawRef = useRef(null)
 
   useEffect(() => {
     if (!map) return undefined
@@ -67,6 +71,25 @@ export default function useMapInteractions({
   }, [map, source, layer, select, geoDrawingTask, hasGeoDrawingTask, activeToolIndex])
 
   useEffect(() => {
+    if (!map || !source || !layer || !select || !hasGeoDrawingTask) return undefined
+    if (activeToolType !== 'Point' || !canCreatePoints) return undefined
+    const pointDraw = createGeoPointInteraction({
+      map,
+      source,
+      featuresLayer: layer,
+      geoDrawingTask,
+      selectInteraction: select
+    })
+    pointDrawRef.current = pointDraw
+    setInteractions((prev) => ({ ...prev, pointDraw }))
+    return () => {
+      pointDrawRef.current = null
+      pointDraw.destroy()
+      setInteractions((prev) => ({ ...prev, pointDraw: null }))
+    }
+  }, [map, source, layer, select, geoDrawingTask, hasGeoDrawingTask, activeToolType, activeToolIndex, canCreatePoints])
+
+  useEffect(() => {
     if (!map || !select || !translate || !layer || !hasGeoDrawingTask) return undefined
 
     const modify = createGeoLineStringModifyInteraction({
@@ -93,7 +116,11 @@ export default function useMapInteractions({
       map,
       selectInteraction: select,
       geoDrawingTask,
-      featuresLayer: layer
+      featuresLayer: layer,
+      isPointDrawBelowCap: () => {
+        const pointDraw = pointDrawRef.current
+        return !!pointDraw && !pointDraw.isCapped()
+      }
     })
 
     setInteractions((prev) => ({ ...prev, modify, uncertaintyModify, moveToClick }))
@@ -105,18 +132,19 @@ export default function useMapInteractions({
     }
   }, [map, select, translate, layer, geoDrawingTask, hasGeoDrawingTask])
 
-  const { draw, modify, uncertaintyModify, moveToClick, measure } = interactions
+  const { draw, modify, pointDraw, uncertaintyModify, moveToClick, measure } = interactions
 
   useEffect(() => {
-    const states = getInteractionStates({ activeToolType, isMeasureModeActive })
+    const states = getInteractionStates({ activeToolType, isMeasureModeActive, canCreatePoints })
     measure?.setActive(states.measure)
     draw?.setActive(states.lineStringDraw)
     modify?.setActive(states.lineStringModify)
+    pointDraw?.setActive(states.pointDraw)
     select?.setActive(states.select)
     translate?.setActive(states.translate)
     uncertaintyModify?.setActive(states.modifyUncertainty)
     moveToClick?.setActive(states.moveToClick)
-  }, [activeToolType, activeToolIndex, isMeasureModeActive, select, translate, draw, modify, uncertaintyModify, moveToClick, measure])
+  }, [activeToolType, activeToolIndex, canCreatePoints, isMeasureModeActive, select, translate, draw, modify, pointDraw, uncertaintyModify, moveToClick, measure])
 
   useEffect(() => {
     if (!scaleLine) return
@@ -146,5 +174,5 @@ export default function useMapInteractions({
     return () => container.removeEventListener('keydown', onKeyDown)
   }, [containerRef, draw])
 
-  return { draw, modify, moveToClick, measure }
+  return { draw, modify, moveToClick, pointDraw, measure }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useSelectionLayer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useSelectionLayer.jsx
@@ -6,6 +6,7 @@ import Overlay from 'ol/Overlay'
 import DeleteIcon from '@plugins/drawingTools/components/DeleteButton/DeleteIcon'
 import getFeatureStyle from '../helpers/getFeatureStyle'
 import isLineStringFeature from '../helpers/isLineStringFeature'
+import isPointFeature from '../helpers/isPointFeature'
 import { clearSelectedFeature } from '../helpers/mapSelection'
 
 const ICON_RADIUS = 8
@@ -16,6 +17,12 @@ function isFirstVertexStyle(style, feature) {
   if (!coord) return false
   const first = feature.getGeometry().getFirstCoordinate()
   return coord[0] === first[0] && coord[1] === first[1]
+}
+
+// Volunteer-created features carry a toolIndex; subject-provided features don't and stay undeletable.
+function isDeletableFeature(feature) {
+  if (isLineStringFeature(feature)) return true
+  return isPointFeature(feature) && typeof feature.get?.('toolIndex') === 'number'
 }
 
 export default function useSelectionLayer({
@@ -56,7 +63,7 @@ export default function useSelectionLayer({
 
     function handleDelete() {
       const current = select.getFeatures()?.item(0)
-      if (!isLineStringFeature(current)) return
+      if (!isDeletableFeature(current)) return
       source.removeFeature(current)
       clearSelectedFeature(select)
     }
@@ -95,7 +102,7 @@ export default function useSelectionLayer({
       layer.changed()
 
       const selected = event.selected?.[0]
-      if (isLineStringFeature(selected)) {
+      if (isDeletableFeature(selected)) {
         overlay.setPosition(selected.getGeometry().getFirstCoordinate())
         element.style.display = ''
         changeKey = selected.on('change', () => {

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
@@ -151,6 +151,67 @@ describe('Model > GeoDrawingTask', function () {
       expect(task.isComplete(annotation)).to.equal(false)
     })
 
+    describe('with a creatable Point tool', function () {
+      const pointTaskSnapshot = {
+        strings: { instruction: 'Mark the points.' },
+        taskKey: 'T0',
+        tools: [
+          { label: 'Point', type: 'Point', min: 2, max: 3 }
+        ],
+        type: 'geoDrawing'
+      }
+
+      function pointFeature(coordinates, properties) {
+        return { type: 'Feature', geometry: { type: 'Point', coordinates }, properties }
+      }
+
+      it('returns false when fewer than tool.min points are tagged for that tool', function () {
+        const task = GeoDrawingTask.create(pointTaskSnapshot)
+        const annotation = task.defaultAnnotation()
+        annotation.update({
+          type: 'FeatureCollection',
+          features: [pointFeature([0, 0], { toolIndex: 0 })]
+        })
+        expect(task.isComplete(annotation)).to.equal(false)
+      })
+
+      it('returns true when at least tool.min points are tagged for that tool', function () {
+        const task = GeoDrawingTask.create(pointTaskSnapshot)
+        const annotation = task.defaultAnnotation()
+        annotation.update({
+          type: 'FeatureCollection',
+          features: [
+            pointFeature([0, 0], { toolIndex: 0 }),
+            pointFeature([1, 1], { toolIndex: 0 })
+          ]
+        })
+        expect(task.isComplete(annotation)).to.equal(true)
+      })
+
+      it('excludes subject-provided points (no toolIndex) from the min count', function () {
+        const task = GeoDrawingTask.create(pointTaskSnapshot)
+        const annotation = task.defaultAnnotation()
+        annotation.update({
+          type: 'FeatureCollection',
+          features: [
+            pointFeature([0, 0], {}),
+            pointFeature([1, 1], { toolIndex: 0 })
+          ]
+        })
+        expect(task.isComplete(annotation)).to.equal(false)
+      })
+
+      it('does not enforce a min for a move-only Point tool (defaults min 0, max 0)', function () {
+        const task = GeoDrawingTask.create({
+          ...pointTaskSnapshot,
+          tools: [{ label: 'Point', type: 'Point' }]
+        })
+        const annotation = task.defaultAnnotation()
+        annotation.update({ type: 'FeatureCollection', features: [] })
+        expect(task.isComplete(annotation)).to.equal(true)
+      })
+    })
+
     describe('with multiple SegmentedLine tools', function () {
       const twoToolSnapshot = {
         strings: { instruction: 'Draw both kinds of lines.' },

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/PointTool/PointTool.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/PointTool/PointTool.js
@@ -1,11 +1,19 @@
 import { types } from 'mobx-state-tree'
+import countType from '../helpers/countType'
 
 const PointTool = types
   .model('PointTool', {
     color: types.optional(types.string, ''),
     label: types.optional(types.string, ''),
+    max: countType(0),
+    min: countType(0),
     type: types.literal('Point'),
     uncertainty_circle: types.optional(types.boolean, false)
   })
+  .views(self => ({
+    get canCreate() {
+      return self.max > 0
+    }
+  }))
 
 export default PointTool

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/PointTool/PointTool.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/PointTool/PointTool.spec.jsx
@@ -27,12 +27,29 @@ describe('Model > PointTool', function () {
     expect(tool.uncertainty_circle).to.equal(false)
   })
 
+  it('should default min to 0', function () {
+    const tool = PointTool.create({ type: 'Point' })
+    expect(tool.min).to.equal(0)
+  })
+
+  it('should default max to 0 (creation disabled)', function () {
+    const tool = PointTool.create({ type: 'Point' })
+    expect(tool.max).to.equal(0)
+  })
+
+  it('should not allow creation by default', function () {
+    const tool = PointTool.create({ type: 'Point' })
+    expect(tool.canCreate).to.equal(false)
+  })
+
   describe('with defined properties', function () {
     const pointToolSnapshot = {
       label: 'Map Point',
       type: 'Point',
       color: '#ff0000',
-      uncertainty_circle: true
+      uncertainty_circle: true,
+      min: 1,
+      max: 3
     }
 
     it('should have a color property', function () {
@@ -48,6 +65,53 @@ describe('Model > PointTool', function () {
     it('should have uncertainty_circle of true', function () {
       const tool = PointTool.create(pointToolSnapshot)
       expect(tool.uncertainty_circle).to.equal(true)
+    })
+
+    it('should accept min', function () {
+      const tool = PointTool.create(pointToolSnapshot)
+      expect(tool.min).to.equal(1)
+    })
+
+    it('should accept max', function () {
+      const tool = PointTool.create(pointToolSnapshot)
+      expect(tool.max).to.equal(3)
+    })
+
+    it('should allow creation when max is greater than 0', function () {
+      const tool = PointTool.create(pointToolSnapshot)
+      expect(tool.canCreate).to.equal(true)
+    })
+  })
+
+  describe('with point-count bounds as strings (Panoptes JSON)', function () {
+    it('should coerce string min to a number', function () {
+      const tool = PointTool.create({ type: 'Point', min: '2' })
+      expect(tool.min).to.equal(2)
+    })
+
+    it('should coerce string max to a number', function () {
+      const tool = PointTool.create({ type: 'Point', max: '5' })
+      expect(tool.max).to.equal(5)
+    })
+
+    it('should fall back to 0 when max is empty string', function () {
+      const tool = PointTool.create({ type: 'Point', max: '' })
+      expect(tool.max).to.equal(0)
+    })
+
+    it('should fall back to 0 when min is empty string', function () {
+      const tool = PointTool.create({ type: 'Point', min: '' })
+      expect(tool.min).to.equal(0)
+    })
+
+    it('should fall back to 0 when max is non-numeric', function () {
+      const tool = PointTool.create({ type: 'Point', max: 'abc' })
+      expect(tool.max).to.equal(0)
+    })
+
+    it('should not allow creation when max coerces to 0', function () {
+      const tool = PointTool.create({ type: 'Point', max: '' })
+      expect(tool.canCreate).to.equal(false)
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/SegmentedLineTool/SegmentedLineTool.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/SegmentedLineTool/SegmentedLineTool.js
@@ -1,56 +1,14 @@
 import { types } from 'mobx-state-tree'
-
-// Panoptes serves workflow config as strings (e.g. min_vertices: '3'); coerce to a finite number.
-function coerceCount(snapshot, fallback) {
-  if (snapshot === undefined || snapshot === null || snapshot === '') return fallback
-  const n = typeof snapshot === 'number' ? snapshot : Number(snapshot)
-  return Number.isFinite(n) ? n : fallback
-}
-
-const MinVertexCount = types.snapshotProcessor(
-  types.optional(types.number, 2),
-  {
-    preProcessor(snapshot) {
-      return coerceCount(snapshot, 2)
-    }
-  }
-)
-
-const MaxVertexCount = types.snapshotProcessor(
-  types.maybe(types.number),
-  {
-    preProcessor(snapshot) {
-      return coerceCount(snapshot, undefined)
-    }
-  }
-)
-
-const MinLineCount = types.snapshotProcessor(
-  types.optional(types.number, 0),
-  {
-    preProcessor(snapshot) {
-      return coerceCount(snapshot, 0)
-    }
-  }
-)
-
-const MaxLineCount = types.snapshotProcessor(
-  types.maybe(types.number),
-  {
-    preProcessor(snapshot) {
-      return coerceCount(snapshot, undefined)
-    }
-  }
-)
+import countType from '../helpers/countType'
 
 const SegmentedLineTool = types
   .model('SegmentedLineTool', {
     color: types.optional(types.string, ''),
     label: types.optional(types.string, ''),
-    max: MaxLineCount,
-    max_vertices: MaxVertexCount,
-    min: MinLineCount,
-    min_vertices: MinVertexCount,
+    max: countType(),
+    max_vertices: countType(),
+    min: countType(0),
+    min_vertices: countType(2),
     type: types.literal('SegmentedLine')
   })
 

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/helpers/countType.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/tools/models/helpers/countType.js
@@ -1,0 +1,19 @@
+import { types } from 'mobx-state-tree'
+
+// Panoptes serves workflow config as strings (e.g. min_vertices: '3'); coerce to a finite number.
+function coerceCount(snapshot, fallback) {
+  if (snapshot === undefined || snapshot === null || snapshot === '') return fallback
+  const n = Number(snapshot)
+  return Number.isFinite(n) ? n : fallback
+}
+
+export default function countType(fallback) {
+  const base = fallback === undefined
+    ? types.maybe(types.number)
+    : types.optional(types.number, fallback)
+  return types.snapshotProcessor(base, {
+    preProcessor(snapshot) {
+      return coerceCount(snapshot, fallback)
+    }
+  })
+}


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #7360
- Closes #7361
- Closes #7362

## Describe your changes
- add `min` and `max` to PointTool, string-coerced like SegmentedLineTool; `max > 0` enables point creation
- create points on empty-map clicks up to `max`, stamped with `toolIndex` and auto-selected; created points are deletable, subject points are not
- gate task completion on `min` created points, excluding subject-provided points from all counts
- fit and constrain the map from the subject bbox alone when a subject has no features, so bbox-only subjects start empty and centered
- show a crosshair over empty map while creation is available; empty-map clicks teleport the selected point only once the cap is reached

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- markbouslog/northstar-mapping-project, workflow 32398 "GeoDrawing Point Create" (subject set 136882, bbox-only subjects, Point tool min 1 / max 3): `https://local.zooniverse.org:3000/projects/markbouslog/northstar-mapping-project/classify/workflow/32398?env=production`

What user actions should my reviewer step through to review this PR?
- [x] run `pnpm build` in `packages/lib-classifier`, then `PANOPTES_ENV=production pnpm dev` in `packages/app-project`, and open the URL above
- [x] the map loads fit to the subject box with the outside greyed out, no point drawn, and the task card reading "0 of 1 required, 3 maximum drawn"
- [x] click empty map three times; each click creates a selected point and the count climbs to 3
- [x] click empty map a 4th time; nothing is created
- [x] re-select a created point and delete it via the overlay button; the count drops to 2 and clicking empty map creates again
- [x] in Storybook (`pnpm storybook` in `packages/lib-classifier`), open the story below and set `max: 0` with `seedSubjectPoint` on; confirm move-only behavior is unchanged (empty-map clicks teleport the seeded point, nothing is created)
- [x] confirm earlier-PR behaviors are intact: segmented line draw with count and vertex bounds, line delete affordance, extent mask and clamping
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `PointTool.spec.jsx`, `createGeoPointInteraction.spec.js`, `loadGeoJSON.spec.js`, `getInteractionStates.spec.js`, `getCursorFromState.spec.js`, and `GeoDrawingTask.spec.jsx` pass

Which storybook stories should be reviewed?
- `Subject Viewers / GeoMapViewer` -> `WithGeoDrawingPointCreationTask` (controls for `min`, `max`, and `seedSubjectPoint`): http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-geo-drawing-point-creation-task

Are there plans for follow up PR's to further fix this bug or develop this feature?
- Yes. This PR completes the Point Refactor milestone (#7360, #7361, #7362) and is stacked on #7524 (Subject Definition), so its base retargets to main when that merges. Following it:
- Panoptes-Front-End: Add "Number of points" Min/Max editor to the GeoDrawing Point tool config (branch ready, PR to follow)

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
