### PR TITLE
lib-classifier: Make subject-supplied geoDrawing points deletable and count them toward the tool max

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/GeoMapViewer.spec.jsx
@@ -1,8 +1,8 @@
 import { composeStory } from '@storybook/react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TileLayer from 'ol/layer/Tile'
-import Meta, { Default, WithGeoDrawingTask, WithoutGeoDrawingTask } from './GeoMapViewer.stories'
+import Meta, { Default, WithGeoDrawingTask, WithGeoDrawingPointCreationTask, WithoutGeoDrawingTask } from './GeoMapViewer.stories'
 
 const DefaultStory = composeStory(Default, Meta)
 const WithGeoDrawingTaskStory = composeStory(WithGeoDrawingTask, Meta)
@@ -174,6 +174,63 @@ describe('Component > GeoMapViewer', function () {
 
       expect(vectorLayer.getVisible()).to.equal(true)
       expect(vectorLayer.getSource()?.getFeatures().length ?? 0).to.equal(featureCountBefore)
+    })
+  })
+
+  describe('subject-supplied point delete and replace', function () {
+    const PointCreationStory = composeStory(WithGeoDrawingPointCreationTask, Meta)
+
+    // jsdom gives the map no size, so OL keeps overlays hidden; assert on overlay position instead.
+    function deleteOverlay(map) {
+      return map?.getOverlays().getArray().find((overlay) => (
+        overlay.getElement()?.querySelector('button[aria-label="Delete selected feature"]')
+      ))
+    }
+
+    it('positions the delete affordance on the auto-selected subject point in a move-only task', async function () {
+      let map = null
+      render(<PointCreationStory min={0} max={0} seedSubjectPoint onMapReady={(olMap) => { map = olMap }} />)
+
+      await waitFor(() => {
+        expect(deleteOverlay(map)?.getPosition()).to.exist
+      })
+    })
+
+    it('removes the subject point and clears the selection on delete', async function () {
+      let map = null
+      render(<PointCreationStory min={0} max={0} seedSubjectPoint onMapReady={(olMap) => { map = olMap }} />)
+
+      let overlay
+      await waitFor(() => {
+        overlay = deleteOverlay(map)
+        expect(overlay?.getPosition()).to.exist
+      })
+      fireEvent.click(overlay.getElement().querySelector('button'))
+
+      await waitFor(() => {
+        expect(window.__geoFeatureCount).to.equal(0)
+      })
+      expect(overlay.getPosition()).to.not.exist
+    })
+
+    it('blocks point drawing while the seed occupies the only slot', async function () {
+      let map = null
+      render(<PointCreationStory min={0} max={1} seedSubjectPoint onMapReady={(olMap) => { map = olMap }} />)
+
+      function activeDraws() {
+        return map.getInteractions().getArray().filter((interaction) => (
+          interaction.constructor.name === 'Draw' && interaction.getActive()
+        ))
+      }
+
+      await waitFor(() => expect(map).to.exist)
+      await waitFor(() => {
+        const vectorSources = map.getLayers().getArray()
+          .map((layer) => layer.getSource?.())
+          .filter((layerSource) => layerSource?.getFeatures)
+        expect(vectorSources.some((layerSource) => layerSource.getFeatures().length > 0)).to.equal(true)
+      })
+      expect(activeDraws()).to.have.lengthOf(0)
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
@@ -85,6 +85,10 @@ function createGeoPointInteraction({
       feature.set('toolIndex', activeToolIndex)
     }
 
+    if (activeTool?.uncertainty_circle === true) {
+      feature.set('uncertainty_radius', 0)
+    }
+
     if (selectInteraction) {
       Promise.resolve().then(() => {
         selectInteraction.getFeatures().clear()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
@@ -7,11 +7,13 @@ import { FEATURE_HIT_TOLERANCE_PX } from './createGeoLineStringInteraction'
 import { isWithinSubjectExtent } from './extentConstraint'
 import isPointFeature from './isPointFeature'
 
-// Subject-provided points carry no toolIndex, so they never count toward the cap.
+// Subject-provided points carry no toolIndex; they occupy capacity until deleted.
 function countPointFeaturesForTool(source, toolIndex) {
-  return source.getFeatures().filter((feature) => (
-    isPointFeature(feature) && feature.get?.('toolIndex') === toolIndex
-  )).length
+  return source.getFeatures().filter((feature) => {
+    if (!isPointFeature(feature)) return false
+    const featureToolIndex = feature.get?.('toolIndex')
+    return featureToolIndex === toolIndex || typeof featureToolIndex !== 'number'
+  }).length
 }
 
 export function createSketchStyle({ map }) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.js
@@ -7,12 +7,14 @@ import { FEATURE_HIT_TOLERANCE_PX } from './createGeoLineStringInteraction'
 import { isWithinSubjectExtent } from './extentConstraint'
 import isPointFeature from './isPointFeature'
 
-// Subject-provided points carry no toolIndex; they occupy capacity until deleted.
-function countPointFeaturesForTool(source, toolIndex) {
+// Subject-provided points carry no toolIndex; assign them to the first Point tool.
+function countPointFeaturesForTool(source, toolIndex, subjectPointToolIndex) {
   return source.getFeatures().filter((feature) => {
     if (!isPointFeature(feature)) return false
     const featureToolIndex = feature.get?.('toolIndex')
-    return featureToolIndex === toolIndex || typeof featureToolIndex !== 'number'
+    return featureToolIndex === toolIndex || (
+      typeof featureToolIndex !== 'number' && toolIndex === subjectPointToolIndex
+    )
   }).length
 }
 
@@ -50,6 +52,10 @@ function createGeoPointInteraction({
   const activeTool = geoDrawingTask?.activeTool
   const activeToolIndex = geoDrawingTask?.activeToolIndex
   const featureCountMax = activeTool?.type === 'Point' ? activeTool.max : 0
+  const configuredSubjectPointToolIndex = geoDrawingTask?.tools?.findIndex(tool => tool?.type === 'Point')
+  const subjectPointToolIndex = configuredSubjectPointToolIndex >= 0
+    ? configuredSubjectPointToolIndex
+    : activeTool?.type === 'Point' ? activeToolIndex : undefined
 
   const draw = new Draw({
     source,
@@ -66,7 +72,7 @@ function createGeoPointInteraction({
 
   function isCapped() {
     if (featureCountMax <= 0) return true
-    return countPointFeaturesForTool(source, activeToolIndex) >= featureCountMax
+    return countPointFeaturesForTool(source, activeToolIndex, subjectPointToolIndex) >= featureCountMax
   }
 
   function syncActive() {
@@ -102,7 +108,7 @@ function createGeoPointInteraction({
     }
 
     // drawend fires before source.addFeature, so include the in-flight feature.
-    if (countPointFeaturesForTool(source, activeToolIndex) + 1 >= featureCountMax) {
+    if (countPointFeaturesForTool(source, activeToolIndex, subjectPointToolIndex) + 1 >= featureCountMax) {
       draw.setActive(false)
     }
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
@@ -163,13 +163,13 @@ describe('helpers > createGeoPointInteraction', function () {
     interaction.destroy()
   })
 
-  it('isCapped() ignores subject-provided points (no toolIndex)', function () {
+  it('isCapped() counts subject-provided points (no toolIndex) toward the max', function () {
     source.addFeature(taggedPoint([0, 0]))
 
     const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 1 } }
     const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
 
-    expect(interaction.isCapped()).to.equal(false)
+    expect(interaction.isCapped()).to.equal(true)
     interaction.destroy()
   })
 
@@ -201,6 +201,68 @@ describe('helpers > createGeoPointInteraction', function () {
     expect(map.getInteractions().getArray().some(i => i.constructor.name === 'Draw')).to.equal(true)
     interaction.destroy()
     expect(map.getInteractions().getArray().some(i => i.constructor.name === 'Draw')).to.equal(false)
+  })
+
+  describe('subject-supplied points occupying capacity', function () {
+    function findDraw() {
+      return map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+    }
+
+    it('frees a drawing slot when the seed point is deleted', function () {
+      const seed = taggedPoint([0, 0])
+      source.addFeature(seed)
+      const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 1 } }
+      const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+      interaction.setActive(true)
+
+      expect(findDraw().getActive()).to.equal(false)
+      source.removeFeature(seed)
+      expect(findDraw().getActive()).to.equal(true)
+
+      source.addFeature(taggedPoint([1, 1], 0))
+      expect(findDraw().getActive()).to.equal(false)
+      interaction.destroy()
+    })
+
+    it('caps a full workflow until the seed is deleted, then allows max total points', function () {
+      const seed = taggedPoint([0, 0])
+      source.addFeature(seed)
+      source.addFeature(taggedPoint([1, 1], 0))
+      source.addFeature(taggedPoint([2, 2], 0))
+      const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 3 } }
+      const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+      interaction.setActive(true)
+
+      expect(findDraw().getActive()).to.equal(false)
+      source.removeFeature(seed)
+      expect(findDraw().getActive()).to.equal(true)
+
+      source.addFeature(taggedPoint([3, 3], 0))
+      expect(interaction.isCapped()).to.equal(true)
+      expect(findDraw().getActive()).to.equal(false)
+      interaction.destroy()
+    })
+
+    it('never activates when max is 0, even after the seed is deleted', function () {
+      const seed = taggedPoint([0, 0])
+      source.addFeature(seed)
+      const moveOnlyTask = { activeToolIndex: 0, activeTool: { type: 'Point', max: 0 } }
+      const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: moveOnlyTask, selectInteraction })
+      interaction.setActive(true)
+
+      source.removeFeature(seed)
+      expect(findDraw().getActive()).to.equal(false)
+      interaction.destroy()
+    })
+
+    it('ignores subject LineStrings for point capacity', function () {
+      source.addFeature(new Feature({ geometry: new LineStringGeom([[0, 0], [1, 1]]) }))
+      const taskWithCap = { activeToolIndex: 0, activeTool: { type: 'Point', max: 1 } }
+      const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: taskWithCap, selectInteraction })
+
+      expect(interaction.isCapped()).to.equal(false)
+      interaction.destroy()
+    })
   })
 
   describe('createDrawCondition', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
@@ -196,6 +196,28 @@ describe('helpers > createGeoPointInteraction', function () {
     interaction.destroy()
   })
 
+  it('counts subject-provided points only toward the first Point tool', function () {
+    source.addFeature(taggedPoint([0, 0], 0))
+
+    const taskWithSecondPointTool = {
+      activeToolIndex: 1,
+      activeTool: { type: 'Point', max: 1 },
+      tools: [
+        { type: 'Point', max: 1 },
+        { type: 'Point', max: 1 }
+      ]
+    }
+    const interaction = createGeoPointInteraction({
+      map,
+      source,
+      geoDrawingTask: taskWithSecondPointTool,
+      selectInteraction
+    })
+
+    expect(interaction.isCapped()).to.equal(false)
+    interaction.destroy()
+  })
+
   it('isCapped() ignores features tagged for another tool', function () {
     source.addFeature(taggedPoint([0, 0], 1))
     source.addFeature(taggedPoint([1, 1], 1))

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/helpers/createGeoPointInteraction.spec.js
@@ -81,6 +81,29 @@ describe('helpers > createGeoPointInteraction', function () {
     interaction.destroy()
   })
 
+  it('initializes uncertainty_radius to 0 on drawend when the tool has uncertainty circles', function () {
+    const task = { activeToolIndex: 0, activeTool: { type: 'Point', max: 3, uncertainty_circle: true } }
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask: task, selectInteraction })
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+
+    const feature = new Feature({ geometry: new PointGeom([5, 5]) })
+    drawInteraction.dispatchEvent({ type: 'drawend', feature })
+
+    expect(feature.get('uncertainty_radius')).to.equal(0)
+    interaction.destroy()
+  })
+
+  it('leaves uncertainty_radius unset on drawend when the tool has no uncertainty circles', function () {
+    const interaction = createGeoPointInteraction({ map, source, geoDrawingTask, selectInteraction })
+    const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')
+
+    const feature = new Feature({ geometry: new PointGeom([5, 5]) })
+    drawInteraction.dispatchEvent({ type: 'drawend', feature })
+
+    expect(feature.get('uncertainty_radius')).to.equal(undefined)
+    interaction.destroy()
+  })
+
   it('dispatches select on the new feature after drawend (microtask)', async function () {
     const interaction = createGeoPointInteraction({ map, source, geoDrawingTask, selectInteraction })
     const drawInteraction = map.getInteractions().getArray().find(i => i.constructor.name === 'Draw')

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useSelectionLayer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/hooks/useSelectionLayer.jsx
@@ -19,10 +19,8 @@ function isFirstVertexStyle(style, feature) {
   return coord[0] === first[0] && coord[1] === first[1]
 }
 
-// Volunteer-created features carry a toolIndex; subject-provided features don't and stay undeletable.
 function isDeletableFeature(feature) {
-  if (isLineStringFeature(feature)) return true
-  return isPointFeature(feature) && typeof feature.get?.('toolIndex') === 'number'
+  return isLineStringFeature(feature) || isPointFeature(feature)
 }
 
 export default function useSelectionLayer({

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.js
@@ -34,8 +34,19 @@ const GeoDrawing = types
       return annotation?.value?.features ?? []
     },
 
+    // Subject-supplied features carry no toolIndex; infer their tool from geometry type.
+    getToolIndexForFeature (feature) {
+      const explicitToolIndex = feature?.properties?.toolIndex
+      if (typeof explicitToolIndex === 'number') return explicitToolIndex
+
+      const geometryType = feature?.geometry?.type
+      const inferredToolType = geometryType === 'Point' ? 'Point' : geometryType === 'LineString' ? 'SegmentedLine' : undefined
+      const toolIndex = self.tools.findIndex(tool => tool.type === inferredToolType)
+      return toolIndex === -1 ? undefined : toolIndex
+    },
+
     drawnCountForTool (toolIndex) {
-      return self.drawnFeatures.filter(feature => feature?.properties?.toolIndex === toolIndex).length
+      return self.drawnFeatures.filter(feature => self.getToolIndexForFeature(feature) === toolIndex).length
     },
 
     defaultAnnotation(id = cuid()) {
@@ -56,7 +67,7 @@ const GeoDrawing = types
         const minLines = tool.min
         if (typeof minLines === 'number' && minLines > 0) {
           const matchingCount = features.filter((feature) => (
-            feature?.properties?.toolIndex === toolIndex
+            self.getToolIndexForFeature(feature) === toolIndex
           )).length
           if (matchingCount < minLines) return false
         }

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/models/GeoDrawingTask.spec.jsx
@@ -139,7 +139,7 @@ describe('Model > GeoDrawingTask', function () {
       expect(task.isComplete(annotation)).to.equal(true)
     })
 
-    it('returns false when features lack properties.toolIndex even if tool count would otherwise be met', function () {
+    it('counts untagged LineStrings toward the first SegmentedLine tool min', function () {
       const task = GeoDrawingTask.create(lineStringTaskSnapshot)
       const annotation = task.defaultAnnotation()
       annotation.update({
@@ -148,7 +148,7 @@ describe('Model > GeoDrawingTask', function () {
           { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] } }
         ]
       })
-      expect(task.isComplete(annotation)).to.equal(false)
+      expect(task.isComplete(annotation)).to.equal(true)
     })
 
     describe('with a creatable Point tool', function () {
@@ -188,7 +188,7 @@ describe('Model > GeoDrawingTask', function () {
         expect(task.isComplete(annotation)).to.equal(true)
       })
 
-      it('excludes subject-provided points (no toolIndex) from the min count', function () {
+      it('counts subject-provided points (no toolIndex) toward the min count', function () {
         const task = GeoDrawingTask.create(pointTaskSnapshot)
         const annotation = task.defaultAnnotation()
         annotation.update({
@@ -198,7 +198,20 @@ describe('Model > GeoDrawingTask', function () {
             pointFeature([1, 1], { toolIndex: 0 })
           ]
         })
-        expect(task.isComplete(annotation)).to.equal(false)
+        expect(task.isComplete(annotation)).to.equal(true)
+      })
+
+      it('is complete when a seed point occupies a min: 1, max: 1 workflow', function () {
+        const task = GeoDrawingTask.create({
+          ...pointTaskSnapshot,
+          tools: [{ label: 'Point', type: 'Point', min: 1, max: 1 }]
+        })
+        const annotation = task.defaultAnnotation()
+        annotation.update({
+          type: 'FeatureCollection',
+          features: [pointFeature([0, 0], { uncertainty_radius: 100 })]
+        })
+        expect(task.isComplete(annotation)).to.equal(true)
       })
 
       it('does not enforce a min for a move-only Point tool (defaults min 0, max 0)', function () {
@@ -269,6 +282,45 @@ describe('Model > GeoDrawingTask', function () {
         expect(task.isComplete(annotation)).to.equal(false)
       })
 
+    })
+  })
+
+  describe('Views > getToolIndexForFeature', function () {
+    const mixedToolSnapshot = {
+      strings: { instruction: 'Draw lines and points.' },
+      taskKey: 'T0',
+      tools: [
+        { label: 'Dam crest', type: 'SegmentedLine' },
+        { label: 'Point', type: 'Point' }
+      ],
+      type: 'geoDrawing'
+    }
+
+    it('returns the explicit properties.toolIndex when present', function () {
+      const task = GeoDrawingTask.create(mixedToolSnapshot)
+      const feature = { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: { toolIndex: 0 } }
+      expect(task.getToolIndexForFeature(feature)).to.equal(0)
+    })
+
+    it('infers the first Point tool for untagged Point features', function () {
+      const task = GeoDrawingTask.create(mixedToolSnapshot)
+      const feature = { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} }
+      expect(task.getToolIndexForFeature(feature)).to.equal(1)
+    })
+
+    it('infers the first SegmentedLine tool for untagged LineString features', function () {
+      const task = GeoDrawingTask.create(mixedToolSnapshot)
+      const feature = { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] }, properties: {} }
+      expect(task.getToolIndexForFeature(feature)).to.equal(0)
+    })
+
+    it('returns undefined when no tool matches the geometry type', function () {
+      const task = GeoDrawingTask.create({
+        ...mixedToolSnapshot,
+        tools: [{ label: 'Dam crest', type: 'SegmentedLine' }]
+      })
+      const feature = { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} }
+      expect(task.getToolIndexForFeature(feature)).to.equal(undefined)
     })
   })
 


### PR DESCRIPTION

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- Follow-on to #7526 (geoDrawing Point tool optional creation with min/max bounds)

## Describe your changes
- make subject-supplied points deletable via the existing delete affordance; previously only volunteer-created features could be deleted
- count subject-supplied points toward the Point tool `max`: with `max: 3` and one seed, two more points can be drawn; delete the seed and three can be drawn in total
- workflows that seed points should set `max` to at least the seed count; existing `max: 0` (move-only) workflows will be updated to `max: [N seeds]` so the seed can be deleted and replaced

## How to Review
What Zooniverse project should my reviewer use to review UX?
- The production Point workflow's subjects are bbox-only (no seed points), so review the seed flows in Storybook (below). For a regression pass on unchanged behavior: markbouslog/northstar-mapping-project, workflow 32398 "GeoDrawing Point Create": `https://local.zooniverse.org:3000/projects/markbouslog/northstar-mapping-project/classify/workflow/32398?env=production`

What user actions should my reviewer step through to review this PR?
- [x] in Storybook, open the story below, set `min: 0`, `max: 1`, and turn `seedSubjectPoint` on
- [x] the seed point is drawn; clicking empty map creates nothing (the seed occupies the only slot) while empty-map clicks still teleport the selected point
- [x] click the seed to select it: the delete button appears; click it and the point is removed
- [x] click empty map once: a replacement point is drawn and selected (crosshair shows while a slot is open)
- [x] click empty map again: nothing is created (max 1 total)
- [x] set `max: 3` with `seedSubjectPoint` on: only two points can be drawn beside the seed; delete the seed and a third can be drawn
- [x] run `pnpm test` in `packages/lib-classifier` and confirm `GeoMapViewer.spec.jsx` and `createGeoPointInteraction.spec.js` pass

Which storybook stories should be reviewed?
- `Subject Viewers / GeoMapViewer` -> `WithGeoDrawingPointCreationTask` (controls for `min`, `max`, and `seedSubjectPoint`): http://localhost:6006/?path=/story/subject-viewers-geomapviewer--with-geo-drawing-point-creation-task

Are there plans for follow up PR's to further fix this bug or develop this feature?
- No.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
