### PR TITLE
Reset Password Page pt2: Redirect on Success

### DIFF
--- a/packages/lib-content/src/screens/ResetPassword/README.md
+++ b/packages/lib-content/src/screens/ResetPassword/README.md
@@ -25,7 +25,8 @@ Behaviours:
     - "busy" state: request is being sent to Panoptes. "Loader" (busy indicator) is shown. Form is disabled.
     - "success" state: request has successfully been processed. Success message is show. Form remains disabled.
     - "error" state: request has failed (API error). Error message is shown. Form is re-enabled.
-  - 🚧 TODO: after a successful reset, user should be redirected to a sign in page.
+  - After a successful reset, user is redirected to the/a Zooniverse Sign In page: https://www.zooniverse.org/accounts/sign-in
+    - Note that as of Aug 2026, this Sign In page is hosted on PFE.
 
 Security:
 

--- a/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
+++ b/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
@@ -2,7 +2,7 @@ import { useId, useRef, useState } from 'react'
 import { Anchor, Box, Form, Heading, Paragraph, Text, TextInput } from 'grommet'
 import { Trans, useTranslation } from '@translations/i18n'
 import styled, { css } from 'styled-components'
-import { string } from 'prop-types'
+import { func, string } from 'prop-types'
 
 import { Loader, StatusMessage } from '@zooniverse/react-components'
 import ResetPasswordHeading from '../ResetPasswordHeading/ResetPasswordHeading'
