### PR TITLE
fix(classifier): MST model for subject dimensions

### DIFF
--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
@@ -1,12 +1,8 @@
 import { autorun } from 'mobx'
 import { addDisposer, getRoot, types } from 'mobx-state-tree'
 
-const SubjectDimensions = types.model('SubjectDimensions', {
-  clientHeight: types.integer,
-  clientWidth: types.integer,
-  naturalHeight: types.integer,
-  naturalWidth: types.integer
-})
+import { SubjectDimensionsArray } from '../SubjectViewerStore/SubjectViewerStore'
+
 
 const ClassificationMetadata = types.model('ClassificationMetadata', {
   classifier_version: types.literal('2.0'),
@@ -18,7 +14,7 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
   session: types.maybe(types.string),
   source: types.enumeration(['api', 'sugar']),
   startedAt: types.optional(types.string, ''),
-  subjectDimensions: types.array(types.maybe(SubjectDimensions)),
+  subjectDimensions: SubjectDimensionsArray,
   subjectSelectionState: types.frozen({
     already_seen: types.optional(types.boolean, false),
     finished_workflow: types.optional(types.boolean, false),

--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
@@ -1,6 +1,13 @@
 import { autorun } from 'mobx'
 import { addDisposer, getRoot, types } from 'mobx-state-tree'
 
+const SubjectDimensions = types.model('SubjectDimensions', {
+  clientHeight: types.integer,
+  clientWidth: types.integer,
+  naturalHeight: types.integer,
+  naturalWidth: types.integer
+})
+
 const ClassificationMetadata = types.model('ClassificationMetadata', {
   classifier_version: types.literal('2.0'),
   featureProjection: types.maybe(types.string),
@@ -11,12 +18,7 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
   session: types.maybe(types.string),
   source: types.enumeration(['api', 'sugar']),
   startedAt: types.optional(types.string, ''),
-  subjectDimensions: types.array(types.frozen({
-    clientHeight: types.integer,
-    clientWidth: types.integer,
-    naturalHeight: types.integer,
-    naturalWidth: types.integer
-  })),
+  subjectDimensions: types.array(types.maybe(SubjectDimensions)),
   subjectSelectionState: types.frozen({
     already_seen: types.optional(types.boolean, false),
     finished_workflow: types.optional(types.boolean, false),

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -2,15 +2,17 @@ import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
 import { addDisposer, getRoot, isValidReference, tryReference, types } from 'mobx-state-tree'
 
+const SubjectDimensions = types.model('SubjectDimensions', {
+  clientHeight: types.integer,
+  clientWidth: types.integer,
+  naturalHeight: types.integer,
+  naturalWidth: types.integer
+})
+
 const SubjectViewer = types
   .model('SubjectViewer', {
     annotate: types.optional(types.boolean, true),
-    dimensions: types.array(types.frozen({
-      clientHeight: types.integer,
-      clientWidth: types.integer,
-      naturalHeight: types.integer,
-      naturalWidth: types.integer
-    })),
+    dimensions: types.array(types.maybe(SubjectDimensions)),
     flipbookSpeed: types.optional(types.number, 1),
     frame: types.optional(types.integer, 0),
     fullscreen: types.optional(types.boolean, false),
@@ -162,7 +164,12 @@ const SubjectViewer = types
           naturalHeight = 0,
           naturalWidth = 0
         } = target || {}
-        self.dimensions[frameIndex] = { clientHeight, clientWidth, naturalHeight, naturalWidth }
+        self.dimensions[frameIndex] = {
+          clientHeight: parseInt(clientHeight),
+          clientWidth: parseInt(clientWidth),
+          naturalHeight: parseInt(naturalHeight),
+          naturalWidth: parseInt(naturalWidth)
+        }
         self.rotation = 0
         self.loadingState = asyncStates.success
       },

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -9,10 +9,12 @@ const SubjectDimensions = types.model('SubjectDimensions', {
   naturalWidth: types.integer
 })
 
+export const SubjectDimensionsArray = types.array(types.maybe(SubjectDimensions))
+
 const SubjectViewer = types
   .model('SubjectViewer', {
     annotate: types.optional(types.boolean, true),
-    dimensions: types.array(types.maybe(SubjectDimensions)),
+    dimensions: SubjectDimensionsArray,
     flipbookSpeed: types.optional(types.number, 1),
     frame: types.optional(types.integer, 0),
     fullscreen: types.optional(types.boolean, false),

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -9,7 +9,9 @@ const SubjectDimensions = types.model('SubjectDimensions', {
   naturalWidth: types.integer
 })
 
-export const SubjectDimensionsArray = types.array(types.maybe(SubjectDimensions))
+const ImmutableSubjectDimensions = types.frozen(SubjectDimensions)
+
+export const SubjectDimensionsArray = types.array(types.maybe(ImmutableSubjectDimensions))
 
 const SubjectViewer = types
   .model('SubjectViewer', {


### PR DESCRIPTION
Replace `types.frozen` with `types.model` for subject dimensions in the MST models for `ClassificationMetadata` and `SubjectViewerStore`. Define a `SubjectDimensions`, `ImmutableSubjectDimensions`, and `SubjectDimensionsArray` model for convenience/readability.

Fixes a bug where the default subject dimensions for a frame contains frozen integer types, rather than frozen integer values.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #7566.

## How to Review
I tested this with subjects from Etch-A-Cell (`default_frame = 3`), but I think any subject set with a default frame that isn't one should work.

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

