### PR TITLE
lib-classifier: Audio  + Spectrogram viewer enhancements

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewer.jsx
@@ -1,14 +1,21 @@
-import { arrayOf, func, shape } from 'prop-types'
+import { arrayOf, bool, func, number, shape } from 'prop-types'
 import { Box } from 'grommet'
 import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
+import asyncStates from '@zooniverse/async-states'
 import { useTranslation } from '@translations/i18n'
 
 import locationValidator from '../../helpers/locationValidator'
+import InteractionLayer from '../InteractionLayer'
 
-const SpectrogramContainer = styled(Box)`
+const SpectrogramContainer = styled.div`
   position: relative;
   overflow: hidden;
+`
+
+const SubjectImage = styled.img`
+  display: block;
+  width: 100%;
 `
 
 const ProgressMarker = styled.div`
@@ -22,9 +29,18 @@ const ProgressMarker = styled.div`
   z-index: 1;
 `
 
+const InteractionLayerContainer = styled(Box)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+`
+
 const DEFAULT_HANDLER = () => {}
 
 function AudioSpectrogramViewer({
+  enableInteractionLayer = true,
   onError = DEFAULT_HANDLER,
   onReady = DEFAULT_HANDLER,
   subject
@@ -73,16 +89,23 @@ function AudioSpectrogramViewer({
   return (
     <Box width='100%'>
       <SpectrogramContainer>
-        <img
-          alt='Spectrogram'
-          onLoad={handleImageLoad}
+        <SubjectImage
+          alt={`Subject ${subject.id}`}
           src={imageLocation.url}
-          style={{ display: 'block', width: '100%', height: 'auto' }}
+          onLoad={handleImageLoad}
         />
         <ProgressMarker
           data-testid='spectrogram-progress-marker'
           style={{ left: `${played * 100}%` }}
         />
+        {enableInteractionLayer && (
+          <InteractionLayerContainer>
+            <svg height='100%'>
+              {/* InteractionLayer is just a <rect/> so has to be a child of <svg /> */}
+              <InteractionLayer height='100%' width='100%' />
+            </svg>
+          </InteractionLayerContainer>
+        )}
       </SpectrogramContainer>
       <audio
         ref={audioRef}
@@ -102,6 +125,7 @@ function AudioSpectrogramViewer({
 }
 
 AudioSpectrogramViewer.propTypes = {
+  enableInteractionLayer: bool,
   onError: func,
   onReady: func,
   subject: shape({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewer.jsx
@@ -1,12 +1,16 @@
-import { arrayOf, bool, func, shape } from 'prop-types'
+import { arrayOf, bool, func, shape, string } from 'prop-types'
 import { Box } from 'grommet'
 import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
-import asyncStates from '@zooniverse/async-states'
 import { useTranslation } from '@translations/i18n'
+import { useResizeDetector } from 'react-resize-detector'
+import asyncStates from '@zooniverse/async-states'
 
 import locationValidator from '../../helpers/locationValidator'
 import InteractionLayer from '../InteractionLayer'
+import SVGCanvas from '../SVGComponents/SVGCanvas/SVGCanvas'
+import ControlsLayer from '../ControlsLayer'
+import { getViewportScale } from '@plugins/drawingTools/shared/SVGContext'
 
 const SpectrogramContainer = styled.div`
   position: relative;
@@ -30,11 +34,9 @@ const ProgressMarker = styled.div`
   z-index: 1;
 `
 
-const InteractionLayerContainer = styled(Box)`
+const DrawingLayer = styled.div`
   position: absolute;
   top: 0;
