### PR TITLE
lib-react-components: Add SubjectCard unsupported mime type fallback

### DIFF
--- a/packages/lib-react-components/src/SubjectCard/components/InteractiveMedia/InteractiveMedia.jsx
+++ b/packages/lib-react-components/src/SubjectCard/components/InteractiveMedia/InteractiveMedia.jsx
@@ -1,6 +1,8 @@
 import { arrayOf, bool, node, number, objectOf, shape, string } from 'prop-types'
 
+import MediaLink from '../MediaLink'
 import SimpleMedia from '../SimpleMedia'
+import MediaFallback from '../MediaFallback'
 import Audio from './components/Audio'
 import MultiMedia from './components/MultiMedia'
 import Video from './components/Video'
@@ -47,6 +49,7 @@ function InteractiveMedia({
     return (
       <MultiMedia
         linkTitle={linkTitle}
+        placeholder={placeholder}
         sources={sources}
         previewHeight={resolvedPreviewHeight}
         subjectIdTitle={subjectIdTitle}
@@ -98,6 +101,19 @@ function InteractiveMedia({
         width={width}
         url={url}
       />
+    )
+  }
+
+  if (singleSource) {
+    return (
+      <MediaLink href={url} title={linkTitle}>
+        <MediaFallback
+          alt={subjectIdTitle}
+          placeholder={placeholder}
+          previewHeight={resolvedPreviewHeight}
+          width={width}
+        />
+      </MediaLink>
     )
   }
 

--- a/packages/lib-react-components/src/SubjectCard/components/InteractiveMedia/InteractiveMedia.spec.jsx
+++ b/packages/lib-react-components/src/SubjectCard/components/InteractiveMedia/InteractiveMedia.spec.jsx
@@ -3,6 +3,7 @@ import { composeStory } from '@storybook/react'
 
 import ImageMeta, { Landscape } from '../../stories/interactive/singleMedia/SubjectCard.image.stories'
 import MultiMediaMeta, { MultiImage } from '../../stories/interactive/multiMedia/SubjectCard.multiMedia.stories'
+import UnsupportedMeta, { UnsupportedMimeType } from '../../stories/interactive/singleMedia/SubjectCard.unsupported.stories'
 
 describe('InteractiveMedia', function () {
   describe('with single image location', function () {
@@ -38,4 +39,17 @@ describe('InteractiveMedia', function () {
       expect(buttons).toBeDefined()
     })
   })
+
+  describe('with an unsupported mime type', function () {
+    it('should render a fallback wrapped in a link', function () {
+      const Story = composeStory(UnsupportedMimeType, UnsupportedMeta)
+      render(<Story />)
+      const link = screen.getByRole('link')
+      expect(link).toBeDefined()
+      expect(link.href).to.contain('/talk/subjects/99999999')
+      const fallback = screen.getByLabelText('Subject 99999999')
+      expect(fallback).toBeTruthy()
+    })
+  })
 })
+

--- a/packages/lib-react-components/src/SubjectCard/components/InteractiveMedia/components/MultiMedia/MultiMedia.jsx
+++ b/packages/lib-react-components/src/SubjectCard/components/InteractiveMedia/components/MultiMedia/MultiMedia.jsx
@@ -1,10 +1,11 @@
 import { Box } from 'grommet'
-import { bool, number, arrayOf, string, shape, objectOf } from 'prop-types'
+import { node, number, arrayOf, string, shape } from 'prop-types'
 import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import Media from '../../../../../Media'
 import MediaLink from '../../../MediaLink'
+import MediaFallback from '../../../MediaFallback'
 import FlipbookControls from '../FlipbookControls'
 import Audio from '../Audio'
 import Image from '../Image'
@@ -23,6 +24,7 @@ function getMediaType(mimeType) {
 
 function MultiMedia({
 	linkTitle,
+	placeholder,
 	sources = [],
 	previewHeight,
 	subjectIdTitle,
@@ -159,7 +161,16 @@ function MultiMedia({
 			)
 		}
 
-		return null
+		return (
+			<MediaLink href={url} title={linkTitle}>
+				<MediaFallback
+					alt={subjectIdTitle}
+					placeholder={placeholder}
+					previewHeight={previewHeight}
+					width={width}
+				/>
+			</MediaLink>
+		)
 	}
 
 	return (
@@ -178,6 +189,7 @@ function MultiMedia({
 
 MultiMedia.propTypes = {
 	linkTitle: string.isRequired,
+	placeholder: node,
 	sources: arrayOf(shape({
 		mimeType: string.isRequired,
 		url: string.isRequired

--- a/packages/lib-react-components/src/SubjectCard/components/MediaFallback/MediaFallback.jsx
+++ b/packages/lib-react-components/src/SubjectCard/components/MediaFallback/MediaFallback.jsx
@@ -1,0 +1,46 @@
+import { Box, Text } from 'grommet'
+import { node, number, string } from 'prop-types'
+
+import { useTranslation } from '../../../translations/i18n'
+
+function MediaFallback({
+  alt,
+  placeholder,
+  previewHeight,
+  width
+}) {
+  const { t } = useTranslation()
+  const message = t('SubjectCard.MediaFallback.message')
+
+  return (
+    <Box
+      align='center'
+      aria-label={alt}
+      height={`${previewHeight}px`}
+      justify='center'
+      round={{ corner: 'top', size: '8px' }}
+      width={`${width}px`}
+    >
+      {placeholder || (
+        <Box align='center' gap='xsmall' pad='small'>
+          <Text
+            color={{ dark: 'neutral-6', light: 'dark-3' }}
+            size='xsmall'
+            textAlign='center'
+          >
+            {message}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+MediaFallback.propTypes = {
+  alt: string,
+  placeholder: node,
+  previewHeight: number.isRequired,
+  width: number.isRequired
+}
+
+export default MediaFallback

--- a/packages/lib-react-components/src/SubjectCard/components/MediaFallback/index.js
+++ b/packages/lib-react-components/src/SubjectCard/components/MediaFallback/index.js
@@ -1,0 +1,1 @@
+export { default } from './MediaFallback'

--- a/packages/lib-react-components/src/SubjectCard/components/SimpleMedia/SimpleMedia.jsx
+++ b/packages/lib-react-components/src/SubjectCard/components/SimpleMedia/SimpleMedia.jsx
@@ -3,6 +3,15 @@ import { bool, node, number, string, oneOf } from 'prop-types'
 import styled from 'styled-components'
 
 import Media from '../../../Media'
+import MediaFallback from '../MediaFallback'
+
+const SUPPORTED_MIME_TYPES = [
+	'application',
+	'audio',
+	'image',
+	'text',
+	'video'
+]
 
 const StyledPreview = styled(Box)`
 	overflow: hidden;
@@ -56,13 +65,24 @@ function SimpleMedia({
 	subjectIdTitle,
 	width
 }) {
+	const isSupportedMimeType = SUPPORTED_MIME_TYPES.includes(defaultMimeType)
+
 	return (
 		<StyledPreview
 			height={`${previewHeight}px`}
 			round={{ corner: 'top', size: '8px' }}
 			width={`${width}px`}
 		>
-			{(mediaSrc && showBackground) ? (
+			{(mediaSrc && !isSupportedMimeType) ? (
+				<MediaFallback
+					alt={subjectIdTitle}
+					placeholder={placeholder}
+					previewHeight={previewHeight}
+					width={width}
+				/>
+			) : null}
+
+			{(mediaSrc && isSupportedMimeType && showBackground) ? (
 				<StyledBackground>
 					<Media
 						alt=''
@@ -79,7 +99,7 @@ function SimpleMedia({
 				</StyledBackground>
 			) : null}
 
-			{mediaSrc ? (
+			{(mediaSrc && isSupportedMimeType) ? (
 				<StyledForegroundMedia
 					alt={subjectIdTitle}
 					controls={false}

--- a/packages/lib-react-components/src/SubjectCard/components/SimpleMedia/SimpleMedia.spec.jsx
+++ b/packages/lib-react-components/src/SubjectCard/components/SimpleMedia/SimpleMedia.spec.jsx
@@ -6,6 +6,7 @@ import VideoMeta, { FloridaKeys } from '../../stories/simple/SubjectCard.video.s
 import AudioMeta, { FrogFind } from '../../stories/simple/SubjectCard.audio.stories'
 import ApplicationMeta, { NotesFromNatureGeoJSON } from '../../stories/simple/SubjectCard.application.stories'
 import TextMeta, { NotesFromNature } from '../../stories/simple/SubjectCard.text.stories'
+import UnsupportedMeta, { UnsupportedMimeType } from '../../stories/simple/SubjectCard.unsupported.stories'
 
 describe('SimpleMedia', function () {
   it('renders image media', function () {
@@ -51,5 +52,14 @@ describe('SimpleMedia', function () {
 
     const textBlock = document.querySelector('pre')
     expect(textBlock).toBeTruthy()
+  })
+
+  it('renders a fallback for an unsupported mime type', function () {
+    const Story = composeStory(UnsupportedMimeType, UnsupportedMeta)
+
+    render(<Story />)
+
+    const fallback = document.querySelector('[aria-label="Subject 99999999"]')
+    expect(fallback).toBeTruthy()
   })
 })

--- a/packages/lib-react-components/src/SubjectCard/stories/SubjectCardStoryData.jsx
+++ b/packages/lib-react-components/src/SubjectCard/stories/SubjectCardStoryData.jsx
@@ -192,6 +192,31 @@ export const NOTES_FROM_NATURE_TEXT_SUBJECT = {
   metadata: DEFAULT_METADATA
 }
 
+export const UNSUPPORTED_MIME_TYPE_SUBJECT = {
+  id: '99999999',
+  links: { project: '1' },
+  locations: [
+    {
+      'model/gltf-binary': 'https://panoptes-uploads.zooniverse.org/subject_location/unsupported-mime-type.glb'
+    }
+  ],
+  metadata: DEFAULT_METADATA
+}
+
+export const MULTI_FRAME_UNSUPPORTED_MIME_TYPE_SUBJECT = {
+  id: '99999998',
+  links: { project: '1' },
+  locations: [
+    {
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/91a4df56-4cd8-429f-9193-d2d8481f74e5.jpeg'
+    },
+    {
+      'model/gltf-binary': 'https://panoptes-uploads.zooniverse.org/subject_location/unsupported-mime-type.glb'
+    }
+  ],
+  metadata: DEFAULT_METADATA
+}
+
 export const SMITHSONIAN_WILDLIFE_MULTI_IMAGE_SUBJECT = {
   id: '121787506',
   links: { project: '31959' },

--- a/packages/lib-react-components/src/SubjectCard/stories/interactive/multiMedia/SubjectCard.multiMedia.stories.jsx
+++ b/packages/lib-react-components/src/SubjectCard/stories/interactive/multiMedia/SubjectCard.multiMedia.stories.jsx
@@ -3,6 +3,7 @@ import {
   InteractiveStory,
   CHIMP_AND_SEE_VIDEO_IMAGES_SUBJECT,
   DATA_IMAGES_SUBJECT,
+  MULTI_FRAME_UNSUPPORTED_MIME_TYPE_SUBJECT,
   NFN_IMAGE_TEXT_SUBJECT,
   PLANET_HUNTERS_TESS_SUBJECT,
   SMITHSONIAN_WILDLIFE_MULTI_IMAGE_SUBJECT,
@@ -48,3 +49,8 @@ export const MultiDataImages = {
 export const VariableStarViewer = {
   render: () => <InteractiveStory login={'TestUser'} subject={ZWICKYS_STELLAR_SLEUTHS_SUBJECT} />
 }
+
+export const MultiFrameUnsupportedMimeType = {
+  render: () => <InteractiveStory login={'TestUser'} subject={MULTI_FRAME_UNSUPPORTED_MIME_TYPE_SUBJECT} />
+}
+

--- a/packages/lib-react-components/src/SubjectCard/stories/interactive/singleMedia/SubjectCard.unsupported.stories.jsx
+++ b/packages/lib-react-components/src/SubjectCard/stories/interactive/singleMedia/SubjectCard.unsupported.stories.jsx
@@ -1,0 +1,16 @@
+import SubjectCard from '../../../SubjectCard'
+import {
+  InteractiveStory,
+  UNSUPPORTED_MIME_TYPE_SUBJECT
+} from '../../SubjectCardStoryData'
+
+const meta = {
+  title: 'Components / SubjectCard / Interactive / SingleMedia / Unsupported',
+  component: SubjectCard
+}
+
+export default meta
+
+export const UnsupportedMimeType = {
+  render: () => <InteractiveStory subject={UNSUPPORTED_MIME_TYPE_SUBJECT} />
+}

--- a/packages/lib-react-components/src/SubjectCard/stories/simple/SubjectCard.unsupported.stories.jsx
+++ b/packages/lib-react-components/src/SubjectCard/stories/simple/SubjectCard.unsupported.stories.jsx
@@ -1,0 +1,16 @@
+import SubjectCard from '../../SubjectCard'
+import {
+  StoryRow,
+  UNSUPPORTED_MIME_TYPE_SUBJECT
+} from '../SubjectCardStoryData'
+
+const meta = {
+  title: 'Components / SubjectCard / Simple / Unsupported',
+  component: SubjectCard
+}
+
+export default meta
+
+export const UnsupportedMimeType = {
+  render: () => <StoryRow login={'TestUser'} subject={UNSUPPORTED_MIME_TYPE_SUBJECT} />
+}

--- a/packages/lib-react-components/src/translations/en.json
+++ b/packages/lib-react-components/src/translations/en.json
@@ -114,6 +114,9 @@
       "pause": "Pause flipbook",
       "play": "Play flipbook",
       "viewFrame": "View frame {{frame}}"
+    },
+    "MediaFallback": {
+      "message": "Preview not available"
     }
   },
   "ZooFooter": {


### PR DESCRIPTION
## Package
- lib-react-components

## Describe your changes
- adds MediaFallback component
- adds related stories and updates tests
- refactor simple and interactive versions of SubjectCard with MediaFallback for unsupported mime types
- does _not_ impact unsupported mime subtypes

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - review linked stories
- Which storybook stories should be reviewed?
  - simple: http://localhost:6007/?path=/story/components-subjectcard-simple-unsupported--unsupported-mime-type&globals=theme:light
  - interactive, single: http://localhost:6007/?path=/story/components-subjectcard-interactive-singlemedia-unsupported--unsupported-mime-type&globals=theme:light
  - interactive, multi-media: http://localhost:6007/?path=/story/components-subjectcard-interactive-multimedia--multi-frame-unsupported-mime-type&globals=theme:light
- Are there plans for follow up PR’s to further fix this bug or develop this feature? see linked GitHub project

## Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

### New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/main/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

### Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).