### PR TITLE
lib-classifier: Add WFS and GeoJSON overlay layers to the GeoMapViewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.jsx
@@ -1,7 +1,7 @@
 import { Box } from 'grommet'
 import { observer } from 'mobx-react'
-import { arrayOf, bool, func, shape, string } from 'prop-types'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { arrayOf, bool, func, number, shape, string } from 'prop-types'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 import GeoJSON from 'ol/format/GeoJSON'
 import throttle from 'lodash/throttle'
@@ -12,6 +12,7 @@ import { useTranslation } from '@translations/i18n'
 import CoordinateInput from './components/CoordinateInput'
 import LayerControl from './components/LayerControl'
 import MeasureButton from './components/MeasureButton'
+import OverlayLayerControl from './components/OverlayLayerControl'
 import RecenterButton from './components/RecenterButton'
 import ResetButton from './components/ResetButton'
 import UnitSelect from './components/UnitSelect'
@@ -25,7 +26,7 @@ import { clearSelectedFeature, fitViewToExtent } from './helpers/mapSelection'
 import useMapCursor from './hooks/useMapCursor'
 import useMapInteractions from './hooks/useMapInteractions'
 import useMapSelection from './hooks/useMapSelection'
-import useOLMap from './hooks/useOLMap'
+import useOLMap, { isUsableOverlayDescriptor } from './hooks/useOLMap'
 import useSelectionLayer from './hooks/useSelectionLayer'
 
 const StyledBox = styled(Box)`
@@ -68,6 +69,7 @@ function sanitizeProperties(properties = {}) {
 }
 
 const EMPTY_TILE_LAYERS = []
+const EMPTY_OVERLAY_LAYERS = []
 
 function GeoMapViewer({
   geoDrawingTask,
@@ -76,6 +78,7 @@ function GeoMapViewer({
   onMapExtentChange = undefined,
   onMapReady = undefined,
   onSelectedFeatureChange = undefined,
+  overlayLayers = EMPTY_OVERLAY_LAYERS,
   tileLayers = EMPTY_TILE_LAYERS
 }) {
   const [isMeasureModeActive, setIsMeasureModeActive] = useState(false)
@@ -93,7 +96,11 @@ function GeoMapViewer({
   // Subject features are only auto-selected in move-only workflows (no creatable point tool).
   const autoSelect = !geoDrawingTask?.tools?.some(tool => tool.canCreate)
 
-  const { map, source, layer, scaleLine, baseLayers } = useOLMap(containerRef, tileLayers)
+  const usableOverlayLayers = useMemo(() => overlayLayers.filter(isUsableOverlayDescriptor), [overlayLayers])
+  // Sparse boolean[] keyed by overlay index; undefined means visible.
+  const [overlayVisibility, setOverlayVisibility] = useState([])
+
+  const { map, source, layer, scaleLine, baseLayers, overlays } = useOLMap(containerRef, tileLayers, overlayLayers)
 
   const { select, translate } = useMapSelection({
     map,
@@ -153,6 +160,18 @@ function GeoMapViewer({
     if (!baseLayers.length) return
     baseLayers.forEach((tileLayer, index) => tileLayer.setVisible(index === currentLayerIndex))
   }, [baseLayers, currentLayerIndex])
+
+  useEffect(() => {
+    overlays.forEach((overlayLayer, index) => overlayLayer.setVisible(overlayVisibility[index] !== false))
+  }, [overlays, overlayVisibility])
+
+  const handleOverlayToggle = useCallback((index, visible) => {
+    setOverlayVisibility((current) => {
+      const next = current.slice()
+      next[index] = visible
+      return next
+    })
+  }, [])
 
   const previousLayerIndexRef = useRef(currentLayerIndex)
   useEffect(() => {
@@ -266,6 +285,11 @@ function GeoMapViewer({
           activeIndex={currentLayerIndex}
           onChange={setCurrentLayerIndex}
         />
+        <OverlayLayerControl
+          overlays={usableOverlayLayers}
+          visibility={overlayVisibility}
+          onToggle={handleOverlayToggle}
+        />
         {geoJSON && (
           <>
             <RecenterButton onClick={handleRecenter} />
@@ -298,6 +322,17 @@ GeoMapViewer.propTypes = {
   onMapExtentChange: func,
   onMapReady: func,
   onSelectedFeatureChange: func,
+  overlayLayers: arrayOf(shape({
+    type: string.isRequired,
+    label: string,
+    url: string,
+    typeName: string,
+    attributions: string,
+    style: shape({
+      stroke: shape({ color: string, width: number }),
+      fill: shape({ color: string })
+    })
+  })),
   tileLayers: arrayOf(shape({
     type: string.isRequired,
     label: string,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.spec.jsx
@@ -2,7 +2,9 @@ import { composeStory } from '@storybook/react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TileLayer from 'ol/layer/Tile'
+import VectorLayer from 'ol/layer/Vector'
 import Meta, { Default, WithGeoDrawingTask, WithoutGeoDrawingTask } from './GeoMapViewer.stories'
+import GeoMapViewer from './GeoMapViewer'
 
 const DefaultStory = composeStory(Default, Meta)
 const WithGeoDrawingTaskStory = composeStory(WithGeoDrawingTask, Meta)
@@ -174,6 +176,133 @@ describe('Component > GeoMapViewer', function () {
 
       expect(vectorLayer.getVisible()).to.equal(true)
       expect(vectorLayer.getSource()?.getFeatures().length ?? 0).to.equal(featureCountBefore)
+    })
+  })
+
+  describe('configured overlay layers', function () {
+    const overlayDescriptors = [
+      {
+        type: 'wfs',
+        label: 'NHD Hydrography',
+        url: 'https://hydro.nationalmap.gov/arcgis/services/nhd/MapServer/WFSServer',
+        typeName: 'nhd:NHDFlowline',
+        attributions: 'Source: U.S. Geological Survey, National Hydrography Dataset'
+      },
+      {
+        type: 'geojson',
+        label: 'Project area',
+        url: 'https://example.org/static/project-area.geojson'
+      }
+    ]
+
+    // overlay layers have url-loading sources; the features + selection layers do not
+    function overlayLayers (map) {
+      return map.getLayers().getArray().filter(layer => (
+        layer instanceof VectorLayer && !!layer.getSource().getUrl()
+      ))
+    }
+
+    it('declares overlayLayers in propTypes', function () {
+      expect(GeoMapViewer.propTypes).to.have.property('overlayLayers')
+    })
+
+    it('builds no overlay layers when none are configured', async function () {
+      let map = null
+      render(<DefaultStory onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      expect(overlayLayers(map)).to.have.lengthOf(0)
+    })
+
+    it('builds one overlay layer per descriptor, between the base layers and the features layer', async function () {
+      let map = null
+      render(<DefaultStory overlayLayers={overlayDescriptors} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      const overlays = overlayLayers(map)
+      expect(overlays).to.have.lengthOf(2)
+
+      const layers = map.getLayers().getArray()
+      expect(layers[0]).to.be.an.instanceOf(TileLayer)
+      expect(layers[1]).to.equal(overlays[0])
+      expect(layers[2]).to.equal(overlays[1])
+      expect(layers[3]).to.be.an.instanceOf(VectorLayer)
+      expect(layers[3].getSource().getUrl()).to.not.exist
+    })
+
+    it('scopes the Select interaction strictly to the features layer when overlays are configured', async function () {
+      // Select keeps its layer scope as the private layerFilter_ fn
+      let map = null
+      render(
+        <WithGeoDrawingTaskStory
+          overlayLayers={overlayDescriptors}
+          onMapReady={(olMap) => { map = olMap }}
+        />
+      )
+      await waitFor(() => expect(map).to.exist)
+      const select = map.getInteractions().getArray().find(i => i.constructor.name === 'Select')
+      expect(select, 'Select interaction is registered').to.exist
+      expect(select.layerFilter_, 'Select layerFilter_ is callable').to.be.a('function')
+
+      const layers = map.getLayers().getArray()
+      const overlays = overlayLayers(map)
+      expect(overlays).to.have.lengthOf(2)
+      const featuresLayer = layers.find(layer => (
+        layer instanceof VectorLayer && !layer.getSource().getUrl()
+      ))
+
+      expect(select.layerFilter_(featuresLayer)).to.equal(true)
+      overlays.forEach(overlay => expect(select.layerFilter_(overlay)).to.equal(false))
+      expect(select.layerFilter_(layers[0])).to.equal(false)
+    })
+
+    it('renders an OverlayLayerControl checkbox per overlay when overlays are configured', async function () {
+      let map = null
+      render(<DefaultStory overlayLayers={overlayDescriptors} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      expect(screen.getByRole('group', { name: /overlay/i })).to.exist
+      expect(screen.getByRole('checkbox', { name: /NHD Hydrography/i })).to.exist
+      expect(screen.getByRole('checkbox', { name: /Project area/i })).to.exist
+    })
+
+    it('does not render the OverlayLayerControl when no overlays are configured', async function () {
+      let map = null
+      render(<DefaultStory onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      expect(screen.queryByRole('group', { name: /overlay/i })).to.not.exist
+    })
+
+    it('toggling an overlay checkbox flips that VectorLayer visibility (and only that one)', async function () {
+      const user = userEvent.setup()
+      let map = null
+      render(<DefaultStory overlayLayers={overlayDescriptors} onMapReady={(olMap) => { map = olMap }} />)
+      await waitFor(() => expect(map).to.exist)
+      const overlays = overlayLayers(map)
+      expect(overlays.map(overlay => overlay.getVisible())).to.deep.equal([true, true])
+
+      await user.click(screen.getByRole('checkbox', { name: /Project area/i }))
+      expect(overlays.map(overlay => overlay.getVisible())).to.deep.equal([true, false])
+
+      await user.click(screen.getByRole('checkbox', { name: /Project area/i }))
+      expect(overlays.map(overlay => overlay.getVisible())).to.deep.equal([true, true])
+    })
+
+    it('filters incomplete overlay descriptors so half-edited Lab drafts do not crash the viewer', async function () {
+      let map = null
+      render(
+        <DefaultStory
+          overlayLayers={[
+            { type: 'wfs' },
+            { type: 'geojson' },
+            {
+              type: 'wfs',
+              url: 'https://hydro.nationalmap.gov/arcgis/services/nhd/MapServer/WFSServer',
+              typeName: 'nhd:NHDFlowline'
+            }
+          ]}
+          onMapReady={(olMap) => { map = olMap }}
+        />
+      )
+      await waitFor(() => expect(map).to.exist)
+      expect(overlayLayers(map)).to.have.lengthOf(1)
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.stories.jsx
@@ -56,6 +56,40 @@ export const WithMultipleLayers = {
   render: () => <MultiLayerStory />,
 }
 
+export const WithOverlayLayers = {
+  args: {
+    tileLayers: [
+      { type: 'osm', label: 'OpenStreetMap' }
+    ],
+    overlayLayers: [
+      {
+        // bbox-templated ArcGIS REST endpoint with open CORS, so the story loads in the browser
+        type: 'geojson',
+        label: 'NHD Hydrography (NHDFlowline)',
+        url: 'https://hydro.nationalmap.gov/arcgis/rest/services/nhd/MapServer/6/query?where=1%3D1&geometry={bbox}&geometryType=esriGeometryEnvelope&inSR=3857&outSR=4326&f=geojson&resultRecordCount=200',
+        attributions: 'Source: U.S. Geological Survey, National Hydrography Dataset',
+        style: { stroke: { color: 'rgba(20, 80, 180, 0.85)', width: 1.5 } }
+      }
+    ],
+    geoJSON: {
+      type: 'FeatureCollection',
+      bbox: [-91.05, 47.96, -90.97, 48.01],
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-91.0125, 47.9847]
+          },
+          properties: {
+            name: 'Knife Lake — center pin (test seed)'
+          }
+        }
+      ]
+    }
+  }
+}
+
 export const WithGeoDrawingTask = {
   args: {
     geoDrawingTask: GeoDrawingTask.create({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.jsx
@@ -9,6 +9,7 @@ import GeoMapViewer from './GeoMapViewer'
 import ReferenceData from './components/ReferenceData'
 
 const EMPTY_TILE_LAYERS = []
+const EMPTY_OVERLAY_LAYERS = []
 
 export function storeMapper(classifierStore) {
   const {
@@ -25,6 +26,8 @@ export function storeMapper(classifierStore) {
 
   const configuredTileLayers = classifierStore.workflows?.active?.configuration?.subject_viewer_config?.tile_layers
   const tileLayers = Array.isArray(configuredTileLayers) ? configuredTileLayers : EMPTY_TILE_LAYERS
+  const configuredOverlayLayers = classifierStore.workflows?.active?.configuration?.subject_viewer_config?.overlay_layers
+  const overlayLayers = Array.isArray(configuredOverlayLayers) ? configuredOverlayLayers : EMPTY_OVERLAY_LAYERS
 
   const latest = subject?.stepHistory.latest
 
@@ -32,6 +35,7 @@ export function storeMapper(classifierStore) {
     activeStepTasks,
     latest,
     loadingState,
+    overlayLayers,
     subject,
     tileLayers
   }
@@ -47,6 +51,7 @@ function GeoMapViewerContainer ({
     activeStepTasks,
     latest,
     loadingState,
+    overlayLayers,
     subject,
     tileLayers
   } = useStores(storeMapper)
@@ -120,6 +125,7 @@ function GeoMapViewerContainer ({
       <GeoMapViewer
         geoDrawingTask={geoDrawingTask}
         geoJSON={geoJSONData}
+        overlayLayers={overlayLayers}
         subjectId={subject.id}
         tileLayers={tileLayers}
         onFeaturesChange={handleFeaturesChange}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewerContainer.spec.jsx
@@ -71,6 +71,56 @@ describe('Component > GeoMapViewerContainer > storeMapper', function () {
     expect(result.tileLayers).to.deep.equal([])
   })
 
+  it('forwards overlay_layers from subject_viewer_config as the overlayLayers prop', function () {
+    const overlayLayers = [
+      {
+        type: 'wfs',
+        label: 'NHD Hydrography',
+        url: 'https://hydro.nationalmap.gov/arcgis/services/nhd/MapServer/WFSServer',
+        typeName: 'nhd:NHDFlowline',
+        attributions: 'Source: U.S. Geological Survey, National Hydrography Dataset'
+      },
+      {
+        type: 'geojson',
+        label: 'Project area',
+        url: 'https://example.org/static/project-area.geojson'
+      }
+    ]
+    const store = buildStore({
+      workflows: {
+        active: {
+          configuration: {
+            subject_viewer: 'geoMap',
+            subject_viewer_config: { overlay_layers: overlayLayers }
+          }
+        }
+      }
+    })
+    const result = storeMapper(store)
+    expect(result.overlayLayers).to.deep.equal(overlayLayers)
+  })
+
+  it('returns an empty overlayLayers array when subject_viewer_config has no overlay_layers', function () {
+    const result = storeMapper(buildStore())
+    expect(result.overlayLayers).to.deep.equal([])
+  })
+
+  it('returns an empty overlayLayers array when subject_viewer_config is missing', function () {
+    const result = storeMapper(buildStore({
+      workflows: {
+        active: {
+          configuration: { subject_viewer: 'geoMap' }
+        }
+      }
+    }))
+    expect(result.overlayLayers).to.deep.equal([])
+  })
+
+  it('returns an empty overlayLayers array when no workflow is active', function () {
+    const result = storeMapper(buildStore({ workflows: { active: undefined } }))
+    expect(result.overlayLayers).to.deep.equal([])
+  })
+
   it('preserves the existing storeMapper outputs (subject, loadingState, activeStepTasks, latest)', function () {
     const subject = { id: 'subject-2', stepHistory: { latest: { foo: 'bar' } } }
     const activeStepTasks = [{ type: 'geoDrawing' }]

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/OverlayLayerControl/OverlayLayerControl.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/OverlayLayerControl/OverlayLayerControl.jsx
@@ -1,0 +1,70 @@
+import { Box } from 'grommet'
+import { arrayOf, bool, func, shape, string } from 'prop-types'
+import styled from 'styled-components'
+
+import { useTranslation } from '@translations/i18n'
+
+const Group = styled(Box).attrs({
+  direction: 'column',
+  gap: 'xxsmall'
+})`
+  background: ${props => (props.theme.dark ? props.theme.global.colors['dark-3'] : '#fff')};
+  border: 1px solid ${props => props.theme.global.colors['light-5']};
+  border-radius: 4px;
+  font-size: 12px;
+  padding: 6px 8px;
+  min-width: 140px;
+`
+
+const Row = styled.label`
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 6px;
+
+  input[type='checkbox'] {
+    accent-color: ${props => props.theme.global.colors['accent-1']};
+  }
+`
+
+function OverlayLayerControl ({ overlays = [], visibility = [], onToggle }) {
+  const { t } = useTranslation('components')
+
+  if (!Array.isArray(overlays) || overlays.length === 0) {
+    return null
+  }
+
+  return (
+    <Group
+      role='group'
+      aria-label={t('SubjectViewer.GeoMapViewer.OverlayLayerControl.label')}
+    >
+      {overlays.map((overlay, idx) => {
+        const checked = visibility[idx] !== false
+        const label = overlay?.label
+          || `${t('SubjectViewer.GeoMapViewer.OverlayLayerControl.fallbackLabel')} ${idx + 1}`
+        return (
+          <Row key={`${idx}-${overlay?.label || overlay?.type}`}>
+            <input
+              type='checkbox'
+              checked={checked}
+              onChange={(event) => onToggle?.(idx, event.target.checked)}
+            />
+            <span>{label}</span>
+          </Row>
+        )
+      })}
+    </Group>
+  )
+}
+
+OverlayLayerControl.propTypes = {
+  overlays: arrayOf(shape({
+    label: string,
+    type: string
+  })),
+  visibility: arrayOf(bool),
+  onToggle: func
+}
+
+export default OverlayLayerControl

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/OverlayLayerControl/OverlayLayerControl.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/OverlayLayerControl/OverlayLayerControl.spec.jsx
@@ -1,0 +1,86 @@
+import { composeStory } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import Meta, {
+  TwoOverlays,
+  PartiallyHidden,
+  SingleOverlay,
+  NoOverlays
+} from './OverlayLayerControl.stories'
+
+const TwoStory = composeStory(TwoOverlays, Meta)
+const PartiallyHiddenStory = composeStory(PartiallyHidden, Meta)
+const SingleStory = composeStory(SingleOverlay, Meta)
+const NoneStory = composeStory(NoOverlays, Meta)
+
+describe('Component > OverlayLayerControl', function () {
+  describe('with 0 overlays', function () {
+    it('renders nothing when overlays is empty', function () {
+      const { container } = render(<NoneStory />)
+      expect(container.querySelector('[role="group"]')).to.equal(null)
+      expect(container.querySelectorAll('input[type="checkbox"]').length).to.equal(0)
+    })
+  })
+
+  describe('with one or more overlays', function () {
+    it('renders one checkbox per overlay descriptor', function () {
+      render(<TwoStory />)
+      const checkboxes = screen.getAllByRole('checkbox')
+      expect(checkboxes.length).to.equal(2)
+    })
+
+    it('renders even a single overlay (unlike LayerControl which hides for <2)', function () {
+      render(<SingleStory />)
+      expect(screen.getAllByRole('checkbox').length).to.equal(1)
+    })
+
+    it('labels each checkbox with the descriptor label', function () {
+      render(<TwoStory />)
+      expect(screen.getByRole('checkbox', { name: /NHD Hydrography/i })).to.exist
+      expect(screen.getByRole('checkbox', { name: /County boundaries/i })).to.exist
+    })
+
+    it('reflects the supplied visibility array on each checkbox', function () {
+      render(<PartiallyHiddenStory />)
+      const nhd = screen.getByRole('checkbox', { name: /NHD Hydrography/i })
+      const counties = screen.getByRole('checkbox', { name: /County boundaries/i })
+      const huc = screen.getByRole('checkbox', { name: /Watersheds/i })
+      expect(nhd.checked).to.equal(true)
+      expect(counties.checked).to.equal(false)
+      expect(huc.checked).to.equal(true)
+    })
+
+    it('calls onToggle(index, false) when a checked overlay is unchecked', async function () {
+      const calls = []
+      const args = {
+        ...TwoOverlays.args,
+        onToggle: (idx, visible) => { calls.push({ idx, visible }) }
+      }
+      const Story = composeStory({ ...TwoOverlays, args }, Meta)
+      const user = userEvent.setup()
+      render(<Story />)
+      await user.click(screen.getByRole('checkbox', { name: /County boundaries/i }))
+      expect(calls).to.deep.equal([{ idx: 1, visible: false }])
+    })
+
+    it('calls onToggle(index, true) when an unchecked overlay is checked', async function () {
+      const calls = []
+      const args = {
+        ...PartiallyHidden.args,
+        onToggle: (idx, visible) => { calls.push({ idx, visible }) }
+      }
+      const Story = composeStory({ ...PartiallyHidden, args }, Meta)
+      const user = userEvent.setup()
+      render(<Story />)
+      await user.click(screen.getByRole('checkbox', { name: /County boundaries/i }))
+      expect(calls).to.deep.equal([{ idx: 1, visible: true }])
+    })
+
+    it('renders an accessible group label', function () {
+      render(<TwoStory />)
+      const group = screen.getByRole('group', { name: /overlay/i })
+      expect(group).to.exist
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/OverlayLayerControl/OverlayLayerControl.stories.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/OverlayLayerControl/OverlayLayerControl.stories.jsx
@@ -1,0 +1,45 @@
+import OverlayLayerControl from './OverlayLayerControl'
+
+export default {
+  title: 'Subject Viewers / GeoMapViewer / OverlayLayerControl',
+  component: OverlayLayerControl
+}
+
+export const TwoOverlays = {
+  args: {
+    overlays: [
+      { type: 'geojson', label: 'NHD Hydrography' },
+      { type: 'wfs', label: 'County boundaries' }
+    ],
+    visibility: [true, true],
+    onToggle: (idx, visible) => console.log('onToggle', idx, visible)
+  }
+}
+
+export const PartiallyHidden = {
+  args: {
+    overlays: [
+      { type: 'geojson', label: 'NHD Hydrography' },
+      { type: 'wfs', label: 'County boundaries' },
+      { type: 'wfs', label: 'Watersheds (HUC8)' }
+    ],
+    visibility: [true, false, true],
+    onToggle: (idx, visible) => console.log('onToggle', idx, visible)
+  }
+}
+
+export const SingleOverlay = {
+  args: {
+    overlays: [{ type: 'geojson', label: 'NHD Hydrography' }],
+    visibility: [true],
+    onToggle: (idx, visible) => console.log('onToggle', idx, visible)
+  }
+}
+
+export const NoOverlays = {
+  args: {
+    overlays: [],
+    visibility: [],
+    onToggle: (idx, visible) => console.log('onToggle', idx, visible)
+  }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/OverlayLayerControl/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/components/OverlayLayerControl/index.js
@@ -1,0 +1,1 @@
+export { default } from './OverlayLayerControl'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createOverlayLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createOverlayLayer.js
@@ -1,0 +1,34 @@
+import VectorLayer from 'ol/layer/Vector'
+import Style from 'ol/style/Style'
+import Stroke from 'ol/style/Stroke'
+import Fill from 'ol/style/Fill'
+
+import createWFSSource from './createWFSSource'
+
+const DEFAULT_OVERLAY_STYLE = new Style({
+  stroke: new Stroke({ color: 'rgba(80, 80, 80, 0.9)', width: 1.5 })
+})
+
+function buildOverlayStyle(descriptor) {
+  const style = descriptor?.style
+  if (!style) return DEFAULT_OVERLAY_STYLE
+
+  const styleOpts = {}
+  if (style.stroke) {
+    styleOpts.stroke = new Stroke({
+      color: style.stroke.color || 'rgba(80, 80, 80, 0.9)',
+      width: style.stroke.width ?? 1.5
+    })
+  }
+  if (style.fill) {
+    styleOpts.fill = new Fill({ color: style.fill.color || 'rgba(0, 0, 0, 0)' })
+  }
+  return new Style(styleOpts)
+}
+
+export default function createOverlayLayer(descriptor) {
+  return new VectorLayer({
+    source: createWFSSource(descriptor),
+    style: buildOverlayStyle(descriptor)
+  })
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createWFSSource.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createWFSSource.js
@@ -1,0 +1,58 @@
+import VectorSource from 'ol/source/Vector'
+import GeoJSON from 'ol/format/GeoJSON'
+import { bbox as bboxStrategy } from 'ol/loadingstrategy'
+
+export default function createWFSSource(descriptor) {
+  if (!descriptor) throw new Error('createWFSSource: descriptor is required')
+  const { type, url, typeName, attributions } = descriptor
+  const sourceOpts = attributions ? { attributions } : {}
+
+  switch (type) {
+    case 'wfs': {
+      if (!url) throw new Error('createWFSSource: wfs descriptor requires a url')
+      if (!typeName) throw new Error('createWFSSource: wfs descriptor requires a typeName')
+
+      return new VectorSource({
+        ...sourceOpts,
+        format: new GeoJSON(),
+        strategy: bboxStrategy,
+        url: (extent, _resolution, projection) => {
+          const code = projection.getCode()
+          const params = new URLSearchParams({
+            service: 'WFS',
+            version: '2.0.0',
+            request: 'GetFeature',
+            typeName,
+            outputFormat: 'application/json',
+            srsname: code,
+            bbox: `${extent.join(',')},${code}`
+          })
+          const separator = url.includes('?') ? '&' : '?'
+          return `${url}${separator}${params.toString()}`
+        }
+      })
+    }
+
+    case 'geojson': {
+      if (!url) throw new Error('createWFSSource: geojson descriptor requires a url')
+
+      if (url.includes('{bbox}')) {
+        return new VectorSource({
+          ...sourceOpts,
+          format: new GeoJSON(),
+          strategy: bboxStrategy,
+          url: (extent) => url.replace('{bbox}', encodeURIComponent(extent.join(',')))
+        })
+      }
+
+      return new VectorSource({
+        ...sourceOpts,
+        format: new GeoJSON(),
+        url
+      })
+    }
+
+    default:
+      throw new Error(`createWFSSource: unknown descriptor type "${type}"`)
+  }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createWFSSource.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createWFSSource.spec.js
@@ -1,0 +1,106 @@
+import VectorSource from 'ol/source/Vector'
+import GeoJSON from 'ol/format/GeoJSON'
+import createWFSSource from './createWFSSource'
+
+const fakeProjection = { getCode: () => 'EPSG:3857' }
+const sampleExtent = [-10131597, 6126858, -10018754, 6178060]
+
+describe('helpers > createWFSSource', function () {
+  describe('descriptor type "wfs"', function () {
+    const wfsDescriptor = {
+      type: 'wfs',
+      label: 'NHD Hydrography',
+      url: 'https://hydro.nationalmap.gov/arcgis/services/nhd/MapServer/WFSServer',
+      typeName: 'nhd:NHDFlowline'
+    }
+
+    it('returns an OL VectorSource with GeoJSON format', function () {
+      const source = createWFSSource(wfsDescriptor)
+      expect(source).to.be.instanceof(VectorSource)
+      expect(source.getFormat()).to.be.instanceof(GeoJSON)
+    })
+
+    it('builds a GetFeature URL containing service=WFS, the configured typeName, the view projection as srsname, and the current bbox', function () {
+      const source = createWFSSource(wfsDescriptor)
+      const urlFn = source.getUrl()
+      expect(urlFn).to.be.a('function')
+
+      const url = urlFn(sampleExtent, 1.0, fakeProjection)
+      expect(url).to.include('service=WFS')
+      expect(url).to.include('request=GetFeature')
+      expect(url).to.include('typeName=nhd%3ANHDFlowline')
+      expect(url).to.include('srsname=EPSG%3A3857')
+      expect(url).to.include('outputFormat=application%2Fjson')
+      expect(url).to.include(`bbox=${sampleExtent.join('%2C')}%2CEPSG%3A3857`)
+    })
+
+    it('forwards attributions from the descriptor to the source', function () {
+      const source = createWFSSource({
+        ...wfsDescriptor,
+        attributions: 'Source: U.S. Geological Survey, National Hydrography Dataset'
+      })
+      const attribFn = source.getAttributions()
+      expect(attribFn).to.be.a('function')
+      expect(attribFn()[0]).to.include('U.S. Geological Survey')
+    })
+
+    it('throws when wfs descriptor omits url', function () {
+      expect(() => createWFSSource({ type: 'wfs', typeName: 'foo' })).to.throw(/url/i)
+    })
+
+    it('throws when wfs descriptor omits typeName', function () {
+      expect(() => createWFSSource({ type: 'wfs', url: 'https://example.org/wfs' })).to.throw(/typeName/)
+    })
+  })
+
+  describe('descriptor type "geojson"', function () {
+    it('returns an OL VectorSource with GeoJSON format and a static url when no bbox placeholder is present', function () {
+      const source = createWFSSource({
+        type: 'geojson',
+        label: 'Project area',
+        url: 'https://example.org/static/project-area.geojson'
+      })
+      expect(source).to.be.instanceof(VectorSource)
+      expect(source.getFormat()).to.be.instanceof(GeoJSON)
+      expect(source.getUrl()).to.equal('https://example.org/static/project-area.geojson')
+    })
+
+    it('uses a bbox-aware URL function when the configured url contains a {bbox} placeholder', function () {
+      const source = createWFSSource({
+        type: 'geojson',
+        label: 'NHD Flowline (REST)',
+        url: 'https://hydro.nationalmap.gov/arcgis/rest/services/nhd/MapServer/6/query?where=1%3D1&geometry={bbox}&geometryType=esriGeometryEnvelope&inSR=4326&outSR=4326&f=geojson'
+      })
+      const urlFn = source.getUrl()
+      expect(urlFn).to.be.a('function')
+
+      const url = urlFn(sampleExtent, 1.0, fakeProjection)
+      expect(url).to.not.include('{bbox}')
+      expect(url).to.include(`geometry=${sampleExtent.join('%2C')}`)
+      expect(url).to.include('f=geojson')
+    })
+
+    it('forwards attributions from the descriptor to the source', function () {
+      const source = createWFSSource({
+        type: 'geojson',
+        url: 'https://example.org/static/project-area.geojson',
+        attributions: 'Project team'
+      })
+      const attribFn = source.getAttributions()
+      expect(attribFn).to.be.a('function')
+      expect(attribFn()).to.include('Project team')
+    })
+
+    it('throws when geojson descriptor omits url', function () {
+      expect(() => createWFSSource({ type: 'geojson' })).to.throw(/url/i)
+    })
+  })
+
+  it('throws on an unknown descriptor type', function () {
+    expect(() => createWFSSource({ type: 'mystery-source', url: 'https://example.org' })).to.throw(/unknown.*type/i)
+  })
+
+  it('throws on a null descriptor', function () {
+    expect(() => createWFSSource(null)).to.throw()
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useOLMap.js
@@ -5,10 +5,19 @@ import ScaleLine from 'ol/control/ScaleLine'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 
+import createOverlayLayer from '../helpers/createOverlayLayer'
 import createTileLayer from '../helpers/createTileLayer'
 
-export default function useOLMap(containerRef, tileLayers = []) {
-  const [state, setState] = useState({ map: null, source: null, layer: null, scaleLine: null, baseLayers: [] })
+// Incomplete descriptors (drafts saved from the Lab editor) are skipped.
+export function isUsableOverlayDescriptor(descriptor) {
+  if (!descriptor?.type) return false
+  if (descriptor.type === 'wfs') return !!descriptor.url && !!descriptor.typeName
+  if (descriptor.type === 'geojson') return !!descriptor.url
+  return false
+}
+
+export default function useOLMap(containerRef, tileLayers = [], overlayLayers = []) {
+  const [state, setState] = useState({ map: null, source: null, layer: null, scaleLine: null, baseLayers: [], overlays: [] })
 
   useEffect(() => {
     if (!containerRef.current) return undefined
@@ -22,20 +31,23 @@ export default function useOLMap(containerRef, tileLayers = []) {
     const defaultLayerIndex = Math.max(0, descriptors.findIndex(descriptor => descriptor?.default))
     baseTileLayers.forEach((tileLayer, index) => tileLayer.setVisible(index === defaultLayerIndex))
 
+    // Overlays render above the active basemap, beneath the editable feature layer.
+    const overlayOlLayers = overlayLayers.filter(isUsableOverlayDescriptor).map(createOverlayLayer)
+
     const map = new Map({
       target: containerRef.current,
-      layers: [...baseTileLayers, layer],
+      layers: [...baseTileLayers, ...overlayOlLayers, layer],
       view: new View({ center: [0, 0], zoom: 0 }),
       controls: defaultControls({ zoom: false }).extend([scaleLine])
     })
 
-    setState({ map, source, layer, scaleLine, baseLayers: baseTileLayers })
+    setState({ map, source, layer, scaleLine, baseLayers: baseTileLayers, overlays: overlayOlLayers })
 
     return () => {
       map.setTarget(undefined)
-      setState({ map: null, source: null, layer: null, scaleLine: null, baseLayers: [] })
+      setState({ map: null, source: null, layer: null, scaleLine: null, baseLayers: [], overlays: [] })
     }
-  }, [containerRef, tileLayers])
+  }, [containerRef, tileLayers, overlayLayers])
 
   return state
 }

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.spec.js
@@ -155,6 +155,95 @@ describe('Model > Workflow', function () {
     })
   })
 
+  describe('with subject_viewer_config.overlay_layers', function () {
+    const overlayLayers = [
+      {
+        type: 'wfs',
+        label: 'NHD Hydrography',
+        url: 'https://hydro.nationalmap.gov/arcgis/services/nhd/MapServer/WFSServer',
+        typeName: 'nhd:NHDFlowline',
+        attributions: 'Source: U.S. Geological Survey, National Hydrography Dataset'
+      },
+      {
+        type: 'geojson',
+        label: 'Project area outline',
+        url: 'https://example.org/static/project-area.geojson'
+      }
+    ]
+
+    it('should round-trip a populated overlay_layers array on a geoMap workflow', function () {
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'workflow1',
+        configuration: {
+          subject_viewer: 'geoMap',
+          subject_viewer_config: {
+            overlay_layers: overlayLayers
+          }
+        },
+        display_name: 'A test geoMap workflow with configured overlay layers',
+        version: '0.0'
+      })
+      const workflow = Workflow.create(workflowSnapshot)
+      expect(workflow.configuration.subject_viewer_config.overlay_layers).to.deep.equal(overlayLayers)
+    })
+
+    it('should accept an empty overlay_layers array', function () {
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'workflow1',
+        configuration: {
+          subject_viewer: 'geoMap',
+          subject_viewer_config: {
+            overlay_layers: []
+          }
+        },
+        display_name: 'A test geoMap workflow with no configured overlay layers',
+        version: '0.0'
+      })
+      const workflow = Workflow.create(workflowSnapshot)
+      expect(workflow.configuration.subject_viewer_config.overlay_layers).to.deep.equal([])
+    })
+
+    it('should be valid when overlay_layers is omitted entirely (back-compat)', function () {
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'workflow1',
+        configuration: {
+          subject_viewer: 'geoMap',
+          subject_viewer_config: {
+            zoomConfiguration: {
+              direction: 'both',
+              minZoom: 1,
+              maxZoom: 10,
+              zoomInValue: 1.2,
+              zoomOutValue: 0.8
+            }
+          }
+        },
+        display_name: 'A test geoMap workflow without overlay_layers',
+        version: '0.0'
+      })
+      const workflow = Workflow.create(workflowSnapshot)
+      expect(workflow.configuration.subject_viewer_config.overlay_layers).to.equal(undefined)
+    })
+
+    it('should round-trip overlay_layers alongside tile_layers', function () {
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'workflow1',
+        configuration: {
+          subject_viewer: 'geoMap',
+          subject_viewer_config: {
+            tile_layers: [{ type: 'osm', label: 'OpenStreetMap' }],
+            overlay_layers: overlayLayers
+          }
+        },
+        display_name: 'A test geoMap workflow with both tile and overlay layers',
+        version: '0.0'
+      })
+      const workflow = Workflow.create(workflowSnapshot)
+      expect(workflow.configuration.subject_viewer_config.tile_layers).to.deep.equal([{ type: 'osm', label: 'OpenStreetMap' }])
+      expect(workflow.configuration.subject_viewer_config.overlay_layers).to.deep.equal(overlayLayers)
+    })
+  })
+
   describe('workflow steps', function () {
     let step
     const task = MultipleChoiceTaskFactory.build({ taskKey: 'T1' })

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -37,7 +37,8 @@ const WorkflowConfiguration = types.snapshotProcessor(
             zoomOutValue: types.number
           })
         ),
-        tile_layers: types.maybe(types.frozen([]))
+        tile_layers: types.maybe(types.frozen([])),
+        overlay_layers: types.maybe(types.frozen([]))
       })
     )
   })

--- a/packages/lib-classifier/src/store/subjects/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/Subject.js
@@ -61,6 +61,15 @@ const Subject = types
         if (!viewer && self.project?.isVolumetricViewer)
           viewer = subjectViewers.volumetric
 
+        // GeoMapViewer is implied when subject_viewer_config declares tile_layers or overlay_layers
+        const { tile_layers, overlay_layers } = configuration.subject_viewer_config || {}
+        if (!viewer && (
+          (Array.isArray(tile_layers) && tile_layers.length > 0) ||
+          (Array.isArray(overlay_layers) && overlay_layers.length > 0)
+        )) {
+          viewer = subjectViewers.geoMap
+        }
+
         if (!viewer && counts.total === 1) {
           if (counts.audio) {
             viewer = subjectViewers.singleAudio

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -191,6 +191,10 @@
         "label": "Map layer",
         "fallbackLabel": "Layer"
       },
+      "OverlayLayerControl": {
+        "label": "Overlay layers",
+        "fallbackLabel": "Overlay"
+      },
       "MeasureButton": {
         "ariaLabel": "Measure distance"
       },


### PR DESCRIPTION

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #7394
- Closes #7395
- Closes #7396
- Closes #7397

## Describe your changes
- render the workflow's configured `overlay_layers` as reference overlays between the active basemap and the drawn features; each entry is a WFS GetFeature endpoint or a GeoJSON url (static or `{bbox}`-templated), with optional per-overlay stroke and fill styling
- add an Overlay layers control beneath the basemap switcher: one visibility checkbox per configured overlay, all visible by default
- keep overlay geometry unselectable, so clicking and hovering only ever interact with the volunteer's own features
- infer the geoMap viewer when a workflow configures tile or overlay layers

## How to Review

What Zooniverse project should my reviewer use to review UX?
- [markbouslog/northstar-mapping-project, workflow 32087 "GeoDrawing SegmentedLine"](https://local.zooniverse.org:3000/projects/markbouslog/northstar-mapping-project/classify/workflow/32087?env=production)

What user actions should my reviewer step through to review this PR?
- [x] open the classify URL above; the configured reference overlays render on top of the basemap and beneath the subject feature
- [x] switch basemaps via the layer control; overlays stay visible on every basemap
- [x] uncheck an overlay in the Overlay layers control; it disappears, re-checking restores it, and the others are unaffected
- [x] click overlay geometry; nothing selects, and drawing and selecting your own features works exactly as before
- [x] draw a line and submit; the classification payload is unchanged
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `GeoMapViewer.spec.jsx`, `OverlayLayerControl.spec.jsx`, and `createWFSSource.spec.js` pass

Which storybook stories should be reviewed?
- [Subject Viewers / GeoMapViewer / WithOverlayLayers](http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-overlay-layers)

Are there plans for follow up PR's to further fix this bug or develop this feature?
- Yes. Panoptes-Front-End: Add overlay_layers configuration UI to the FEM Lab workflow editor (#7466).
