### PR TITLE
Add GeoMap feature documentation

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Layout/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/README.md
@@ -49,6 +49,6 @@ On viewports smaller than 768px, the vertical layout displays the subject area s
 
 ## GeoMapLayout
 
-This layout is assigned to workflows with `configuration.subject_viewer` set as `geoMap`. The viewer container has a fixed height of 600px (400px on mobile). The task area is sticky positioned with a width of 20rem.
+This layout is assigned to workflows with `configuration.subject_viewer` set as `geoMap`. The viewer container has a height of 90vh (70vh on viewports smaller than 768px). The task area is sticky positioned with a width of 20rem.
 
 On viewports smaller than 768px, the vertical layout displays the subject area stacked above the task area.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/README.md
@@ -23,6 +23,10 @@ A subject viewer is a component designed to render the media of a subject and an
 - [`BarChartViewer`](components/BarChartViewer/README.md) - renders JSON conforming to a particular convention as an interactive bar chart. Currently only used in the `VariableStarViewer`, but in theory could be used on its own.
 - [`LightCurveViewer`](components/LightCurveViewer/README.md) - renders JSON specifically for the Planet Hunters TESS project and coupled with its particular annotation task. This could be reused with other projects if they want to do exactly what PH TESS does, but going forward, the `ScatterPlotViewer` is preferred and the SPV should [enhanced to support a variety of annotation tools](https://github.com/zooniverse/front-end-monorepo/discussions/2421).
 
+### Maps
+
+- [`GeoMapViewer`](components/GeoMapViewer/README.md) - renders GeoJSON subjects on an interactive OpenLayers map. Supports configurable base tile layers (OSM, WMS, XYZ, COG), distance measurement, coordinate navigation, and, when paired with the [`geoDrawing`](../../../../plugins/tasks/experimental/geoDrawing/task/README.md) task, repositioning point features and drawing segmented lines.
+
 ### Complex composites
 
 - [`VariableStarViewer`](components/VariableStarViewer/README.md) - renders JSON and an image media file for a composite of two scatter plots, two bar charts, and an image. Supports pan and zoom for each scatter plot independently as well as project specific interactive tools for the scatter plots.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/GeoMapViewer/README.md
@@ -1,13 +1,16 @@
 # Geographic Map Viewer
 
-The GeoMapViewer is a variant of the Subject Viewer that displays geographic data on an interactive map using OpenLayers. It provides interactive tools for viewing, selecting, and modifying geographic features when paired with a `geoDrawing` task.
+The GeoMapViewer is a variant of the Subject Viewer that displays geographic data on an interactive map using OpenLayers. It provides interactive tools for viewing, selecting, and modifying geographic features when paired with a [`geoDrawing`](../../../../../../plugins/tasks/experimental/geoDrawing/task/README.md) task.
 
 ## Features
 
 - **Interactive Map Display**: Uses OpenLayers with OpenStreetMap as the default base layer
+- **Configurable Tile Layers**: Base layers (OSM, WMS, XYZ, COG) are configured per workflow, with a layer control to switch between them
 - **Feature Rendering**: Displays GeoJSON features with customizable styling based on feature properties
 - **Feature Selection**: Click to select features for editing or annotation
 - **Feature Translation**: Drag selected features to reposition them on the map
+- **Line Drawing**: Draw and edit segmented lines when the active `geoDrawing` task has a `SegmentedLine` tool
+- **Subject Extent Constraint**: Panning and zooming are constrained to the subject's `bbox`, with the area outside the subject bounds masked
 - **Zoom Controls**: Zoom in/out buttons and scroll wheel zooming
 - **Distance Measurement**: Toggle measurement mode to draw polylines on the map with live distance tooltips
 - **Unit Selection**: Choose the display unit (meters, kilometers, feet, miles, nautical miles) for both the scale line and measurement tool
@@ -29,13 +32,17 @@ The container component that:
 ### GeoMapViewer
 
 The main map component that:
-- Creates the OpenLayers map **once on mount** with an OSM tile layer, a vector features layer, a `ScaleLine` control, and — when a `geoDrawing` task is active — `Select`, `Translate`, `ModifyUncertainty`, and `MoveToClick` interactions
+- Creates the OpenLayers map **once on mount** with the configured tile layers (falling back to OSM), a vector features layer, and a `ScaleLine` control. When a `geoDrawing` task is active, it also creates `Select`, `Translate`, `ModifyUncertainty`, and `MoveToClick` interactions, plus `Draw` and `Modify` interactions for `SegmentedLine` tools
 - Syncs the `ScaleLine` units and measure interaction when `selectedUnit` state changes
 - Toggles measure mode on/off, pausing all other interactions during measurement and re-selecting the first feature on exit
 - Reloads the vector source when the `geoJSON` prop changes, fits the view, and selects the first feature
 - Reports map extent info (`widthMeters`, `heightMeters`, `resolution`) on `moveend` (throttled) via `onMapExtentChange`
 - Serializes all OL features to a GeoJSON `FeatureCollection` on every add/change/remove and calls `onFeaturesChange`
 - Manages cursor states for point center, drag handle (ew-resize), uncertainty circle, and hover
+
+### LayerControl
+
+Dropdown for switching the visible base tile layer. Only rendered when the workflow configures more than one tile layer. The initially visible layer is the one marked `default: true` (or the first layer when none is marked).
 
 ### ReferenceData
 
@@ -63,27 +70,80 @@ Labeled text input and "Go" button to navigate the map to an entered latitude/lo
 
 ## External Setup: Workflows and Subjects
 
+### Setting Up a Project
+
+A complete GeoMap project is set up as follows:
+
+1. Create a project and workflow in the Project Builder
+2. An admin toggles the "Mapping" experimental feature flag for the project
+3. An admin sets the workflow's Subject Viewer to "Geographic Map" (`subject_viewer: 'geoMap'`)
+4. Add a "GeoDrawing" task to the workflow
+5. Add a "Point" or "Segmented Line" tool to the task
+6. Add a map tile layer (without one, the viewer falls back to OpenStreetMap)
+7. Create a subject set and upload GeoJSON subjects (see Subject Data below)
+8. Set the workflow's subject set to the one created in step 7
+
+Example project: [workflow editor](https://www.zooniverse.org/lab/34877/workflows/32503), [classify page](https://www.zooniverse.org/projects/kieftrav/mapping-test-project/classify/workflow/32503).
+
+The "Mapping" experimental feature flag unlocks the map-specific options in the Project Builder. The classifier itself is driven entirely by the workflow configuration: `subject_viewer: 'geoMap'` selects both the GeoMapViewer and the GeoMapLayout.
+
 ### Workflow Configuration
 
 The workflow must include a configuration for the GeoMapViewer:
 
 ```javascript
-workflow.configuration = { subject_viewer: 'geoMap' }
+workflow.configuration = {
+  subject_viewer: 'geoMap',
+  subject_viewer_config: {
+    tile_layers: [
+      { type: 'osm', label: 'OpenStreetMap', default: true },
+      {
+        type: 'wms',
+        label: '2023 imagery',
+        url: 'https://imageserver.gisdata.mn.gov/cgi-bin/wms',
+        params: { LAYERS: 'fsa2023' }
+      }
+    ]
+  }
+}
 ```
 
-Workflows using GeoMapViewer typically include a `geoDrawing` task that provides tools for annotating geographic features.
+Workflows using GeoMapViewer typically include a [`geoDrawing`](../../../../../../plugins/tasks/experimental/geoDrawing/task/README.md) task that provides tools for annotating geographic features.
+
+#### Tile Layers
+
+`subject_viewer_config.tile_layers` is an array of base layer descriptors. When it is absent or empty, the viewer renders a single OpenStreetMap layer. Each descriptor supports:
+
+- `type` (string, required): one of `osm`, `wms`, `xyz`, or `cog`
+- `label` (string): display name shown in the layer control
+- `url` (string): source URL, required for `wms`, `xyz`, and `cog` layers
+- `params` (object): WMS request parameters; `LAYERS` is required for `wms` layers, `FORMAT` defaults to `image/png`
+- `attributions` (string): attribution text for the layer source
+- `projection` (string): source projection for `wms` and `xyz` layers
+- `default` (boolean): marks the initially visible layer; otherwise the first layer is shown
 
 ### Subject Data
 
-Subjects must contain GeoJSON data. The subject's JSON location should point to a GeoJSON file or the subject metadata should include GeoJSON data.
+Subjects must contain GeoJSON data. The subject's location should be a JSON file (`application/json` mime type) containing a GeoJSON `FeatureCollection`.
 
 #### GeoJSON Structure
 
-The GeoJSON should be a `FeatureCollection`:
+The GeoJSON should be a `FeatureCollection`. A minimal subject defines only the map area, with no preloaded features:
 
 ```json
 {
   "type": "FeatureCollection",
+  "bbox": [-91.05, 47.96, -90.97, 48.01],
+  "features": []
+}
+```
+
+A subject can also preload features (for example, a point for volunteers to reposition) and include reference data:
+
+```json
+{
+  "type": "FeatureCollection",
+  "bbox": [-82.8, 35.15, -82.65, 35.3],
   "features": [
     {
       "type": "Feature",
@@ -104,6 +164,10 @@ The GeoJSON should be a `FeatureCollection`:
   }
 }
 ```
+
+#### bbox
+
+`bbox` is a GeoJSON bounding box (`[west, south, east, north]` in longitude/latitude) defining the subject's map area. The viewer fits the initial view to it and constrains panning and minimum zoom to the padded bounds, with the area outside the bounds masked. When `bbox` is absent, the extent of the subject's features is used instead; a zero-area extent (for example, a single point) is not constrained.
 
 #### Reference Data
 
@@ -131,12 +195,18 @@ This information appears in a styled section above the map with labels and value
 When a `geoDrawing` task is active:
 
 1. **Select**: Click a feature to select it (restricted to features layer)
-2. **Translate**: Drag a selected feature to move it (restricted to a hit radius around the point center)
+2. **Translate**: Drag a selected feature to move it (restricted to a hit radius around the point center, clamped to the subject extent)
 3. **Modify Uncertainty**: Drag the uncertainty circle's drag handle to resize the uncertainty radius
 4. **Move to Click**: Move the selected point feature to a new location via a map click
+
+When the active tool is a `SegmentedLine` tool:
+
+1. **Draw**: Click to place vertices, double-click to finish the line, Escape to abort an in-progress line. Vertex counts and line counts are enforced from the tool's `min_vertices`/`max_vertices` and `min`/`max` configuration, and vertices must fall within the subject extent
+2. **Modify**: Drag a selected line's vertices to edit it
+3. **Delete**: Remove a selected line via the delete button anchored to its first vertex
 
 Without a `geoDrawing` task, features are displayed in read-only mode with static styling.
 
 ## Layout
 
-The GeoMapLayout is assigned to workflows with `configuration.subject_viewer` set as `geoMap`. The viewer container has a height of 90vh (70vh on screens ≤ 768px). The task area is sticky positioned with a width of 20rem.
+The [GeoMapLayout](../../../Layout/README.md#geomaplayout) is assigned to workflows with `configuration.subject_viewer` set as `geoMap`. The viewer container has a height of 90vh (70vh on screens ≤ 768px). The task area is sticky positioned with a width of 20rem.

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/README.md
@@ -2,7 +2,9 @@
 
 The geoDrawing task is an experimental task type for capturing geospatial annotations. It is designed to pair with the [GeoMapViewer](../../../../../components/Classifier/components/SubjectViewer/components/GeoMapViewer/README.md) subject viewer.
 
-Volunteers use the map viewer to view and reposition geographic point features. The task tracks the active feature selection, uncertainty radius, and map extent, and persists the final feature positions as a GeoJSON `FeatureCollection` annotation.
+Volunteers use the map viewer to view and reposition geographic point features and to draw segmented lines. The task tracks the active tool, active feature selection, uncertainty radius, and map extent, and persists the final features as a GeoJSON `FeatureCollection` annotation.
+
+For the full project setup walkthrough (Project Builder steps, tile layers, subject format), see [External Setup: Workflows and Subjects](../../../../../components/Classifier/components/SubjectViewer/components/GeoMapViewer/README.md#external-setup-workflows-and-subjects) in the GeoMapViewer README.
 
 ## Workflow Configuration
 
@@ -19,16 +21,47 @@ Task definition shape:
       "label": "Location",
       "color": "#ff0000",
       "uncertainty_circle": true
+    },
+    {
+      "type": "SegmentedLine",
+      "label": "Route",
+      "color": "#0000ff",
+      "min": 1,
+      "max": 3,
+      "min_vertices": 3,
+      "max_vertices": 10
     }
   ]
 }
 ```
 
+### Tools
+
+Both tool types support:
+
+- _label (string)_ display name for the tool
+- _color (string)_ stroke/fill color for features drawn with the tool
+
+`Point` tools additionally support:
+
+- _uncertainty_circle (boolean = false)_ render a resizable uncertainty circle around the point and a radius slider in the task area
+
+`SegmentedLine` tools additionally support:
+
+- _min (number = 0)_ minimum number of lines that must be drawn before the task is complete
+- _max (number)_ maximum number of lines that can be drawn; drawing is disabled once reached
+- _min_vertices (number = 2)_ minimum vertices per line
+- _max_vertices (number)_ maximum vertices per line, enforced while drawing and editing
+
+Panoptes may serve the count fields as strings; the tool models coerce them to numbers.
+
 ### Annotation
 
-The annotation `value` is a GeoJSON `FeatureCollection` written by the map viewer as features are moved or modified. It is `null` until the subject data is loaded.
+The annotation `value` is a GeoJSON `FeatureCollection` written by the map viewer as features are moved, drawn, or modified. It is `null` until the subject data is loaded.
 
-`isComplete` returns `true` when `value !== null`.
+`isComplete` returns `true` when `value !== null` and every tool's `min` line count has been met.
+
+Feature coordinates in the annotation are longitude/latitude (`EPSG:4326`), matching the subject GeoJSON. The map renders internally in web mercator (`EPSG:3857`), and features are reprojected back to `EPSG:4326` when the annotation is serialized. Features drawn by a tool carry `properties.toolIndex` identifying which tool created them.
 
 ```json
 {
@@ -41,7 +74,7 @@ The annotation `value` is a GeoJSON `FeatureCollection` written by the map viewe
         "type": "Feature",
         "geometry": {
           "type": "Point",
-          "coordinates": [-9189987.47, 4213962.65]
+          "coordinates": [-82.7326, 35.2351]
         },
         "properties": {
           "uncertainty_radius": 500

--- a/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/README.md
@@ -41,6 +41,10 @@ Both tool types support:
 
 - _label (string)_ display name for the tool
 - _color (string)_ stroke/fill color for features drawn with the tool
+- _min (number = 0)_ minimum number of features that must be created before the task is complete
+- _max (number)_ maximum number of features that can be created; creation is disabled once reached
+
+For `Point` tools, creation is enabled only when `max` is greater than 0; without it, volunteers can only reposition subject-provided points, which do not count toward `min` or `max`.
 
 `Point` tools additionally support:
 
@@ -48,8 +52,6 @@ Both tool types support:
 
 `SegmentedLine` tools additionally support:
 
-- _min (number = 0)_ minimum number of lines that must be drawn before the task is complete
-- _max (number)_ maximum number of lines that can be drawn; drawing is disabled once reached
 - _min_vertices (number = 2)_ minimum vertices per line
 - _max_vertices (number)_ maximum vertices per line, enforced while drawing and editing
 
@@ -59,7 +61,7 @@ Panoptes may serve the count fields as strings; the tool models coerce them to n
 
 The annotation `value` is a GeoJSON `FeatureCollection` written by the map viewer as features are moved, drawn, or modified. It is `null` until the subject data is loaded.
 
-`isComplete` returns `true` when `value !== null` and every tool's `min` line count has been met.
+`isComplete` returns `true` when `value !== null` and every tool's `min` created-feature count has been met.
 
 Feature coordinates in the annotation are longitude/latitude (`EPSG:4326`), matching the subject GeoJSON. The map renders internally in web mercator (`EPSG:3857`), and features are reprojected back to `EPSG:4326` when the annotation is serialized. Features drawn by a tool carry `properties.toolIndex` identifying which tool created them.
 

--- a/packages/lib-classifier/src/plugins/tasks/readme.md
+++ b/packages/lib-classifier/src/plugins/tasks/readme.md
@@ -4,7 +4,7 @@ Tasks are the individual steps in a workflow that are used to collect data for a
 
 - Data Vis
 - [Drawing](/packages/lib-classifier/src/plugins/drawingTools/README.md)
-- [Geo Drawing](/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/README.md)
+- [Geo Drawing](/packages/lib-classifier/src/plugins/tasks/experimental/geoDrawing/task/README.md)
 - [Highlighter](/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/README.md)
 - Multiple Answer Question
 - Single Answer Question


### PR DESCRIPTION
## Package

lib-classifier

## Linked Issue and/or Talk Post

N/A

## Describe your changes

Documentation for the GeoMap feature (Geographic Map subject viewer + GeoDrawing task). No code changes.

- Add a "Setting Up a Project" walkthrough to the GeoMapViewer README: Project Builder steps, the "Mapping" experimental feature flag, tile layer configuration (`subject_viewer_config.tile_layers` field reference for `osm`/`wms`/`xyz`/`cog`), and GeoJSON subject format including `bbox` and the subject extent constraint
- Update the GeoMapViewer README's Features, Components, and Interactions sections to cover the layer control, segmented line drawing (draw, modify vertices, delete), and the extent constraint
- Document `SegmentedLine` tool configuration in the GeoDrawing task README: `min`/`max` line counts, `min_vertices`/`max_vertices`, string coercion of Panoptes count fields, and completeness rules (`isComplete` requires each tool's `min`)
- Clarify the annotation format: coordinates are serialized in `EPSG:4326` longitude/latitude (matching the subject GeoJSON), features carry `properties.toolIndex`; the previous example showed internal web mercator coordinates and has been corrected
- Add GeoMapViewer to the Subject Viewer index README under a new "Maps" category
- Fix the broken "Geo Drawing" link in the tasks index (pointed at a nonexistent path)
- Correct the GeoMapLayout heights in the Layout README (600px/400px to 90vh/70vh, matching `GeoMapLayout.jsx`)
- Cross-link the viewer README, task README, and Layout README to each other

## How to Review

Documentation only. Suggested review path:

- Read the two main docs in the "Files changed" rich diff: `GeoMapViewer/README.md` and `geoDrawing/task/README.md`
- Check the relative links resolve when browsing the rendered READMEs on this branch (viewer <-> task <-> Layout, Subject Viewer index, tasks index)
- Verify the setup walkthrough against a real project: [workflow editor](https://www.zooniverse.org/lab/34877/workflows/32503) and [classify page](https://www.zooniverse.org/projects/kieftrav/mapping-test-project/classify/workflow/32503)
- Behavior claims can be checked against the `Subject Viewers / GeoMapViewer` storybook stories (Default, WithMultipleLayers, WithGeoDrawingTask, WithGeoDrawingLineStringTask)
- The tile layer example config is taken from the existing `GeoMapViewerContainer` spec fixture
- No follow-up PRs planned; future feature PRs should update these docs as behavior changes

## Checklist

### General
- [x] Documentation is up to date (this PR is documentation only; no code, tests, or translations changed)
- [x] Rendered markdown and relative links checked locally
