### PR TITLE
app-root: Edit middleware to ignore commit_it.txt and favicons

### DIFF
--- a/packages/app-root/src/app/[locale]/layout.js
+++ b/packages/app-root/src/app/[locale]/layout.js
@@ -17,7 +17,7 @@ export const metadata = {
   },
   icons: {
     icon: '/icon.svg',
-    apple: 'apple-icon.png'
+    apple: '/apple-icon.png'
   },
   twitter: {
     card: 'summary',

--- a/packages/app-root/src/app/[locale]/layout.js
+++ b/packages/app-root/src/app/[locale]/layout.js
@@ -17,7 +17,7 @@ export const metadata = {
   },
   icons: {
     icon: '/icon.svg',
-    apple: '/touch-icon.png'
+    apple: 'apple-icon.png'
   },
   twitter: {
     card: 'summary',

--- a/packages/app-root/src/middleware.js
+++ b/packages/app-root/src/middleware.js
@@ -1,11 +1,30 @@
 import { i18nRouter } from 'next-i18n-router'
+import { NextResponse } from 'next/server'
 import i18nConfig from '../i18nConfig'
 
 export function middleware(req) {
-   return i18nRouter(req, i18nConfig)
+  // ignore the commit_id.txt for deployment actions
+  if (req.nextUrl.pathname.startsWith('/commit_id.txt')) {
+    return NextResponse.next()
+  }
+
+  // ignore the favicons
+  if (req.nextUrl.pathname.startsWith('/favicon.ico')) {
+    return NextResponse.next()
+  }
+  if (req.nextUrl.pathname.startsWith('/icon.svg')) {
+    return NextResponse.next()
+  }
+  if (req.nextUrl.pathname.startsWith('/apple-icon.png')) {
+    return NextResponse.next()
+  }
+
+  // handle locale prefix
+  return i18nRouter(req, i18nConfig)
 }
 
 // runs this function only on requests to pages in our app directory
+// ignore _next internals
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)']
+  matcher: ['/((?!api|_next/static|_next/image).*)']
 }


### PR DESCRIPTION
## Package
app-root

## Linked Issue and/or Talk Post
- Edit middleware to ignore commit_id.txt and favicons
- Reference the correct icon file name for apple-icon

## Describe your changes

## How to Review
You can run app-root locally to test the following paths exist:
- https://local.zooniverse.org:3000/icon.svg
- https://local.zooniverse.org:3000/apple-icon.png
- Any page in the App Router should work with and without a locale prefix

The `commit_id.txt` file gets added via Dockerfile, so you'd either have to look via Docker locally (takes a lot of time, don't recommend it), or merge this PR and check `fe-root.preview`.

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`