@@ -188,6 +188,7 @@ function CommitResetForm ({
 }
 
 CommitResetForm.propTypes = {
+  onSuccess: func,
   resetPasswordToken: string,
 }
 

--- a/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
+++ b/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
@@ -1,6 +1,6 @@
 import { useId, useRef, useState } from 'react'
-import { Box, Form, Heading, Paragraph, TextInput } from 'grommet'
-import { useTranslation } from '@translations/i18n'
+import { Anchor, Box, Form, Heading, Paragraph, TextInput } from 'grommet'
+import { Trans, useTranslation } from '@translations/i18n'
 import styled, { css } from 'styled-components'
 import { string } from 'prop-types'
 
@@ -8,7 +8,7 @@ import { Loader, StatusMessage } from '@zooniverse/react-components'
 import ResetPasswordHeader from '../ResetPasswordHeader/ResetPasswordHeader'
 import doCommitPasswordReset from '../../helpers/doCommitPasswordReset.js'
 import isNewPasswordValid from '../../helpers/isNewPasswordValid.js'
-import redirectToSignInPage from '../../helpers/redirectToSignInPage.js'
+import redirectToSignInPage, { SIGN_IN_URL } from '../../helpers/redirectToSignInPage.js'
 import DarkTealPrimaryButton from '../../../Unsubscribe/components/DarkTealPrimaryButton/DarkTealPrimaryButton'
 
 const InputBoxes = styled(Box)`
@@ -102,7 +102,17 @@ function CommitResetForm ({
 
   } else if (isComplete) {
     statusType = 'success'
-    statusText = t('ResetPassword.CommitResetForm.status.success')
+    statusText = (
+      <span>
+        <Trans
+          i18nKey='ResetPassword.CommitResetForm.status.success'
+          t={t}
+          components={[
+            <Anchor key='sign-in-link' href={SIGN_IN_URL} />
+          ]}
+        />
+      </span>
+    )
   }
 
   return (

--- a/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
+++ b/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
@@ -8,6 +8,7 @@ import { Loader, StatusMessage } from '@zooniverse/react-components'
 import ResetPasswordHeader from '../ResetPasswordHeader/ResetPasswordHeader'
 import doCommitPasswordReset from '../../helpers/doCommitPasswordReset.js'
 import isNewPasswordValid from '../../helpers/isNewPasswordValid.js'
+import redirectToSignInPage from '../../helpers/redirectToSignInPage.js'
 import DarkTealPrimaryButton from '../../../Unsubscribe/components/DarkTealPrimaryButton/DarkTealPrimaryButton'
 
 const InputBoxes = styled(Box)`
@@ -42,7 +43,8 @@ const MINIMUM_PASSWORD_LENGTH = 8
 const PASSWORD_PATTERN = `.{${MINIMUM_PASSWORD_LENGTH},}`
 
 function CommitResetForm ({
-  resetPasswordToken = ''
+  resetPasswordToken = '',
+  onSuccess = redirectToSignInPage,
 }) {
 
   const { t } = useTranslation()
@@ -84,6 +86,7 @@ function CommitResetForm ({
     setIsBusy(false)
     setApiError(submitError)
     setIsComplete(!submitError)
+    if (!submitError) { onSuccess() }  // Trigger a redirect on success.
   }
 
   // Update StatusMessage

--- a/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
+++ b/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
@@ -8,6 +8,7 @@ import { Loader, StatusMessage } from '@zooniverse/react-components'
 import ResetPasswordHeading from '../ResetPasswordHeading/ResetPasswordHeading'
 import doCommitPasswordReset from '../../helpers/doCommitPasswordReset.js'
 import isNewPasswordValid from '../../helpers/isNewPasswordValid.js'
+import redirectToSignInPage from '../../helpers/redirectToSignInPage.js'
 import DarkTealPrimaryButton from '../../../Unsubscribe/components/DarkTealPrimaryButton/DarkTealPrimaryButton'
 
 const InputBoxes = styled(Box)`
@@ -32,7 +33,8 @@ const MINIMUM_PASSWORD_LENGTH = 8
 const PASSWORD_PATTERN = `.{${MINIMUM_PASSWORD_LENGTH},}`
 
 function CommitResetForm ({
-  resetPasswordToken = ''
+  resetPasswordToken = '',
+  onSuccess = redirectToSignInPage,
 }) {
 
   const { t } = useTranslation()
@@ -78,6 +80,7 @@ function CommitResetForm ({
     setIsBusy(false)
     setApiError(submitError)
     setIsComplete(!submitError)
+    if (!submitError) { onSuccess() }  // Trigger a redirect on success.
   }
 
   // Update StatusMessage

--- a/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
+++ b/packages/lib-content/src/screens/ResetPassword/components/CommitResetForm/CommitResetForm.jsx
@@ -1,6 +1,6 @@
 import { useId, useRef, useState } from 'react'
-import { Box, Form, Heading, Paragraph, Text, TextInput } from 'grommet'
-import { useTranslation } from '@translations/i18n'
+import { Anchor, Box, Form, Heading, Paragraph, Text, TextInput } from 'grommet'
+import { Trans, useTranslation } from '@translations/i18n'
 import styled, { css } from 'styled-components'
 import { string } from 'prop-types'
 
@@ -8,7 +8,7 @@ import { Loader, StatusMessage } from '@zooniverse/react-components'
 import ResetPasswordHeading from '../ResetPasswordHeading/ResetPasswordHeading'
 import doCommitPasswordReset from '../../helpers/doCommitPasswordReset.js'
 import isNewPasswordValid from '../../helpers/isNewPasswordValid.js'
-import redirectToSignInPage from '../../helpers/redirectToSignInPage.js'
+import redirectToSignInPage, { SIGN_IN_URL } from '../../helpers/redirectToSignInPage.js'
 import DarkTealPrimaryButton from '../../../Unsubscribe/components/DarkTealPrimaryButton/DarkTealPrimaryButton'
 
 const InputBoxes = styled(Box)`
@@ -96,7 +96,17 @@ function CommitResetForm ({
 
   } else if (isComplete) {
     statusType = 'success'
-    statusText = t('ResetPassword.CommitResetForm.status.success')
+    statusText = (
+      <span>
+        <Trans
+          i18nKey='ResetPassword.CommitResetForm.status.success'
+          t={t}
+          components={[
+            <Anchor key='sign-in-link' href={SIGN_IN_URL} />
+          ]}
+        />
+      </span>
+    )
   }
 
   return (

--- a/packages/lib-content/src/screens/ResetPassword/helpers/redirectToSignInPage.js
+++ b/packages/lib-content/src/screens/ResetPassword/helpers/redirectToSignInPage.js
@@ -10,8 +10,8 @@ and it sits on PFE. As a result, we're using a very simple redirect code to
 avoid any possible complications from traversing the FEM-PFE boundaries. 
  */
 
-const WAIT_TIME = 5000  // 5 seconds
-const SIGN_IN_URL = '/accounts/sign-in'
+const WAIT_TIME = 6000  // 6 seconds
+export const SIGN_IN_URL = '/accounts/sign-in'
 
 export default async function redirectToSignInPage () {
 

--- a/packages/lib-content/src/screens/ResetPassword/helpers/redirectToSignInPage.js
+++ b/packages/lib-content/src/screens/ResetPassword/helpers/redirectToSignInPage.js
@@ -1,0 +1,27 @@
+/*
+Redirect To Sign In Page
+
+After a short delay, this function redirects users to the Zooniverse sign in
+page.  This is meant to be called by CommitResetForm, after the "commit reset"
+action is successful.
+
+As of Aug 2026, the "canonical" sign in page is https://www.zooniverse.org/accounts/sign-in
+and it sits on PFE. As a result, we're using a very simple redirect code to
+avoid any possible complications from traversing the FEM-PFE boundaries. 
+ */
+
+const WAIT_TIME = 5000  // 5 seconds
+const SIGN_IN_URL = '/accounts/sign-in'
+
+export default async function redirectToSignInPage () {
+
+  await sleep(WAIT_TIME)
+  
+  if (window && window.location) {
+    window.location = SIGN_IN_URL
+  }
+}
+
+function sleep (time = 0) {
+  return new Promise(resolve => setTimeout(resolve, time))
+}

--- a/packages/lib-content/src/translations/en.json
+++ b/packages/lib-content/src/translations/en.json
@@ -377,7 +377,7 @@
       "infoPassword": "Minimum 8 characters",
       "infoConfirmation": "Both fields must match",
       "status": {
-        "success": "Your password has been changed! Please log in with your new password.",
+        "success": "Your password has been changed! You'll be redirected to the sign in page in a few seconds, please sign in with your new password.",
         "errorInvalidInput": "Error: invalid input",
         "errorPasswordsDoNotMatch": "Error: the passwords do not match, please try again."
       },

--- a/packages/lib-content/src/translations/en.json
+++ b/packages/lib-content/src/translations/en.json
@@ -377,7 +377,7 @@
       "infoPassword": "Minimum 8 characters",
       "infoConfirmation": "Both fields must match",
       "status": {
-        "success": "Your password has been changed! You'll be redirected to the sign in page in a few seconds, please sign in with your new password.",
+        "success": "Your password has been changed! You'll be redirected to the <0>sign in page</0> in a few seconds, please use your new password.",
         "errorInvalidInput": "Error: invalid input",
         "errorPasswordsDoNotMatch": "Error: the passwords do not match, please try again."
       },


### PR DESCRIPTION
## PR Overview

Part of: Reset Password Page (#7117)
Package: lib-content
Follows: #7529

The Zooniverse has [a Reset Password Page](https://www.zooniverse.org/unsubscribe) but it's hosted on PFE. This PR adds a "redirect to Sign In page" action after the password is successfully reset.

See 7117 for additional discussions on what's exactly our "Sign In page". (Spoiler: we decided on https://zooniverse.org/accounts/sign-in for now)

<img width="620" height="382" alt="image" src="https://github.com/user-attachments/assets/d67318c3-489c-4aec-bacb-cc19f026433b" />

Functional changes:

- Reset Password form, **Mode 3: Commit Reset**
  - Now, when the password reset completes successfully, the user is directed to the Sign In page _(which is on PFE)_ after a 6-second delay.[^1]
  - Also, the "success" message also has a link to the sign in page.

[^1]: the 6 seconds is arbitrary.

Code changes:

- CommitResetForm: change status message
- redirectToSignInPage: helper function added.

### Testing

**Scenario: app-root with ?env=production**

_(This is the same as the test in 7529, but with a few 🆕 steps.)_

- Boot up app-root and go to https://local.zooniverse.org:3000/reset-password?env=production
  - Visit the page while logged in. Ensure the page stops you from doing anything.
  - Visit the page while logged out, then continue the test scenario.
- You should see the **Request Reset form**.
- Type in the email for your test account and submit.
  - You should see a success message.

- ⏳ Wait a few minutes in realtime. Go grab some tea or something.
- 📩 Check your test account's email. Copy the `reset_password_token` in the "reset password" link.

- Go to `https://local.zooniverse.org:3000/reset-password?env=production&reset_password_token=(INSERT TOKEN HERE)`
- You should now see the **Commit Reset form**.
- Submit a valid new password + confirmation.
  - 🆕 You should see a success message with a reminder to the user to sign in. The success message should have a link to `https://local.zooniverse.org:3000/accounts/sign-in`
  - 🆕 Quick! You have 6 seconds to check if the link is legit! But DON'T click it because-
  - 🆕 -after 6 seconds, you'll be automatically redirected to `https://local.zooniverse.org:3000/accounts/sign-in` (which should be a 404 on app-root)

### Status

Ready for review 👍 