### PR TITLE
lib-classifier: Check if a subject has enough multi-media in locations to use default_frame

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/README.md
@@ -79,13 +79,3 @@ The state container component should:
 The return render should be the child subject viewer that has the needed required props passed to it.
 
 The container components for the complex subject viewers like the `VariableStarViewer` and the `DataImageViewer` handle the load of multiple media types as well as may handle data transformations and other component states relevant to the composite, i.e. if pan and zoom is enabled or disabled for one of them. The complex viewers should also have a grid layout defined for how to render all the individual viewers together.
-
-## Future Enhancements
-
-Some immediate enhancements can be:
-
-- An audio media viewer
-- A spectrogram viewer containing audio, an image, and additional controller functionality.
-- Media support to the `MultiFrameViewer` beyond images
-- Refactoring `SingleImageViewer` to use `VisXZoom`
-- Implementing the additional layouts design including full screen.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.jsx
@@ -41,7 +41,7 @@ const FlipbookViewer = ({
   // Prior to Apr 2026, FlipbookViewer used to store the "current frame" value
   // in local state, but this caused issues with the image toolbar which
   // expected synced with the Subject Viewer Store's "current frame".
-  
+
   // Also, Subject Viewer Store's resetSubject() ensures that the first `frame`
   // fed to the FlipbookViewer will either be 0, or the default_frame as set by
   // subject.metadata. As a result, the defaultFrame prop of FlipbookViewer is
@@ -80,7 +80,7 @@ const FlipbookViewer = ({
   // that we want to display.
   // Believe it or not, all that hullabaloo above 👆 with the "default media" is
   // only for the sake of determining a consistent viewer width/height for
-  // all media files. 
+  // all media files.
   // --------------------------------
   const currentMediaType = subject?.locations[frame]?.type
   const currentMediaUrl = subject?.locations[frame]?.url
@@ -162,7 +162,7 @@ FlipbookViewer.propTypes = {
   move: PropTypes.bool,
   /** Passed from SubjectViewer and called if media-fetching hook fails. */
   onError: PropTypes.func,
-  /** Passed from SubjectViewer and dimensions are added to classification metadata. Called after svg layers successfully load with `defaultFrameSrc`. */
+  /** Passed from SubjectViewer and dimensions are added to classification metadata. Called after svg layers successfully load with `defaultMediaUrl`. */
   onReady: PropTypes.func,
   /** Fetched from workflow configuration. Number preference for how many loops to play */
   playIterations: PropTypes.number,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -140,7 +140,7 @@ FlipbookViewerContainer.propTypes = {
   loadingState: PropTypes.string,
   /** Passed from SubjectViewer and called if `useSubjectImage()` hook fails. */
   onError: PropTypes.func,
-  /** Passed from SubjectViewer and dimensions are added to classification metadata. Called after svg layers successfully load with `defaultFrameSrc`. */
+  /** Passed from SubjectViewer and dimensions are added to classification metadata. Called after svg layers successfully load with `defaultMediaUrl`. */
   onReady: PropTypes.func,
   /** OPTIONAL: only supply this function if you want to override the setOnPan function from the store. (As of Apr 2026, only used by DataImageViewer.) */
   setOnPan: PropTypes.func,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.jsx
@@ -92,7 +92,7 @@ function FlipbookViewerContainer({
   // be overridden by Subject metadata.
   // This code matches SubjectViewerStore.js's resetSubject()
   let defaultFrame = 0
-  if (subject?.metadata?.default_frame > 0) {
+  if (subject?.metadata?.default_frame > 0 && subject?.locations.length >= subject.metadata.default_frame) {
     // To the research teams who set the default_frame value, the first item in a list is "1". Hence, we need to change that to Array index "0".
     defaultFrame = parseInt(subject.metadata.default_frame - 1)
   }

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -185,10 +185,11 @@ const SubjectViewer = types
 
       resetSubject (subject) {
         let frame = 0
-        // teams set default frame in the project builder
-        // here we're converting it to index
-        if (subject?.metadata?.default_frame > 0) {
-          frame = parseInt(subject.metadata.default_frame - 1)
+        // teams set default_frame in each subject per metadata prop
+        // here we're converting it to index for the subject viewer
+        // and checking if the subject has enough frames for it to apply
+        if (subject?.metadata?.default_frame > 0 && subject?.locations.length >= subject.metadata.default_frame) {
+            frame = parseInt(subject.metadata.default_frame - 1)
         }
         self.dimensions = []
         self.frame = frame


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Freshdesk ticket: https://zooniverse.freshdesk.com/a/tickets/28217

## Describe your changes
- Add a check for `subject.locations.length` on new subject load. If there's a `default_frame` prop in its metadata, only apply it if there's enough multi-media frames in the `locations` array.

## How to Review
- Run lib-classifier locally and try out a couple of flipbook projects.
    - This one has `metadata.default_frame = 2` on every subject: https://local.zooniverse.org:8080/?project=34006&workflow=32270&env=production&demo=true
    - This one does not have a `default_frame` prop: https://local.zooniverse.org:8080/?project=19645&workflow=22533&env=production

Note there are a couple of other bugs related to `subject.metadata.default_frame` surfacing because the MP project is probably the first to use it in FEM's classifier. When a classification is submitted, there's extra data in `metadata.dimensions[0]` for multi-image subjects. I'm going to open a separate Issue for that.

https://github.com/zooniverse/front-end-monorepo/issues/6416 also applies to the MP subjects.

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out


### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed