### PR TITLE
app-root: Adjust regex in middleware matcher

### DIFF
--- a/packages/app-root/src/middleware.js
+++ b/packages/app-root/src/middleware.js
@@ -7,5 +7,5 @@ export function middleware(req) {
 
 // runs this function only on requests to pages in our app directory
 export const config = {
-  matcher: '/((?!api|static|.*\\..*|_next).*)'
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)']
 }


### PR DESCRIPTION
## Package
app-root

## Linked Issue and/or Talk Post
Freshdesk: https://zooniverse.freshdesk.com/helpdesk/tickets/28157
Closes: https://github.com/zooniverse/front-end-monorepo/issues/7560

## Describe your changes
- Adjust the matcher in middleware so it catches routes with `.` in the dynamic subpath

## How to Review
Run app-root locally with admin mode on
- Should be able to visit any app-root route with `en` hidden as a prefix and `test` visible as a prefix
- https://www.zooniverse.org/test/users/goplayoutside3/stats
- https://local.zooniverse.org:3000/users/am.zooni/stats

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)



### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