-  left: 0;
-  height: 100%;
   width: 100%;
 `
 
@@ -42,12 +44,25 @@ const DEFAULT_HANDLER = () => {}
 
 function AudioSpectrogramViewer({
   enableInteractionLayer = true,
+  loadingState = asyncStates.initialized,
   invert = false,
   onError = DEFAULT_HANDLER,
   onReady = DEFAULT_HANDLER,
   subject
 }) {
   const { t } = useTranslation('components')
+
+  /* For Drawing Tools */
+  const [imgHeight, setImgHeight] = useState(0)
+  const [imgWidth, setImgWidth] = useState(0)
+
+  const enableDrawing = loadingState === asyncStates.success && enableInteractionLayer
+
+  // Set up resize detector for calculation of scale in SVGContext
+  const { width: svgWidth, ref: svgRef } = useResizeDetector()
+  const viewportScale = getViewportScale(svgWidth, imgWidth)
+
+  /* Spectrogram Progress */
   const audioRef = useRef(null)
   const rafRef = useRef(null)
   const [played, setPlayed] = useState(0)
@@ -64,6 +79,8 @@ function AudioSpectrogramViewer({
   function handleImageLoad(e) {
     const { naturalHeight, naturalWidth, clientHeight, clientWidth } = e.target
     onReady({ target: { clientHeight, clientWidth, naturalHeight, naturalWidth } })
+    setImgHeight(naturalHeight)
+    setImgWidth(naturalWidth)
   }
 
   function syncMarker() {
@@ -101,14 +118,18 @@ function AudioSpectrogramViewer({
           data-testid='spectrogram-progress-marker'
           style={{ left: `${played * 100}%` }}
         />
-        {enableInteractionLayer && (
-          <InteractionLayerContainer>
-            <svg height='100%'>
-              {/* InteractionLayer is just a <rect/> so has to be a child of <svg /> */}
-              <InteractionLayer height='100%' width='100%' />
-            </svg>
-          </InteractionLayerContainer>
+        {enableDrawing && (
+          <DrawingLayer>
+            <Box overflow='hidden'>
+              <svg ref={svgRef} viewBox={`0 0 ${imgWidth} ${imgHeight}`}>
+                <SVGCanvas scale={viewportScale} transform=''>
+                  <InteractionLayer height={imgHeight} width={imgWidth} />
+                </SVGCanvas>
+              </svg>
+            </Box>
+          </DrawingLayer>
         )}
+        <ControlsLayer enableInteractionLayer={enableInteractionLayer} />
       </SpectrogramContainer>
       <audio
         ref={audioRef}
@@ -129,6 +150,7 @@ function AudioSpectrogramViewer({
 
 AudioSpectrogramViewer.propTypes = {
   enableInteractionLayer: bool,
+  loadingState: string,
   invert: bool,
   onError: func,
   onReady: func,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewer.jsx
@@ -16,6 +16,7 @@ const SpectrogramContainer = styled.div`
 const SubjectImage = styled.img`
   display: block;
   width: 100%;
+  filter: invert(${props => (props.$invert ? 1 : 0)});
 `
 
 const ProgressMarker = styled.div`
@@ -41,6 +42,7 @@ const DEFAULT_HANDLER = () => {}
 
 function AudioSpectrogramViewer({
   enableInteractionLayer = true,
+  invert = false,
   onError = DEFAULT_HANDLER,
   onReady = DEFAULT_HANDLER,
   subject
@@ -93,6 +95,7 @@ function AudioSpectrogramViewer({
           alt={`Subject ${subject.id}`}
           src={imageLocation.url}
           onLoad={handleImageLoad}
+          $invert={invert}
         />
         <ProgressMarker
           data-testid='spectrogram-progress-marker'
@@ -126,6 +129,7 @@ function AudioSpectrogramViewer({
 
 AudioSpectrogramViewer.propTypes = {
   enableInteractionLayer: bool,
+  invert: bool,
   onError: func,
   onReady: func,
   subject: shape({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewer.jsx
@@ -1,4 +1,4 @@
-import { arrayOf, bool, func, number, shape } from 'prop-types'
+import { arrayOf, bool, func, shape } from 'prop-types'
 import { Box } from 'grommet'
 import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewerContainer.jsx
@@ -2,10 +2,23 @@ import { arrayOf, bool, func, shape, string } from 'prop-types'
 import asyncStates from '@zooniverse/async-states'
 import { observer } from 'mobx-react'
 
+import { useStores } from '@hooks'
 import locationValidator from '../../helpers/locationValidator'
 import AudioSpectrogramViewer from './AudioSpectrogramViewer'
 
 const DEFAULT_HANDLER = () => {}
+
+function storeMapper(store) {
+  const drawingTasks = store.workflowSteps.findTasksByType('drawing')
+
+  const {
+    subjectViewer: { invert }
+  } = store
+
+  return {
+    invert
+  }
+}
 
 function AudioSpectrogramViewerContainer({
   enableInteractionLayer = false, // rare for project teams to combine drawing tools with this subject type
@@ -14,9 +27,12 @@ function AudioSpectrogramViewerContainer({
   onReady = DEFAULT_HANDLER,
   subject
 }) {
+  const { invert } = useStores(storeMapper)
+
   return (
     <AudioSpectrogramViewer
       enableInteractionLayer={enableInteractionLayer}
+      invert={invert}
       onError={onError}
       onReady={onReady}
       subject={subject}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewerContainer.jsx
@@ -9,8 +9,6 @@ import AudioSpectrogramViewer from './AudioSpectrogramViewer'
 const DEFAULT_HANDLER = () => {}
 
 function storeMapper(store) {
-  const drawingTasks = store.workflowSteps.findTasksByType('drawing')
-
   const {
     subjectViewer: { invert }
   } = store
@@ -32,6 +30,7 @@ function AudioSpectrogramViewerContainer({
   return (
     <AudioSpectrogramViewer
       enableInteractionLayer={enableInteractionLayer}
+      loadingState={loadingState}
       invert={invert}
       onError={onError}
       onReady={onReady}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewerContainer.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewerContainer.jsx
@@ -1,4 +1,4 @@
-import { arrayOf, func, shape, string } from 'prop-types'
+import { arrayOf, bool, func, shape, string } from 'prop-types'
 import asyncStates from '@zooniverse/async-states'
 import { observer } from 'mobx-react'
 
@@ -8,6 +8,7 @@ import AudioSpectrogramViewer from './AudioSpectrogramViewer'
 const DEFAULT_HANDLER = () => {}
 
 function AudioSpectrogramViewerContainer({
+  enableInteractionLayer = false, // rare for project teams to combine drawing tools with this subject type
   loadingState = asyncStates.initialized,
   onError = DEFAULT_HANDLER,
   onReady = DEFAULT_HANDLER,
@@ -15,6 +16,7 @@ function AudioSpectrogramViewerContainer({
 }) {
   return (
     <AudioSpectrogramViewer
+      enableInteractionLayer={enableInteractionLayer}
       onError={onError}
       onReady={onReady}
       subject={subject}
@@ -23,6 +25,7 @@ function AudioSpectrogramViewerContainer({
 }
 
 AudioSpectrogramViewerContainer.propTypes = {
+  enableInteractionLayer: bool,
   loadingState: string,
   onError: func,
   onReady: func,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewerContainer.spec.jsx
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/AudioSpectrogramViewerContainer.spec.jsx
@@ -14,7 +14,7 @@ describe('Component > AudioSpectrogramViewerContainer', function () {
 
     it('should render a spectrogram image', function () {
       const { container } = render(<Default />)
-      const imgElement = container.querySelector('img[alt="Spectrogram"]')
+      const imgElement = container.querySelector('img') // only one img in this viewer
       expect(imgElement).to.exist
     })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/AudioSpectrogramViewer/README.md
@@ -11,3 +11,4 @@ The Audio Spectrogram Viewer displays an audio file and an image file (a spectro
 - The image file has a time/progress bar that's synced to the progress of the played audio.
   - When the audio starts playing, the time/progress bar starts at the left of the image. When the audio finishes playing, the time/progress bar finishes at the right of the image.
 - The image file can't be interacted with (i.e. no pan or zoom). Only the audio player provides any interactions.
+- However, you can combine drawing tools with this subject type, which enables the InteractionLayer on top of the spectrogram.

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -42,8 +42,12 @@ const SubjectViewer = types
   .views(self => ({
     get disableImageToolbar () {
       const subject = tryReference(() => getRoot(self).subjects?.active)
+      const viewer = subject?.viewer
+
       const frameType = subject?.locations[self.frame].type
       if (frameType === 'text' || frameType === 'video' || frameType === 'audio') {
+        return true
+      } else if (viewer === 'audioSpectrogram') {
         return true
       }
       return false
@@ -51,8 +55,12 @@ const SubjectViewer = types
 
     get disableInvertButton () {
       const subject = tryReference(() => getRoot(self).subjects?.active)
+      const viewer = subject?.viewer
+
       const frameType = subject?.locations[self.frame].type
       if (frameType === 'text') {
+        return true
+      } else if (viewer === 'audioSpectrogram') {
         return true
       }
       return false

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -55,8 +55,6 @@ const SubjectViewer = types
 
     get disableInvertButton () {
       const subject = tryReference(() => getRoot(self).subjects?.active)
-      const viewer = subject?.viewer
-
       const frameType = subject?.locations[self.frame].type
       if (frameType === 'text') {
         return true

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -60,8 +60,6 @@ const SubjectViewer = types
       const frameType = subject?.locations[self.frame].type
       if (frameType === 'text') {
         return true
-      } else if (viewer === 'audioSpectrogram') {
-        return true
       }
       return false
     },


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Ticket request for drawing on spectrogram subjects: https://zooniverse.freshdesk.com/a/tickets/28332

## Describe your changes
- Allow audio + spectrogram subjects to be inverted via the ImageToolbar
- Disable the pan/zoom buttons in ImageToolbar
- When `enableInteractionLayer` is true, display the InteractionLayer component on top of the spectrogram

## How to Review
- Any non-spectrogram subject viewer should be unchanged
- Test out an audio + spectrogram subject with workflow configurations for a drawing task and invert: https://local.zooniverse.org:3000/projects/goplayoutside3/fem-test-project/classify/workflow/32190?env=production&demo=true or https://local.zooniverse.org:8080/?project=14974&workflow=32190&env=production

## Checklist

### General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `pnpm panic && pnpm bootstrap`
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

### General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/main/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)