### PR TITLE
app-project: Adjust ETC for recently launched workflows and completeness for those configed to classification count stats instead of retirement count

### DIFF
--- a/packages/app-project/src/helpers/getProjectStatsPageProps/fetchWorkflowStatsHelper.js
+++ b/packages/app-project/src/helpers/getProjectStatsPageProps/fetchWorkflowStatsHelper.js
@@ -120,6 +120,23 @@ function calcDaysToCompletion(erasData, workflow) {
   return numDays
 }
 
+function calcCompleteness(workflow) {
+  if (workflow.completeness === 1) return 1
+
+  let completeness = workflow.completeness // the value returned from panoptes API
+
+  const totalCount = workflow.subjects_count * workflow.retirement.options.count
+
+  // This config prop only applies to stats page UI. Configuring stats_completion_type in
+  // the project builder as "Completeness statistic" does not recalc workflow.completeness on the backend.
+  // The default stats_completeness_type is by retirement count, so we have to override here.
+  if (workflow.configuration.stats_completeness_type === 'classification') {
+    completeness = workflow.classifications_count / totalCount
+  }
+
+  return completeness
+}
+
 async function fetchWorkflowStatsHelper(language = 'en', workflowIDs, env, workflowOrder) {
   // Fetch workflow data from Panoptes API
   const workflows = await fetchWorkflowData(workflowIDs, env)
@@ -151,8 +168,10 @@ async function fetchWorkflowStatsHelper(language = 'en', workflowIDs, env, workf
 
     if (workflowERASData?.data) {
       const workflowETC = calcDaysToCompletion(workflowERASData, workflow) ?? null
+      const workflowCompleteness = calcCompleteness(workflow)
       const workflowWithETC = {
         ...workflow,
+        completeness: workflowCompleteness,
         etc: workflowETC
       }
       return workflowWithETC

--- a/packages/app-project/src/helpers/getProjectStatsPageProps/fetchWorkflowStatsHelper.js
+++ b/packages/app-project/src/helpers/getProjectStatsPageProps/fetchWorkflowStatsHelper.js
@@ -61,15 +61,26 @@ async function fetchWorkflowClassificationStats(workflowID, env) {
 
   const today = new Date()
 
-  // Subtract one day because today's stats bucket is still accumulating
-  const yesterday = new Date(today)
-  yesterday.setDate(yesterday.getDate() - 1)
-  const endDate = yesterday.toISOString().substring(0, 10)
+  // Subtract one day because today's stats bucket is still accumulating (always UTC)
+  const yesterdayUTC = new Date(
+    Date.UTC(
+      today.getUTCFullYear(),
+      today.getUTCMonth(),
+      today.getUTCDate() - 1
+    )
+  )
 
-  // Get date of two weeks ago
-  const twoWeeksAgo = new Date(today)
-  twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14)
-  const startDate = twoWeeksAgo.toISOString().substring(0, 10)
+  const endDate = yesterdayUTC.toISOString().substring(0, 10)
+
+  // Get date of two weeks ago (always UTC)
+  const twoWeeksAgoUTC = new Date(
+    Date.UTC(
+      today.getUTCFullYear(),
+      today.getUTCMonth(),
+      today.getUTCDate() - 14
+    )
+  )
+  const startDate = twoWeeksAgoUTC.toISOString().substring(0, 10)
 
   try {
     const statsResponse = await fetch(
@@ -88,7 +99,7 @@ async function fetchWorkflowClassificationStats(workflowID, env) {
  * Returns estimate number of days based on ERAS query excluding the current day because it's not over yet.
  */
 function calcDaysToCompletion(erasData, workflow) {
-  if (workflow.completeness === 1) return 0
+  if (workflow.completeness === 1) return null
 
   let numDays = undefined
 
@@ -96,17 +107,13 @@ function calcDaysToCompletion(erasData, workflow) {
   // multiplied by the number of classifications required to retire a subject
   const totalCount = workflow.subjects_count * workflow.retirement.options.count
 
-  const dataLength = erasData.length // number of days the workflow has stats for
+  const dataLength = erasData.data.length // number of days the workflow has stats for
 
-  if (dataLength > 1) {
-    const classificationCountsArray = erasData.map(statObject => statObject.count)
-    // Sum the classifications per day the workflow has been live (up to 14 days)
-    const rate = classificationCountsArray.reduce((a, b) => a + b)
-
+  if (dataLength > 0) {
     // Estimate number of days needed to achieve the classification counts to retire remaining subjects
     numDays = Math.max(
       0,
-      Math.ceil((dataLength * (totalCount - workflow.classifications_count)) / rate)
+      Math.ceil((dataLength * (totalCount - workflow.classifications_count)) / erasData.total_count)
     )
   }
 
@@ -143,7 +150,7 @@ async function fetchWorkflowStatsHelper(language = 'en', workflowIDs, env, workf
     const workflowERASData = await fetchWorkflowClassificationStats(workflow.id, env)
 
     if (workflowERASData?.data) {
-      const workflowETC = calcDaysToCompletion(workflowERASData.data, workflow) || null
+      const workflowETC = calcDaysToCompletion(workflowERASData, workflow) ?? null
       const workflowWithETC = {
         ...workflow,
         etc: workflowETC

--- a/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.jsx
@@ -137,11 +137,14 @@ function Workflows({ workflows = [] }) {
                     })}
                   </Text>
                   {/*
-                  Only show the ETC if retirement is based on classification count per subject (and the workflow isn't complete).
-                  Other options are 'never_retire' such as in Leveling Up workflows.
+                  Only show the ETC if:
+                    1. Retirement is based on classification count per subject (other options are 'never_retire' such as in Leveling Up workflows)
+                    2. The workflow isn't complete (etc is null if complete)
+                    3. There is more than 1 day of stats data available via ERAS API (etc is null if just launched workflow)
                 */}
                   {workflow?.completeness !== 1 &&
-                  workflow?.retirement?.criteria === 'classification_count' ? (
+                  workflow?.retirement?.criteria === 'classification_count' &&
+                  Number.isFinite(workflow?.etc) ? (
                     <Box direction='row' gap='3px'>
                       <Tip
                         content={<Text color='white'>{t('ProjectStats.workflows.tip')}</Text>}
@@ -156,7 +159,7 @@ function Workflows({ workflows = [] }) {
                         <Button plain icon={<CircleInformation size='0.75rem' />} />
                       </Tip>
                       <Text color={{ light: 'dark-4', dark: 'white' }} size='1rem'>
-                        ETC: {nf.format(workflow?.etc)}
+                        ETC: {nf.format(workflow.etc)}
                       </Text>
                     </Box>
                   ) : null}

--- a/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.jsx
+++ b/packages/app-project/src/screens/ProjectStatsPage/components/Workflows/Workflows.jsx
@@ -86,6 +86,7 @@ function Workflows({ workflows = [] }) {
     unitDisplay: 'long'
   })
 
+
   return (
     <ContentBox
       title={t('ProjectStats.workflows.title')}


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
https://github.com/zooniverse/front-end-monorepo/issues/7472

## Describe your changes
- Adjust when to show ETC per workflow (only need 1 day bucket of stats instead of 2)
- Don't show ETC if it's `null` (happens if workflow is just launched today or workflow is complete)
- Remove unnecessary calc of eras response `total_count`
- Override `workflow.completeness` when its `stats_completeness_type` is set to "classification". The default `stats_completeness_type` is by retirement count, so we have to override it because toggling in the project builder does not recalc `workflow.completeness` on the backend. This prop is only for the project stats page UI.

## How to Review

Review the discussion in https://github.com/zooniverse/front-end-monorepo/issues/7472

Compare a project's stats page to its current page, PFE's old stats page, and running app-project locally:
1. Notes From Nature - Southeastern U.S. Biodiversity (wants to show stats by classification count, not the default by retirement count)
    i. https://pr-7406.pfe-preview.zooniverse.org/projects/md68135/notes-from-nature-southeastern-us-biodiversity/stats
    ii. https://localhost.zooniverse.org:3000/projects/md68135/notes-from-nature-southeastern-us-biodiversity/stats?env=production
    iii. https://www.zooniverse.org/projects/md68135/notes-from-nature-southeastern-us-biodiversity/stats
2. [E-I-E-I-O No! (shows stats by the default UI - retirement count)
    i. https://pr-7406.pfe-preview.zooniverse.org/projects/blerdapprentice/e-i-e-i-o-no/stats
    ii. https://localhost.zooniverse.org:3000/projects/blerdapprentice/e-i-e-i-o-no/stats?env=production
    iii. https://www.zooniverse.org/projects/blerdapprentice/e-i-e-i-o-no/stats
3. Nature Spam Filter (a finished project)
    i. https://pr-7406.pfe-preview.zooniverse.org/projects/dverissimo/nature-spam-filter/stats
    ii. https://localhost.zooniverse.org:3000/projects/dverissimo/nature-spam-filter/stats?env=production
    iii. https://www.zooniverse.org/projects/dverissimo/nature-spam-filter/stats

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
